### PR TITLE
chore(deps): patch js-yaml denial-of-service advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -198,7 +198,7 @@
         "globals": "17.7.0",
         "globby": "16.2.2",
         "husky": "9.1.7",
-        "js-yaml": "5.2.1",
+        "js-yaml": "5.2.2",
         "jsdom": "^26.1.0",
         "lint-staged": "^17.1.0",
         "madge": "8.0.0",
@@ -18510,9 +18510,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
-      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
+      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -319,7 +319,7 @@
     "globals": "17.7.0",
     "globby": "16.2.2",
     "husky": "9.1.7",
-    "js-yaml": "5.2.1",
+    "js-yaml": "5.2.2",
     "jsdom": "^26.1.0",
     "lint-staged": "^17.1.0",
     "madge": "8.0.0",

--- a/scripts/assemble-docs.mjs
+++ b/scripts/assemble-docs.mjs
@@ -24,7 +24,7 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
-import yaml from 'js-yaml';
+import { load as loadYaml } from 'js-yaml';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -114,7 +114,7 @@ class DocumentationAssembler {
     }
 
     const manifestContent = readFileSync(manifestPath, 'utf-8');
-    this.manifest = yaml.load(manifestContent);
+    this.manifest = loadYaml(manifestContent);
 
     this.log(`  Module: ${this.manifest.modules.waterfall.description}`, true);
     this.log(`  Source files: ${this.manifest.modules.waterfall.source_files.length}`, true);


### PR DESCRIPTION
## Summary

- upgrade direct dev dependency `js-yaml` from 5.2.1 to patched 5.2.2
- migrate documentation assembler from removed ESM default export to supported named `load` export
- keep lockfile resolution exact and isolated from transitive js-yaml 4.x consumers

## Security

Addresses Dependabot alert #247 / GHSA-pm4m-ph32-ghv5: exponential parsing time in flow collections can cause denial of service. Patched version: 5.2.2.

## Verification

- `npm audit --package-lock-only --audit-level=low` - 0 vulnerabilities
- `npm ls js-yaml --all` - direct resolution 5.2.2
- `npm run doctor:quick` - pass
- `node scripts/assemble-docs.mjs --skip-tests --verbose` - pass
- `npm run lint` - pass
- `npm run check` - 0 TypeScript errors
- focused waterfall suite - 53 tests passed

Full `npm test` not rerun because changed package is dev-only and its sole direct consumer is the documentation assembler exercised above.