### PR TITLE
fix(release): recover canonical rounds before Task 11 closeout

### DIFF
--- a/.github/workflows/task11-prod-closeout-once.yml
+++ b/.github/workflows/task11-prod-closeout-once.yml
@@ -20,7 +20,9 @@ concurrency:
 env:
   TASK11_ISSUE: '1174'
   TASK11_REPAIR_MERGE: 'a0a53a6a82f3e16402011c2a777f37421c109e0f'
-  CLOSEOUT_COMMIT_TITLE: 'chore(release): execute Task 11 production closeout'
+  TASK11_RECOVERY_BASE: '6d9a969cab14ba0bf2d1e8c02ef8af4d75e04354'
+  TASK11_FAILED_RUN: '30291848347'
+  CLOSEOUT_COMMIT_TITLE: 'fix(release): recover Task 11 production closeout'
 
 jobs:
   preflight:
@@ -48,7 +50,7 @@ jobs:
             exit 1
           fi
           if [[ "$RUN_ATTEMPT" != "1" ]]; then
-            echo "::error::Task 11 closeout is one-shot and cannot be rerun."
+            echo "::error::Task 11 recovery closeout is one-shot and cannot be rerun."
             exit 1
           fi
 
@@ -64,16 +66,35 @@ jobs:
           fi
           LIVE_MAIN="$(gh api "repos/${REPO}/commits/main" --jq '.sha')"
           if [[ "$LIVE_MAIN" != "$EXPECTED_SHA" ]]; then
-            echo "::error::Live main does not equal this closeout SHA."
+            echo "::error::Live main does not equal this recovery SHA."
+            exit 1
+          fi
+          if [[ "$BEFORE_SHA" != "$TASK11_RECOVERY_BASE" ]]; then
+            echo "::error::Recovery merge parent is not the failed closeout SHA."
             exit 1
           fi
 
-          mapfile -t CHANGED_FILES < <(
-            gh api "repos/${REPO}/compare/${BEFORE_SHA}...${EXPECTED_SHA}" --jq '.files[].filename'
+          COMPARE="$(gh api "repos/${REPO}/compare/${TASK11_RECOVERY_BASE}...${EXPECTED_SHA}")"
+          if [[ "$(jq -r '.status' <<<"$COMPARE")" != "ahead" ]] || \
+             [[ "$(jq -r '.ahead_by' <<<"$COMPARE")" != "1" ]]; then
+            echo "::error::Recovery must be one commit directly after the failed closeout SHA."
+            exit 1
+          fi
+
+          EXPECTED_FILES=(
+            "$WORKFLOW_PATH"
+            "scripts/prod-schema-manifests/15-vehicle-financing-participations.json"
+            "scripts/prod-schema-patches/0027_investment_rounds_foundation.sql"
+            "tests/integration/prod-schema-clone.test.ts"
+            "tests/unit/prod-schema-manifest-sentinels.test.ts"
           )
-          if (( ${#CHANGED_FILES[@]} != 1 )) || [[ "${CHANGED_FILES[0]:-}" != "$WORKFLOW_PATH" ]]; then
-            printf '::error::Closeout merge must change only %s. Changed: %s\n' \
-              "$WORKFLOW_PATH" "${CHANGED_FILES[*]:-<none>}"
+          mapfile -t CHANGED_FILES < <(jq -r '.files[].filename' <<<"$COMPARE" | sort)
+          mapfile -t SORTED_EXPECTED_FILES < <(printf '%s\n' "${EXPECTED_FILES[@]}" | sort)
+          if (( ${#CHANGED_FILES[@]} != ${#SORTED_EXPECTED_FILES[@]} )) || \
+             [[ "$(printf '%s\n' "${CHANGED_FILES[@]}")" != \
+                "$(printf '%s\n' "${SORTED_EXPECTED_FILES[@]}")" ]]; then
+            printf '::error::Unexpected recovery diff. Changed: %s\n' \
+              "${CHANGED_FILES[*]:-<none>}"
             exit 1
           fi
 
@@ -82,6 +103,45 @@ jobs:
           )"
           if [[ "$ANCESTRY_STATUS" != "ahead" && "$ANCESTRY_STATUS" != "identical" ]]; then
             echo "::error::Current main does not contain the reviewed Task 11 release repair."
+            exit 1
+          fi
+
+          PRIOR_RUN="$(gh api "repos/${REPO}/actions/runs/${TASK11_FAILED_RUN}")"
+          if [[ "$(jq -r '.head_sha' <<<"$PRIOR_RUN")" != "$TASK11_RECOVERY_BASE" ]] || \
+             [[ "$(jq -r '.event' <<<"$PRIOR_RUN")" != "push" ]] || \
+             [[ "$(jq -r '.head_branch' <<<"$PRIOR_RUN")" != "main" ]] || \
+             [[ "$(jq -r '.conclusion' <<<"$PRIOR_RUN")" != "failure" ]]; then
+            echo "::error::Recorded closeout failure does not match the recovery base."
+            exit 1
+          fi
+
+          PRIOR_JOBS="$(gh api "repos/${REPO}/actions/runs/${TASK11_FAILED_RUN}/jobs?per_page=100")"
+          FAILED_SCHEMA_JOBS="$(
+            jq -r '[.jobs[] | select(
+              .name == "Apply Governed Production Schema / Reconcile Production Schema" and
+              .conclusion == "failure"
+            )] | length' <<<"$PRIOR_JOBS"
+          )"
+          SKIPPED_RELEASE_JOBS="$(
+            jq -r '[.jobs[] | select(
+              .name == "Dispatch and Verify Governed Release" and
+              .conclusion == "skipped"
+            )] | length' <<<"$PRIOR_JOBS"
+          )"
+          if [[ "$FAILED_SCHEMA_JOBS" != "1" || "$SKIPPED_RELEASE_JOBS" != "1" ]]; then
+            echo "::error::Prior closeout did not fail safely at schema apply."
+            exit 1
+          fi
+
+          ARTIFACT_COUNT="$(
+            gh api "repos/${REPO}/actions/runs/${TASK11_FAILED_RUN}/artifacts?per_page=100" \
+              --jq '[.artifacts[] | select(
+                .name == "prod-schema-reconcile-30291848347-apply" and
+                .expired == false
+              )] | length'
+          )"
+          if [[ "$ARTIFACT_COUNT" != "1" ]]; then
+            echo "::error::Redacted failed-apply evidence artifact is unavailable or ambiguous."
             exit 1
           fi
 

--- a/scripts/prod-schema-manifests/15-vehicle-financing-participations.json
+++ b/scripts/prod-schema-manifests/15-vehicle-financing-participations.json
@@ -3,8 +3,14 @@
   "order": 15,
   "description": "Task 10 (#1174) vehicle participation ledger table and additive compat lineage pointers.",
   "missingTablePolicy": "create_or_repair",
-  "sqlFiles": ["migrations/0041_vehicle_financing_participations.sql"],
-  "allowedCreateTables": ["vehicle_financing_participations"],
+  "sqlFiles": [
+    "scripts/prod-schema-patches/0027_investment_rounds_foundation.sql",
+    "migrations/0041_vehicle_financing_participations.sql"
+  ],
+  "allowedCreateTables": [
+    "investment_rounds",
+    "vehicle_financing_participations"
+  ],
   "expectedTables": [
     {
       "name": "vehicles",
@@ -121,6 +127,38 @@
     {
       "name": "investment_rounds",
       "columns": [
+        { "name": "id", "type": "integer", "nullable": false },
+        { "name": "investment_id", "type": "integer", "nullable": false },
+        { "name": "fund_id", "type": "integer", "nullable": false },
+        { "name": "round_name", "type": "varchar", "nullable": false },
+        { "name": "security_type", "type": "varchar", "nullable": false },
+        { "name": "round_date", "type": "date", "nullable": false },
+        { "name": "currency", "type": "varchar", "nullable": false },
+        {
+          "name": "investment_amount",
+          "type": "numeric",
+          "nullable": false
+        },
+        { "name": "round_size", "type": "numeric", "nullable": true },
+        {
+          "name": "pre_money_valuation",
+          "type": "numeric",
+          "nullable": true
+        },
+        {
+          "name": "idempotency_key",
+          "type": "varchar",
+          "nullable": false
+        },
+        { "name": "request_hash", "type": "varchar", "nullable": false },
+        {
+          "name": "supersedes_round_id",
+          "type": "integer",
+          "nullable": true
+        },
+        { "name": "created_by", "type": "integer", "nullable": true },
+        { "name": "created_at", "type": "timestamptz", "nullable": true },
+        { "name": "updated_at", "type": "timestamptz", "nullable": true },
         { "name": "imported_from", "type": "varchar", "nullable": true },
         {
           "name": "vehicle_participation_id",
@@ -130,8 +168,19 @@
         { "name": "financing_tranche_id", "type": "integer", "nullable": true }
       ],
       "constraints": [
+        "investment_rounds_security_type_check",
+        "investment_rounds_amount_positive",
+        "investment_rounds_investment_fund_fk",
+        "investment_rounds_fund_idem_key",
+        "investment_rounds_id_fund_uq",
         "investment_rounds_vfp_fund_fk",
         "investment_rounds_financing_tranche_fund_fk"
+      ],
+      "indexes": [
+        "investment_rounds_fund_investment_idx",
+        "investment_rounds_investment_round_date_idx",
+        "investment_rounds_fund_round_order_idx",
+        "investment_rounds_supersedes_uq"
       ]
     },
     {

--- a/scripts/prod-schema-patches/0027_investment_rounds_foundation.sql
+++ b/scripts/prod-schema-patches/0027_investment_rounds_foundation.sql
@@ -1,0 +1,55 @@
+-- @drift-patch
+-- Reason: production truth disproved the historical 0027 assumption that
+-- investment_rounds already existed via db:push. Manifest 15 requires the
+-- canonical table before 0041 can add participation lineage. This patch
+-- mirrors only the investment_rounds portion of journal migration 0027.
+-- It is additive, data-free, and replay-safe.
+
+CREATE TABLE IF NOT EXISTS "investment_rounds" (
+  "id" serial PRIMARY KEY,
+  "investment_id" integer NOT NULL,
+  "fund_id" integer NOT NULL REFERENCES "funds"("id") ON UPDATE restrict ON DELETE restrict,
+  "round_name" varchar(120) NOT NULL,
+  "security_type" varchar(32) NOT NULL,
+  "round_date" date NOT NULL,
+  "currency" varchar(3) NOT NULL DEFAULT 'USD',
+  "investment_amount" numeric(20,6) NOT NULL,
+  "round_size" numeric(20,6),
+  "pre_money_valuation" numeric(20,6),
+  "idempotency_key" varchar(255) NOT NULL,
+  "request_hash" varchar(64) NOT NULL,
+  "supersedes_round_id" integer REFERENCES "investment_rounds"("id") ON DELETE restrict,
+  "created_by" integer REFERENCES "users"("id"),
+  "created_at" timestamp with time zone DEFAULT now(),
+  "updated_at" timestamp with time zone DEFAULT now(),
+  CONSTRAINT "investment_rounds_security_type_check"
+    CHECK ("security_type" IN ('equity', 'convertible_note', 'safe', 'warrant', 'other')),
+  CONSTRAINT "investment_rounds_amount_positive"
+    CHECK ("investment_amount" > 0),
+  CONSTRAINT "investment_rounds_investment_fund_fk"
+    FOREIGN KEY ("investment_id", "fund_id")
+    REFERENCES "investments"("id", "fund_id")
+    ON UPDATE restrict
+    ON DELETE restrict,
+  CONSTRAINT "investment_rounds_fund_idem_key"
+    UNIQUE ("fund_id", "idempotency_key"),
+  CONSTRAINT "investment_rounds_id_fund_uq"
+    UNIQUE ("id", "fund_id")
+);
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "investment_rounds_fund_investment_idx"
+  ON "investment_rounds" ("fund_id", "investment_id");
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "investment_rounds_investment_round_date_idx"
+  ON "investment_rounds" ("investment_id", "round_date" DESC);
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "investment_rounds_fund_round_order_idx"
+  ON "investment_rounds" ("fund_id", "investment_id", "round_date", "created_at", "id");
+--> statement-breakpoint
+
+CREATE UNIQUE INDEX IF NOT EXISTS "investment_rounds_supersedes_uq"
+  ON "investment_rounds" ("supersedes_round_id")
+  WHERE "supersedes_round_id" IS NOT NULL;

--- a/tests/integration/prod-schema-clone.test.ts
+++ b/tests/integration/prod-schema-clone.test.ts
@@ -10,7 +10,12 @@ import { Pool } from 'pg';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { pgIdentifier } from '../../scripts/db-push-core.mjs';
-import { ACTION_SKIP, auditManifest, loadManifests } from '../../scripts/reconcile-prod-schema.mjs';
+import {
+  ACTION_SKIP,
+  auditManifest,
+  loadManifests,
+  runReconciliation,
+} from '../../scripts/reconcile-prod-schema.mjs';
 import { runMigrationsWithConnectionString } from '../helpers/testcontainers-migration';
 
 const STARTUP_TIMEOUT_MS = 90_000;
@@ -22,6 +27,7 @@ let pool: Pool | undefined;
 let shapePool: Pool | undefined;
 
 const SHAPE_DATABASE = 'shape_db';
+const INVESTMENT_ROUNDS_RECOVERY_DATABASE = 'investment_rounds_recovery_db';
 const C1_MOUNTED_TABLES = [
   'cohort_definitions',
   'sector_taxonomy',
@@ -1051,4 +1057,73 @@ describe.skipIf(skipIfNoDocker)('prod schema synthetic clone', () => {
     // operator apply (company_overrides.canonical_sector_id nullability).
     expect(failures).toEqual([]);
   }, 120_000);
+
+  it('recovers a production-shaped database with no investment_rounds and replays cleanly', async () => {
+    expect(pool).toBeDefined();
+    expect(postgres).toBeDefined();
+
+    await pool!.query(`DROP DATABASE IF EXISTS "${INVESTMENT_ROUNDS_RECOVERY_DATABASE}"`);
+    await pool!.query(`CREATE DATABASE "${INVESTMENT_ROUNDS_RECOVERY_DATABASE}"`);
+
+    const recoveryUrl = new URL(postgres!.getConnectionUri());
+    recoveryUrl.pathname = `/${INVESTMENT_ROUNDS_RECOVERY_DATABASE}`;
+    let recoveryPool: Pool | undefined;
+
+    try {
+      await runMigrationsWithConnectionString(
+        recoveryUrl.toString(),
+        '0040_multi_entity_ledger_foundation'
+      );
+      recoveryPool = new Pool({ connectionString: recoveryUrl.toString(), max: 1 });
+      await recoveryPool.query('DROP TABLE IF EXISTS "investment_round_model_overrides" CASCADE');
+      await recoveryPool.query('DROP TABLE "investment_rounds" CASCADE');
+
+      const manifest = (await loadManifests()).find(
+        (candidate) => candidate.name === 'vehicle-financing-participations'
+      );
+      expect(manifest).toBeDefined();
+
+      const client = await recoveryPool.connect();
+      try {
+        const stdout = { write: () => true };
+        const first = await runReconciliation({
+          client,
+          manifests: [manifest!],
+          apply: true,
+          expectedDatabase: INVESTMENT_ROUNDS_RECOVERY_DATABASE,
+          stdout,
+        });
+        expect(first.applied).toEqual(['vehicle-financing-participations']);
+
+        const afterFirst = await auditManifest(client, manifest!);
+        expect(afterFirst.action).toBe(ACTION_SKIP);
+        expect(afterFirst.objects.every((object) => object.action === ACTION_SKIP)).toBe(true);
+
+        const replay = await runReconciliation({
+          client,
+          manifests: [manifest!],
+          apply: true,
+          expectedDatabase: INVESTMENT_ROUNDS_RECOVERY_DATABASE,
+          stdout,
+        });
+        expect(replay.applied).toEqual([]);
+
+        const afterReplay = await auditManifest(client, manifest!);
+        expect(afterReplay.action).toBe(ACTION_SKIP);
+        expect(afterReplay.objects.every((object) => object.action === ACTION_SKIP)).toBe(true);
+      } finally {
+        client.release();
+      }
+    } finally {
+      await recoveryPool?.end();
+      await pool!.query(
+        `SELECT pg_terminate_backend(pid)
+         FROM pg_stat_activity
+         WHERE datname = $1
+           AND pid <> pg_backend_pid()`,
+        [INVESTMENT_ROUNDS_RECOVERY_DATABASE]
+      );
+      await pool!.query(`DROP DATABASE IF EXISTS "${INVESTMENT_ROUNDS_RECOVERY_DATABASE}"`);
+    }
+  }, STARTUP_TIMEOUT_MS * 2);
 });

--- a/tests/unit/prod-schema-manifest-sentinels.test.ts
+++ b/tests/unit/prod-schema-manifest-sentinels.test.ts
@@ -133,6 +133,27 @@ describe('prod-schema manifest sentinels', () => {
     }
   });
 
+  it('creates the canonical investment-rounds foundation before applying participation lineage', () => {
+    const participationManifest = manifests.find(
+      (entry) => entry.file === '15-vehicle-financing-participations.json'
+    );
+    expect(participationManifest).toBeDefined();
+    expect(participationManifest!.manifest.sqlFiles).toEqual([
+      'scripts/prod-schema-patches/0027_investment_rounds_foundation.sql',
+      'migrations/0041_vehicle_financing_participations.sql',
+    ]);
+    expect(participationManifest!.manifest.allowedCreateTables).toContain('investment_rounds');
+
+    const foundationSql = fs.readFileSync(
+      path.join(repoRoot, participationManifest!.manifest.sqlFiles![0]),
+      'utf8'
+    );
+    expect(foundationSql).toMatch(/CREATE TABLE IF NOT EXISTS "investment_rounds"/);
+    expect(foundationSql).toContain('CONSTRAINT "investment_rounds_investment_fund_fk"');
+    expect(foundationSql).toContain('CONSTRAINT "investment_rounds_id_fund_uq"');
+    expect(foundationSql).not.toMatch(/^\s*(?:DROP|DELETE|TRUNCATE)\b/im);
+  });
+
   it('every manifest SQL file begins with a -- @generated or -- @drift-patch marker', () => {
     const offenders: string[] = [];
 


### PR DESCRIPTION
## Why

Governed production closeout run `30291848347` proved production lacks `investment_rounds`. Migrations 0035-0040 committed cleanly; manifest 15 then rolled back atomically when migration 0041 reached its implicit `investment_rounds` dependency. Release dispatch stayed skipped.

## Recovery

- Add canonical, additive, data-free `investment_rounds` foundation before 0041.
- Expand manifest 15 sentinels to verify base rounds shape plus participation lineage.
- Add real-PostgreSQL proof for absent-table apply, post-audit clean state, and replay.
- Re-fence the one-shot closeout to exact failed SHA `6d9a969cab14ba0bf2d1e8c02ef8af4d75e04354`, failed run `30291848347`, its redacted artifact, and this exact five-file diff.
- Keep production mutation inside `prod-schema-reconcile.yml`; no direct SQL.

## Local proof

- 58 focused unit tests passed.
- TypeScript baseline check: 0 errors.
- Targeted ESLint passed.
- `policy:verify`: 109 route policy entries passed.
- `validate:schema-drift`: 7 surfaces, 100 passes, 0 warnings/errors.
- Workflow YAML parsed with four expected jobs and least-privilege permissions.

## CI-required proof

Testcontainers must execute the new absent-`investment_rounds` apply/replay case. Merge remains blocked until required CI, Testcontainers, security, CodeQL, and preview deployment checks pass.

Relates to #1174, #1222, #1223.