### PR TITLE
Fix/streaming mc serverless off

### DIFF
--- a/server/services/current-forecast-reference-service.ts
+++ b/server/services/current-forecast-reference-service.ts
@@ -8,7 +8,7 @@ import {
   FundCalculationModeIdempotencyConflictError,
   FundCalculationModeInProgressError,
   FundCalculationModeVersionConflictError,
-} from './fund-calculation-mode-service';
+} from './fund-calculation-mode-errors';
 
 /**
  * Append-only reference plane for the current-forecast calculation key

--- a/server/services/fund-calculation-mode-errors.ts
+++ b/server/services/fund-calculation-mode-errors.ts
@@ -1,0 +1,29 @@
+export class FundCalculationModeVersionConflictError extends Error {
+  readonly code = 'stale_expected_version';
+
+  constructor(
+    readonly expectedVersion: number,
+    readonly actualVersion: number
+  ) {
+    super(`Expected mode version ${expectedVersion}, found ${actualVersion}`);
+    this.name = 'FundCalculationModeVersionConflictError';
+  }
+}
+
+export class FundCalculationModeIdempotencyConflictError extends Error {
+  readonly code = 'idempotency_conflict';
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'FundCalculationModeIdempotencyConflictError';
+  }
+}
+
+export class FundCalculationModeInProgressError extends Error {
+  readonly code = 'idempotency_request_in_progress';
+
+  constructor() {
+    super('Idempotent MOIC mode update is still in progress');
+    this.name = 'FundCalculationModeInProgressError';
+  }
+}

--- a/server/services/fund-calculation-mode-service.ts
+++ b/server/services/fund-calculation-mode-service.ts
@@ -9,6 +9,11 @@ import {
 } from '../../shared/contracts/h9-actionability.contract';
 import { canonicalSha256 } from '../../shared/lib/canonical-hash';
 import {
+  FundCalculationModeIdempotencyConflictError,
+  FundCalculationModeInProgressError,
+  FundCalculationModeVersionConflictError,
+} from './fund-calculation-mode-errors';
+import {
   FUND_MOIC_CALCULATION_KEY,
   getFundMoicRankingSources,
   type FundMoicFactsSource,
@@ -18,6 +23,12 @@ import { invalidateH9Artifacts } from './h9-artifact-invalidation-service';
 import { reconciliationRuns } from '../../shared/schema';
 import { buildRoundsToModelEvidence } from './rounds-to-model-evidence-service';
 import { CURRENT_FORECAST_CALCULATION_KEY } from './current-forecast-calc-mode-resolver';
+
+export {
+  FundCalculationModeIdempotencyConflictError,
+  FundCalculationModeInProgressError,
+  FundCalculationModeVersionConflictError,
+} from './fund-calculation-mode-errors';
 
 const MODE_ROUTE = 'PUT /api/admin/funds/:fundId/calculation-modes/fund-moic-rankings';
 const CURRENT_FORECAST_MODE_ROUTE =
@@ -68,42 +79,12 @@ interface GenericFundCalculationModePreview {
   version: number;
 }
 
-export class FundCalculationModeVersionConflictError extends Error {
-  readonly code = 'stale_expected_version';
-
-  constructor(
-    readonly expectedVersion: number,
-    readonly actualVersion: number
-  ) {
-    super(`Expected mode version ${expectedVersion}, found ${actualVersion}`);
-    this.name = 'FundCalculationModeVersionConflictError';
-  }
-}
-
 export class FundCalculationModeBlockedError extends Error {
   readonly code = 'mode_activation_blocked';
 
   constructor(readonly blockers: FundCalculationModeBlocker[]) {
     super(`MOIC calculation mode update is blocked: ${blockers.join(', ')}`);
     this.name = 'FundCalculationModeBlockedError';
-  }
-}
-
-export class FundCalculationModeIdempotencyConflictError extends Error {
-  readonly code = 'idempotency_conflict';
-
-  constructor(message: string) {
-    super(message);
-    this.name = 'FundCalculationModeIdempotencyConflictError';
-  }
-}
-
-export class FundCalculationModeInProgressError extends Error {
-  readonly code = 'idempotency_request_in_progress';
-
-  constructor() {
-    super('Idempotent MOIC mode update is still in progress');
-    this.name = 'FundCalculationModeInProgressError';
   }
 }
 

--- a/server/services/monte-carlo-service-unified.ts
+++ b/server/services/monte-carlo-service-unified.ts
@@ -503,6 +503,10 @@ export class UnifiedMonteCarloService {
     const explicit = process.env['ENABLE_STREAMING_MONTE_CARLO'];
     if (explicit === '1') return true;
     if (explicit === '0') return false;
+    // Serverless (Vercel Lambda) cannot open the Neon WebSocket pool the streaming
+    // engine depends on; creating it wedges the function's event loop until the 300s
+    // ceiling, 504-ing every route. Off by default there unless explicitly enabled.
+    if (process.env['VERCEL']) return false;
     return process.env['NODE_ENV'] === 'production';
   }
 

--- a/tests/unit/scripts/build-vercel-api.test.mjs
+++ b/tests/unit/scripts/build-vercel-api.test.mjs
@@ -1,8 +1,9 @@
 /* global process */
 
 import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
 import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
@@ -51,5 +52,77 @@ describe('build-vercel-api', () => {
     expect(bundleState.hasRequire2).toBe(false);
     expect(bundleState.hasRequire).toBe(false);
     expect(bundleState.mentionsNeonHttp).toBe(true);
+  }, 60000);
+
+  it('imports the built Vercel app without blocking on async module initialization', () => {
+    const buildResult = spawnSync(
+      process.execPath,
+      [resolve(root, 'scripts/build-vercel-api.mjs')],
+      {
+        cwd: root,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          NODE_ENV: 'test',
+        },
+        timeout: 45000,
+      }
+    );
+
+    expect(buildResult.status, buildResult.stderr || buildResult.stdout).toBe(0);
+
+    const generatedUrl = pathToFileURL(resolve(root, 'api/_app.generated.mjs')).href;
+    const importResult = spawnSync(
+      process.execPath,
+      [
+        '--input-type=module',
+        '-e',
+        `
+          try {
+            const appModule = await import(process.argv[1]);
+            if (typeof appModule.makeApp !== 'function') {
+              throw new Error('Built Vercel app does not export makeApp');
+            }
+            console.log('IMPORT_OK');
+            process.exit(0);
+          } catch (error) {
+            console.error(error?.stack ?? error);
+            process.exit(1);
+          }
+        `,
+        generatedUrl,
+      ],
+      {
+        cwd: tmpdir(),
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          NODE_ENV: 'production',
+          _EXPLICIT_NODE_ENV: '1',
+          VITEST: 'false',
+          VERCEL: '1',
+          VERCEL_ENV: 'preview',
+          DATABASE_URL: 'postgresql://user:pass@127.0.0.1:1/updog',
+          _EXPLICIT_DATABASE_URL: '1',
+          SESSION_SECRET: 'test-session-secret-at-least-thirty-two-characters',
+          JWT_SECRET: 'test-jwt-secret-at-least-thirty-two-characters',
+          _EXPLICIT_JWT_SECRET: '1',
+          CSRF_SECRET: 'test-csrf-secret-at-least-thirty-two-characters',
+          REDIS_URL: 'memory://',
+          _EXPLICIT_REDIS_URL: '1',
+          QUEUE_REDIS_URL: 'memory://',
+          _EXPLICIT_QUEUE_REDIS_URL: '1',
+          ENABLE_QUEUES: '0',
+          _EXPLICIT_ENABLE_QUEUES: '1',
+          ENABLE_STREAMING_MONTE_CARLO: '0',
+        },
+        timeout: 15000,
+      }
+    );
+
+    const diagnostic =
+      importResult.error?.stack || importResult.stderr || importResult.stdout || 'No child output';
+    expect(importResult.status, diagnostic).toBe(0);
+    expect(importResult.stdout).toContain('IMPORT_OK');
   }, 60000);
 });


### PR DESCRIPTION
### Summary:

This pull request resolves a critical startup deadlock issue in Vercel serverless environments by disabling the streaming Monte Carlo engine (which relies on a Neon WebSocket pool) and refactoring fund calculation error classes into a dedicated module to ensure clean module initialization.

### Key Changes:

* **Disabled Vercel Streaming Engine:** Added a check in `server/services/monte-carlo-service-unified.ts` to explicitly disable the streaming engine if the `VERCEL` environment variable is present. This prevents the Neon WebSocket pool from wedging the event loop up to the 300s execution ceiling.
* **Extracted Error Classes:** Created a new file `server/services/fund-calculation-mode-errors.ts` to house `FundCalculationModeVersionConflictError`, `FundCalculationModeIdempotencyConflictError`, and `FundCalculationModeInProgressError`.
* **Refactored Imports:** Updated `server/services/current-forecast-reference-service.ts` and `server/services/fund-calculation-mode-service.ts` to import and export the error classes from the new dedicated error file, cleaning up module dependencies.
* **Added Vercel Startup Test:** Introduced a new test case in `tests/unit/scripts/build-vercel-api.test.mjs` that imports the built Vercel app to verify it initializes instantly without blocking on async module resolution.

### Impact:

* **System Stability:** Directly prevents 504 Gateway Timeouts across all routes deployed to Vercel by ensuring the serverless event loop doesn't get blocked during startup.
* **Codebase Organization:** Improves the separation of concerns by isolating error definitions, reducing the risk of circular dependencies or import deadlocks when services load.
* **Regression Prevention:** The newly added automated test ensures that future architectural changes won't silently reintroduce Vercel initialization deadlocks.

### Testing:

* Run the test suite locally to verify the new test in `build-vercel-api.test.mjs` passes and correctly mimics the Vercel production environment variables (`VERCEL='1'`, `ENABLE_STREAMING_MONTE_CARLO='0'`).
* Deploy this branch to a Vercel Preview environment and trigger an API route to confirm the application boots successfully without hitting a timeout.
* Trigger a Monte Carlo forecast in the preview environment to confirm the fallback calculation logic handles the request gracefully when the streaming engine is disabled.