### PR TITLE
chore(release): execute Task 11 production closeout

### DIFF
--- a/.github/workflows/task11-prod-closeout-once.yml
+++ b/.github/workflows/task11-prod-closeout-once.yml
@@ -156,7 +156,7 @@ jobs:
               STATUSES="$(gh api "repos/${REPO}/deployments/${DEPLOYMENT_ID}/statuses")"
               STATE="$(jq -r '.[0].state // empty' <<<"$STATUSES")"
               DEPLOYMENT_URL="$(
-                jq -r '.[0].environment_url // .[0].target_url // empty' <<<"$STATUSES"
+                jq -r '.[0].target_url // .[0].environment_url // empty' <<<"$STATUSES"
               )"
 
               case "$STATE" in

--- a/.github/workflows/task11-prod-closeout-once.yml
+++ b/.github/workflows/task11-prod-closeout-once.yml
@@ -161,7 +161,7 @@ jobs:
 
               case "$STATE" in
                 success)
-                  if [[ ! "$DEPLOYMENT_URL" =~ ^https://[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.vercel\.app/?$ ]]; then
+                  if [[ ! "$DEPLOYMENT_URL" =~ ^https://[a-z0-9]([a-z0-9-]*[a-z0-9])?\.vercel\.app/?$ ]]; then
                     echo "::error::Exact-SHA deployment returned a non-bare Vercel URL."
                     exit 1
                   fi
@@ -194,7 +194,7 @@ jobs:
     steps:
       - name: Re-fence release target
         env:
-          EXPECTED_SHA: ${{ needs.schema-apply.outputs.target_sha || needs.wait-for-vercel.outputs.target_sha || github.sha }}
+          EXPECTED_SHA: ${{ github.sha }}
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |

--- a/.github/workflows/task11-prod-closeout-once.yml
+++ b/.github/workflows/task11-prod-closeout-once.yml
@@ -1,0 +1,309 @@
+name: Task 11 Production Closeout Once
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/task11-prod-closeout-once.yml'
+
+permissions:
+  actions: write
+  contents: read
+  deployments: read
+  issues: read
+
+concurrency:
+  group: task11-production-closeout-1174
+  cancel-in-progress: false
+
+env:
+  TASK11_ISSUE: '1174'
+  TASK11_REPAIR_MERGE: 'a0a53a6a82f3e16402011c2a777f37421c109e0f'
+  CLOSEOUT_COMMIT_TITLE: 'chore(release): execute Task 11 production closeout'
+
+jobs:
+  preflight:
+    name: Fence One-Time Closeout
+    runs-on: ubuntu-latest
+    outputs:
+      target_sha: ${{ steps.fence.outputs.target_sha }}
+    steps:
+      - name: Require single authorized closeout push
+        id: fence
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          EXPECTED_SHA: ${{ github.sha }}
+          GH_TOKEN: ${{ github.token }}
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          REPO: ${{ github.repository }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          WORKFLOW_FILE: task11-prod-closeout-once.yml
+          WORKFLOW_PATH: .github/workflows/task11-prod-closeout-once.yml
+        run: |
+          set -euo pipefail
+
+          if [[ "$GITHUB_EVENT_NAME" != "push" || "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "::error::Task 11 closeout must run from a push to main."
+            exit 1
+          fi
+          if [[ "$RUN_ATTEMPT" != "1" ]]; then
+            echo "::error::Task 11 closeout is one-shot and cannot be rerun."
+            exit 1
+          fi
+
+          ACTUAL_TITLE="${HEAD_COMMIT_MESSAGE%%$'\n'*}"
+          if [[ "$ACTUAL_TITLE" != "$CLOSEOUT_COMMIT_TITLE" ]]; then
+            echo "::error::Unexpected closeout commit title."
+            exit 1
+          fi
+
+          if [[ ! "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Current workflow SHA is invalid."
+            exit 1
+          fi
+          LIVE_MAIN="$(gh api "repos/${REPO}/commits/main" --jq '.sha')"
+          if [[ "$LIVE_MAIN" != "$EXPECTED_SHA" ]]; then
+            echo "::error::Live main does not equal this closeout SHA."
+            exit 1
+          fi
+
+          mapfile -t CHANGED_FILES < <(
+            gh api "repos/${REPO}/compare/${BEFORE_SHA}...${EXPECTED_SHA}" --jq '.files[].filename'
+          )
+          if (( ${#CHANGED_FILES[@]} != 1 )) || [[ "${CHANGED_FILES[0]:-}" != "$WORKFLOW_PATH" ]]; then
+            printf '::error::Closeout merge must change only %s. Changed: %s\n' \
+              "$WORKFLOW_PATH" "${CHANGED_FILES[*]:-<none>}"
+            exit 1
+          fi
+
+          ANCESTRY_STATUS="$(
+            gh api "repos/${REPO}/compare/${TASK11_REPAIR_MERGE}...${EXPECTED_SHA}" --jq '.status'
+          )"
+          if [[ "$ANCESTRY_STATUS" != "ahead" && "$ANCESTRY_STATUS" != "identical" ]]; then
+            echo "::error::Current main does not contain the reviewed Task 11 release repair."
+            exit 1
+          fi
+
+          ISSUE_STATE="$(gh api "repos/${REPO}/issues/${TASK11_ISSUE}" --jq '.state')"
+          if [[ "$ISSUE_STATE" != "open" ]]; then
+            echo "::error::Task 11 issue must remain open until production proof completes."
+            exit 1
+          fi
+
+          PRIOR_SUCCESSES="$(
+            gh api "repos/${REPO}/actions/workflows/${WORKFLOW_FILE}/runs?status=success&per_page=1" \
+              --jq '.total_count'
+          )"
+          if [[ "$PRIOR_SUCCESSES" != "0" ]]; then
+            echo "::error::A successful Task 11 production closeout already exists."
+            exit 1
+          fi
+
+          echo "target_sha=${EXPECTED_SHA}" >> "$GITHUB_OUTPUT"
+          echo "One-time closeout fence passed for ${EXPECTED_SHA}."
+
+  schema-apply:
+    name: Apply Governed Production Schema
+    needs: preflight
+    uses: ./.github/workflows/prod-schema-reconcile.yml
+    with:
+      mode: apply
+      expected_sha: ${{ needs.preflight.outputs.target_sha }}
+    secrets: inherit
+
+  wait-for-vercel:
+    name: Resolve Exact-SHA Vercel Deployment
+    needs: preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    outputs:
+      deployment_url: ${{ steps.discover.outputs.deployment_url }}
+    steps:
+      - name: Wait for exact production deployment
+        id: discover
+        env:
+          EXPECTED_SHA: ${{ needs.preflight.outputs.target_sha }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          for attempt in $(seq 1 120); do
+            LIVE_MAIN="$(gh api "repos/${REPO}/commits/main" --jq '.sha')"
+            if [[ "$LIVE_MAIN" != "$EXPECTED_SHA" ]]; then
+              echo "::error::Main advanced while waiting for the exact deployment."
+              exit 1
+            fi
+
+            DEPLOYMENTS="$(
+              gh api "repos/${REPO}/deployments?sha=${EXPECTED_SHA}&environment=Production&per_page=100"
+            )"
+            DEPLOYMENT_ID="$(
+              jq -r --arg sha "$EXPECTED_SHA" '
+                [.[] | select(
+                  .sha == $sha and
+                  .environment == "Production" and
+                  .creator.login == "vercel[bot]"
+                )]
+                | sort_by(.created_at)
+                | last
+                | .id // empty
+              ' <<<"$DEPLOYMENTS"
+            )"
+
+            if [[ -n "$DEPLOYMENT_ID" ]]; then
+              STATUSES="$(gh api "repos/${REPO}/deployments/${DEPLOYMENT_ID}/statuses")"
+              STATE="$(jq -r '.[0].state // empty' <<<"$STATUSES")"
+              DEPLOYMENT_URL="$(
+                jq -r '.[0].environment_url // .[0].target_url // empty' <<<"$STATUSES"
+              )"
+
+              case "$STATE" in
+                success)
+                  if [[ ! "$DEPLOYMENT_URL" =~ ^https://[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.vercel\.app/?$ ]]; then
+                    echo "::error::Exact-SHA deployment returned a non-bare Vercel URL."
+                    exit 1
+                  fi
+                  DEPLOYMENT_URL="${DEPLOYMENT_URL%/}"
+                  echo "deployment_url=${DEPLOYMENT_URL}" >> "$GITHUB_OUTPUT"
+                  echo "Resolved exact-SHA production deployment ${DEPLOYMENT_URL}."
+                  exit 0
+                  ;;
+                failure|error|inactive)
+                  echo "::error::Exact-SHA Vercel deployment ended in ${STATE}."
+                  exit 1
+                  ;;
+              esac
+            fi
+
+            echo "Waiting for Vercel deployment for ${EXPECTED_SHA} (attempt ${attempt}/120)."
+            sleep 10
+          done
+
+          echo "::error::Timed out waiting for exact-SHA Vercel deployment."
+          exit 1
+
+  release-production:
+    name: Dispatch and Verify Governed Release
+    needs:
+      - schema-apply
+      - wait-for-vercel
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Re-fence release target
+        env:
+          EXPECTED_SHA: ${{ needs.schema-apply.outputs.target_sha || needs.wait-for-vercel.outputs.target_sha || github.sha }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          LIVE_MAIN="$(gh api "repos/${REPO}/commits/main" --jq '.sha')"
+          if [[ "$LIVE_MAIN" != "$EXPECTED_SHA" || "$GITHUB_SHA" != "$EXPECTED_SHA" ]]; then
+            echo "::error::Release target no longer equals exact live main."
+            exit 1
+          fi
+          ISSUE_STATE="$(gh api "repos/${REPO}/issues/${TASK11_ISSUE}" --jq '.state')"
+          if [[ "$ISSUE_STATE" != "open" ]]; then
+            echo "::error::Task 11 issue closed before production release proof."
+            exit 1
+          fi
+
+      - name: Dispatch Release Production
+        id: dispatch
+        env:
+          DEPLOYMENT_URL: ${{ needs.wait-for-vercel.outputs.deployment_url }}
+          EXPECTED_SHA: ${{ github.sha }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          DISPATCHED_AT="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          gh workflow run release-production.yml \
+            --repo "$REPO" \
+            --ref main \
+            --field expected_sha="$EXPECTED_SHA" \
+            --field deployment_url="$DEPLOYMENT_URL"
+          echo "dispatched_at=${DISPATCHED_AT}" >> "$GITHUB_OUTPUT"
+
+      - name: Find dispatched release run
+        id: release-run
+        env:
+          DISPATCHED_AT: ${{ steps.dispatch.outputs.dispatched_at }}
+          EXPECTED_SHA: ${{ github.sha }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          for attempt in $(seq 1 30); do
+            RUNS="$(
+              gh api "repos/${REPO}/actions/workflows/release-production.yml/runs?event=workflow_dispatch&branch=main&per_page=30"
+            )"
+            MATCH_COUNT="$(
+              jq -r --arg sha "$EXPECTED_SHA" --arg since "$DISPATCHED_AT" '
+                [.workflow_runs[] | select(
+                  .head_sha == $sha and
+                  .created_at >= $since
+                )] | length
+              ' <<<"$RUNS"
+            )"
+            if [[ "$MATCH_COUNT" == "1" ]]; then
+              RUN_ID="$(
+                jq -r --arg sha "$EXPECTED_SHA" --arg since "$DISPATCHED_AT" '
+                  [.workflow_runs[] | select(
+                    .head_sha == $sha and
+                    .created_at >= $since
+                  )][0].id
+                ' <<<"$RUNS"
+              )"
+              echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
+              echo "Found Release Production run ${RUN_ID}."
+              exit 0
+            fi
+            if (( MATCH_COUNT > 1 )); then
+              echo "::error::Multiple matching Release Production runs found; refusing ambiguity."
+              exit 1
+            fi
+            sleep 2
+          done
+
+          echo "::error::Dispatched Release Production run was not found."
+          exit 1
+
+      - name: Require successful release completion
+        env:
+          EXPECTED_SHA: ${{ github.sha }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_RUN_ID: ${{ steps.release-run.outputs.run_id }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          for attempt in $(seq 1 240); do
+            LIVE_MAIN="$(gh api "repos/${REPO}/commits/main" --jq '.sha')"
+            if [[ "$LIVE_MAIN" != "$EXPECTED_SHA" ]]; then
+              echo "::error::Main advanced while Release Production was running."
+              exit 1
+            fi
+
+            RUN="$(gh api "repos/${REPO}/actions/runs/${RELEASE_RUN_ID}")"
+            STATUS="$(jq -r '.status' <<<"$RUN")"
+            CONCLUSION="$(jq -r '.conclusion // "pending"' <<<"$RUN")"
+            echo "Release Production ${RELEASE_RUN_ID}: ${STATUS}/${CONCLUSION}."
+
+            if [[ "$STATUS" == "completed" ]]; then
+              if [[ "$CONCLUSION" == "success" ]]; then
+                echo "Governed Task 11 production release passed for ${EXPECTED_SHA}."
+                exit 0
+              fi
+              echo "::error::Release Production ${RELEASE_RUN_ID} concluded ${CONCLUSION}."
+              exit 1
+            fi
+
+            sleep 20
+          done
+
+          echo "::error::Timed out waiting for Release Production completion."
+          exit 1


### PR DESCRIPTION
## Purpose

Execute remaining authorized Task 11 production closeout through existing governed workflows after merge.

Local/manual `workflow_dispatch` writes are unavailable in this execution lane. This PR adds one self-triggered, one-shot wrapper; it does not duplicate schema DDL, release proof, smoke, or promotion logic.

## Safety fences

- triggers only on `main` push changing this workflow path
- requires first run attempt and exact squash title
- requires live `main == github.sha`
- requires merge diff to contain exactly this one workflow file
- requires reviewed Task 11 repair merge `a0a53a6a82f3e16402011c2a777f37421c109e0f` as ancestor
- requires issue #1174 to remain open and no prior successful closeout run
- applies schema only through `prod-schema-reconcile.yml` in additive-safe `apply` mode
- resolves exact-SHA Vercel production artifact from GitHub deployment metadata
- dispatches existing `release-production.yml`, then waits for terminal success
- fails if `main` advances, deployment identity is ambiguous, or any child proof fails

## Scope

One workflow file only. No product, schema, migration, dependency, UI, or production SQL changes.

## Evidence before merge

- YAML parses successfully
- static guard validator passes
- two independent architecture/test reviews approved design after Bash ERE, exact-SHA binding, and immutable deployment URL fixes
- protected CI required before merge

Relates to #1174, #1212, and #1222.