### PR TITLE
fix(facts): disclose stale-mark & contingent exclusion to forecast snapshot

### DIFF
--- a/server/services/financial-facts-snapshot-service.ts
+++ b/server/services/financial-facts-snapshot-service.ts
@@ -49,6 +49,10 @@ import type {
   CashFlowPerspectiveLite,
   ParsedValuationMark,
 } from './lp-reporting/metrics-engine';
+import {
+  DIRECT_MARK_STALE_DAYS,
+  ageDays,
+} from './investment-ledger/position-valuation-service';
 
 const ACCEPTED_STATUSES = new Set(['approved', 'locked']);
 const CASH_FLOW_TYPES = new Set<CashFlowEventType>([
@@ -152,6 +156,11 @@ interface PositionCompanyRef {
   readonly vehicleId: number;
   readonly companyIdentityId: number;
   readonly companyId: number;
+}
+
+interface DirectValuationRefRead {
+  readonly valuationRef: ValuationRef;
+  readonly markDate: string;
 }
 
 interface CanonicalContributionInput {
@@ -928,7 +937,7 @@ async function readDirectValuationRefs(params: {
   fundId: number;
   asOfDate: string;
   knowledgeCutoff: string;
-}): Promise<ValuationRef[]> {
+}): Promise<DirectValuationRefRead[]> {
   const rows = await executeRows<RawRow>(
     params.database,
     sql`
@@ -938,6 +947,7 @@ async function readDirectValuationRefs(params: {
         mark.id AS "directMarkId",
         mark.vehicle_id AS "vehicleId",
         link.company_identity_id AS "companyIdentityId",
+          mark.mark_date AS "markDate",
           mark.source_observation_id AS "directSourceObservationId",
           ROW_NUMBER() OVER (
             PARTITION BY mark.vehicle_id, link.company_identity_id
@@ -972,6 +982,7 @@ async function readDirectValuationRefs(params: {
         "directMarkId",
         "vehicleId",
         "companyIdentityId",
+        "markDate",
         "directSourceObservationId"
       FROM ranked_direct_marks
       WHERE mark_rank = 1
@@ -980,16 +991,19 @@ async function readDirectValuationRefs(params: {
   );
 
   return rows.map((row) => ({
-    basis: 'direct',
-    vehicleId: asPositiveInt(row['vehicleId']),
-    companyIdentityId: asPositiveInt(row['companyIdentityId']),
-    directMarkId: asPositiveInt(row['directMarkId']),
-    directSourceObservationId: asPositiveInt(row['directSourceObservationId']),
-    ownershipSnapshotId: null,
-    derivedTrancheId: null,
-    derivedTrancheVersion: null,
-    derivedParticipationId: null,
-    derivedParticipationVersion: null,
+    valuationRef: {
+      basis: 'direct',
+      vehicleId: asPositiveInt(row['vehicleId']),
+      companyIdentityId: asPositiveInt(row['companyIdentityId']),
+      directMarkId: asPositiveInt(row['directMarkId']),
+      directSourceObservationId: asPositiveInt(row['directSourceObservationId']),
+      ownershipSnapshotId: null,
+      derivedTrancheId: null,
+      derivedTrancheVersion: null,
+      derivedParticipationId: null,
+      derivedParticipationVersion: null,
+    },
+    markDate: asDateString(row['markDate']),
   }));
 }
 
@@ -1496,12 +1510,13 @@ function buildValuationRefs(params: {
 
 function addConsumerReason(
   evaluation: ConsumerEvaluationV2,
-  reason: ConsumerEvaluationReasonV2
+  reason: ConsumerEvaluationReasonV2,
+  blocking = true
 ): ConsumerEvaluationV2 {
   if (evaluation.reasons.includes(reason)) return evaluation;
   return {
     ...evaluation,
-    status: 'blocked',
+    status: blocking ? 'blocked' : evaluation.status,
     reasons: [...evaluation.reasons, reason],
   };
 }
@@ -1522,6 +1537,8 @@ function mergeV2ConsumerEvaluations(params: {
   positionRefs: readonly PositionRef[];
   positionCompanyRefs: readonly PositionCompanyRef[];
   valuationRefs: readonly ValuationRef[];
+  directMarkDatesByScope: ReadonlyMap<string, string>;
+  asOfDate: string;
   companyActuals: FinancialFactsPayloadV1['companyActuals'];
 }): ConsumerEvaluationV2[] {
   return params.base.map((evaluation) => {
@@ -1577,6 +1594,36 @@ function mergeV2ConsumerEvaluations(params: {
       }
     }
 
+    for (const valuationRef of params.valuationRefs) {
+      const key = scopeKey(valuationRef);
+      const directMarkDate = params.directMarkDatesByScope.get(key);
+      if (
+        valuationRef.basis === 'direct' &&
+        directMarkDate !== undefined &&
+        ageDays(directMarkDate, params.asOfDate) > DIRECT_MARK_STALE_DAYS
+      ) {
+        forecast = addConsumerReason(forecast, 'valuation_mark_stale', false);
+        forecast = addConsumerDetail(forecast, {
+          code: 'valuation_mark_stale',
+          vehicleId: valuationRef.vehicleId,
+          companyIdentityId: valuationRef.companyIdentityId,
+          message: `Direct position valuation mark is older than ${DIRECT_MARK_STALE_DAYS} days and remains selected.`,
+        });
+      }
+      if (
+        valuationRef.basis !== 'unavailable' &&
+        termsByScope.get(key)?.some((row) => row.kind === 'contingent')
+      ) {
+        forecast = addConsumerReason(forecast, 'contingent_instrument_excluded', false);
+        forecast = addConsumerDetail(forecast, {
+          code: 'contingent_instrument_excluded',
+          vehicleId: valuationRef.vehicleId,
+          companyIdentityId: valuationRef.companyIdentityId,
+          message: 'Contingent instruments are excluded from the disclosed priced-component FMV.',
+        });
+      }
+    }
+
     const ledgerPositionCompanyIds = new Set(params.positionCompanyRefs.map((ref) => ref.companyId));
     const legacyCompanyIds = [
       ...new Set(
@@ -1611,7 +1658,7 @@ async function buildPayloadV2(params: {
     positionRefs,
     componentRows,
     ownershipRefs,
-    directValuationRefs,
+    directValuationRefReads,
     derivedValuationRefs,
     positionCompanyRefs,
   ] = await Promise.all([
@@ -1622,6 +1669,10 @@ async function buildPayloadV2(params: {
     readDerivedValuationRefs(params),
     readPositionCompanyRefs(params),
   ]);
+  const directValuationRefs = directValuationRefReads.map((read) => read.valuationRef);
+  const directMarkDatesByScope = new Map(
+    directValuationRefReads.map((read) => [scopeKey(read.valuationRef), read.markDate])
+  );
   const valuationRefs = buildValuationRefs({
     positionRefs,
     ownershipRefs,
@@ -1675,6 +1726,8 @@ async function buildPayloadV2(params: {
       positionRefs,
       positionCompanyRefs,
       valuationRefs,
+      directMarkDatesByScope,
+      asOfDate: params.asOfDate,
       companyActuals: params.base.companyActuals,
     }),
   };

--- a/server/services/investment-ledger/position-valuation-service.ts
+++ b/server/services/investment-ledger/position-valuation-service.ts
@@ -17,6 +17,8 @@ import { listOwnershipSnapshots } from './ownership-snapshot-service';
 
 type LedgerDatabase = typeof db;
 
+export const DIRECT_MARK_STALE_DAYS = 120;
+
 interface DirectMarkRow {
   id: number;
   fundId: number;
@@ -635,11 +637,11 @@ async function selectObservation(
 }
 
 function staleWarning(markDate: string, asOfDate: string): PositionValuationSelectionV1['warnings'] {
-  return ageDays(markDate, asOfDate) > 120
+  return ageDays(markDate, asOfDate) > DIRECT_MARK_STALE_DAYS
     ? [
         {
           code: 'DIRECT_POSITION_MARK_STALE',
-          message: 'Direct position valuation mark is older than 120 days and remains selected.',
+          message: `Direct position valuation mark is older than ${DIRECT_MARK_STALE_DAYS} days and remains selected.`,
         },
       ]
     : [];
@@ -659,7 +661,7 @@ function contingentIncompleteWarnings(): PositionValuationSelectionV1['warnings'
   ];
 }
 
-function ageDays(evidenceDate: string, asOfDate: string): number {
+export function ageDays(evidenceDate: string, asOfDate: string): number {
   return Math.floor(
     (Date.parse(`${asOfDate}T00:00:00.000Z`) -
       Date.parse(`${evidenceDate}T00:00:00.000Z`)) /

--- a/shared/contracts/financial-facts-consumer-policies.ts
+++ b/shared/contracts/financial-facts-consumer-policies.ts
@@ -24,6 +24,8 @@ export const ConsumerEvaluationReasonV2Schema = z.enum([
   'uniformly_stale_refs',
   'mixed_legacy_ledger_provenance',
   'position_valuation_incomplete',
+  'valuation_mark_stale',
+  'contingent_instrument_excluded',
 ]);
 
 export const ConsumerEvaluationDetailV2Schema = z

--- a/tests/unit/services/financial-facts-snapshot-service.test.ts
+++ b/tests/unit/services/financial-facts-snapshot-service.test.ts
@@ -851,6 +851,7 @@ describe('buildFinancialFactsSnapshot', () => {
       directMarkId: 701,
       vehicleId: 10,
       companyIdentityId: 42,
+      markDate: '2026-06-30',
       directSourceObservationId: 71,
     });
 
@@ -896,6 +897,7 @@ describe('buildFinancialFactsSnapshot', () => {
         directSourceObservationId: 71,
       }),
     ]);
+    expect(snapshot.payload.valuationRefs[0]).not.toHaveProperty('markDate');
     expect(snapshot.payload.observationRefs).toEqual([
       {
         observationId: 71,
@@ -921,6 +923,8 @@ describe('buildFinancialFactsSnapshot', () => {
       .toContain("observation.domain = 'valuation'");
     expect(renderedSql.find((sql) => sql.includes('financial_facts_v2_direct_valuation_refs')))
       .toContain('COALESCE(mark.approved_at, mark.locked_at, mark.created_at) <=');
+    expect(renderedSql.find((sql) => sql.includes('financial_facts_v2_direct_valuation_refs')))
+      .toContain('mark.mark_date AS "markDate"');
     expect(renderedSql.find((sql) => sql.includes('financial_facts_v2_derived_valuation_refs')))
       .toContain("observation.domain = 'ledger_event'");
     expect(renderedSql.find((sql) => sql.includes('financial_facts_v2_derived_valuation_refs')))
@@ -1053,6 +1057,109 @@ describe('buildFinancialFactsSnapshot', () => {
       });
   });
 
+  it('discloses a selected direct valuation mark older than 120 days without blocking', async () => {
+    const fakeDb = new FakeSnapshotDb();
+    fakeDb.directValuationRefRows.push({
+      directMarkId: 701,
+      vehicleId: 10,
+      companyIdentityId: 42,
+      markDate: '2026-03-01',
+      directSourceObservationId: 71,
+    });
+
+    const snapshot = await buildFinancialFactsSnapshot({
+      fundId: 1,
+      asOfDate: '2026-06-30',
+      actorId: 7,
+      idempotencyKey: 'snapshot-stale-direct-valuation',
+      database: fakeDb.asDatabase(),
+      now: new Date('2026-07-22T01:42:44.186Z'),
+    });
+
+    expect(snapshot.consumerEvaluations.find((evaluation) => evaluation.consumer === 'forecast'))
+      .toEqual({
+        consumer: 'forecast',
+        status: 'accepted',
+        reasons: ['valuation_mark_stale'],
+        details: [
+          {
+            code: 'valuation_mark_stale',
+            vehicleId: 10,
+            companyIdentityId: 42,
+            message: 'Direct position valuation mark is older than 120 days and remains selected.',
+          },
+        ],
+      });
+  });
+
+  it('does not disclose a direct valuation mark exactly 120 days old', async () => {
+    const fakeDb = new FakeSnapshotDb();
+    fakeDb.directValuationRefRows.push({
+      directMarkId: 701,
+      vehicleId: 10,
+      companyIdentityId: 42,
+      markDate: '2026-03-02',
+      directSourceObservationId: 71,
+    });
+
+    const snapshot = await buildFinancialFactsSnapshot({
+      fundId: 1,
+      asOfDate: '2026-06-30',
+      actorId: 7,
+      idempotencyKey: 'snapshot-current-direct-valuation',
+      database: fakeDb.asDatabase(),
+      now: new Date('2026-07-22T01:42:44.186Z'),
+    });
+    expect(snapshot.consumerEvaluations.find((evaluation) => evaluation.consumer === 'forecast'))
+      .toEqual({ consumer: 'forecast', status: 'accepted', reasons: [] });
+  });
+
+  it('discloses contingent components excluded from a valued scope without blocking', async () => {
+    const fakeDb = new FakeSnapshotDb();
+    fakeDb.participationTermRefRows.push({
+      participationId: 201,
+      participationVersion: 1,
+      financingTrancheId: 301,
+      trancheVersion: 1,
+      vehicleId: 10,
+      companyIdentityId: 42,
+      isCurrent: true,
+      kind: 'contingent',
+    });
+    fakeDb.directValuationRefRows.push({
+      directMarkId: 701,
+      vehicleId: 10,
+      companyIdentityId: 42,
+      markDate: '2026-06-30',
+      directSourceObservationId: 71,
+    });
+
+    const snapshot = await buildFinancialFactsSnapshot({
+      fundId: 1,
+      asOfDate: '2026-06-30',
+      actorId: 7,
+      idempotencyKey: 'snapshot-contingent-component-excluded',
+      database: fakeDb.asDatabase(),
+      now: new Date('2026-07-22T01:42:44.186Z'),
+    });
+
+    expect(snapshot.consumerEvaluations.find((evaluation) => evaluation.consumer === 'forecast'))
+      .toEqual({
+        consumer: 'forecast',
+        status: 'accepted',
+        reasons: ['contingent_instrument_excluded'],
+        details: [
+          {
+            code: 'contingent_instrument_excluded',
+            vehicleId: 10,
+            companyIdentityId: 42,
+            message:
+              'Contingent instruments are excluded from the disclosed priced-component FMV.',
+          },
+        ],
+      });
+  });
+
   it('blocks forecast evaluation when payload 2 mixes current and stale term refs', async () => {
     const fakeDb = new FakeSnapshotDb();
     fakeDb.positionRefRows.push({
@@ -1075,7 +1182,7 @@ describe('buildFinancialFactsSnapshot', () => {
         vehicleId: 10,
         companyIdentityId: 42,
         isCurrent: false,
-        kind: 'contingent',
+        kind: 'priced',
       },
       {
         participationId: 202,
@@ -1092,6 +1199,7 @@ describe('buildFinancialFactsSnapshot', () => {
       directMarkId: 701,
       vehicleId: 10,
       companyIdentityId: 42,
+      markDate: '2026-06-30',
       directSourceObservationId: 71,
     });
 
@@ -1150,12 +1258,13 @@ describe('buildFinancialFactsSnapshot', () => {
       vehicleId: 10,
       companyIdentityId: 42,
       isCurrent: false,
-      kind: 'contingent',
+      kind: 'priced',
     });
     fakeDb.directValuationRefRows.push({
       directMarkId: 701,
       vehicleId: 10,
       companyIdentityId: 42,
+      markDate: '2026-06-30',
       directSourceObservationId: 71,
     });
 
@@ -1304,6 +1413,7 @@ describe('buildFinancialFactsSnapshot', () => {
       directMarkId: 701,
       vehicleId: 10,
       companyIdentityId: 42001,
+      markDate: '2026-06-30',
       directSourceObservationId: 71,
     });
     const allLedger = await buildFinancialFactsSnapshot({
@@ -1342,6 +1452,7 @@ describe('buildFinancialFactsSnapshot', () => {
       directMarkId: 701,
       vehicleId: 10,
       companyIdentityId: 42099,
+      markDate: INTERNAL_FUND_CORPUS.asOfDate,
       directSourceObservationId: 71,
     });
     const nonOverlap = await buildFinancialFactsSnapshot({
@@ -1392,6 +1503,7 @@ describe('buildFinancialFactsSnapshot', () => {
       directMarkId: 701,
       vehicleId: 10,
       companyIdentityId: 42001,
+      markDate: INTERNAL_FUND_CORPUS.asOfDate,
       directSourceObservationId: 71,
     });
     const mixed = await buildFinancialFactsSnapshot({


### PR DESCRIPTION
## Description

Follow-up to the PR #1212 review. Closes a disclosure gap found there: a **stale direct FMV mark (>120d) is flagged on the interactive `GET /position-valuations` endpoint but was invisible in the forecast-facing financial-facts snapshot** — so a forecast could silently consume a stale mark as current. Same for contingent-instrument exclusion. PR #1212's checklist claim "Stale mark and contingent-exclusion states remain visible" was true only interactively; this makes it true for the snapshot forecasts read.

Verified against merged `main` (`b923470d`): `mergeV2ConsumerEvaluations` emitted only `mixed_term_versions`/`uniformly_stale_refs`/`position_valuation_incomplete`/`mixed_legacy_ledger_provenance` — no stale-mark or contingent signal.

## Change (additive, non-blocking, replay-safe)

- `financial-facts-consumer-policies.ts`: two new codes on `ConsumerEvaluationReasonV2Schema` — `valuation_mark_stale`, `contingent_instrument_excluded`. V1 schema untouched.
- `financial-facts-snapshot-service.ts`: `mergeV2ConsumerEvaluations` now discloses, for the `forecast` consumer, (a) a selected direct mark older than `DIRECT_MARK_STALE_DAYS` (120), and (b) a valued scope that also holds `kind='contingent'` components. `readDirectValuationRefs` threads `mark_date` via a **build-time-only** sibling field + `directMarkDatesByScope` map — **not** added to the persisted `ValuationRef`, so payload-2 shape and replay hash are unchanged.
- `position-valuation-service.ts`: exports `DIRECT_MARK_STALE_DAYS` + `ageDays` as the single source of truth (interactive `staleWarning` now consumes the constant, so the two paths cannot drift).
- Disclosures are **non-blocking**: `addConsumerReason` gained a `blocking` flag (default `true`, preserving existing behavior); the two new reasons pass `false`, so `status` stays `accepted`. No block-semantics change.

## Non-goals

- No block on stale marks (disclosure only). If forecasts should later gate on staleness, that's a separate slice.
- No V1 / 1.0.x schema, payload-2 shape, or replay-hash change.

## Verification (run locally on this branch, isolated worktree off `b923470d`)

- `npm run check` — 0 TypeScript errors
- Focused: `financial-facts-snapshot-service.test.ts` + `financial-facts.contract.test.ts` — 39/39
- `phoenix:truth` — 291/291 (zero delta, no calc change)
- Full **server** project — 8327 passed / 0 failed (76 skipped). Client project untouched (server+shared change only).
- New tests assert: >120d stale disclosed with `status: 'accepted'` (non-blocking); exactly-120d NOT disclosed (boundary); contingent-in-valued-scope disclosed non-blocking; `markDate` NOT present on persisted `valuationRefs`.

## Related

Refs #1174. Follow-up to #1212 (Task 11 Option B).
