### PR TITLE
fix(hermes): add dispatch timeout, process-tree-kill, and ledger secret scrubbing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -278,6 +278,9 @@ _archive/
 # Hermes run ledger (ephemeral runtime state)
 ai-logs/
 
+# ~/.ai-brain staging notes (personal cross-project memory, not a repo deliverable)
+.remember/
+
 # Skill staging directories (source material, not deployed)
 uiux-skill/
 

--- a/orchestrate.js
+++ b/orchestrate.js
@@ -33,6 +33,15 @@ const DEFAULT_DEBATE = {
   synthesis: 'claude',
 };
 
+// REFL-039 (2026-07-13 OOM): orphaned model-CLI processes accumulated across
+// lane sessions with no automated bound. These two defaults are the safety
+// net that prose "Lane Hygiene" rules stood in for — a timeout kills a hung
+// dispatch's whole process tree; one retry absorbs a transient hang without
+// masking a genuine model failure (only timeouts are retried, never a real
+// non-zero exit).
+const DEFAULT_MODEL_TIMEOUT_MS = 10 * 60 * 1000;
+const DEFAULT_MODEL_MAX_ATTEMPTS = 2;
+
 function normalizeEntrypointPath(value) {
   return String(value || '')
     .replace(/^file:\/\//, '')
@@ -658,13 +667,91 @@ function printDoctorReport(report, stdout = process.stdout) {
   stdout.write(`${formatDoctorReport(report)}\n`);
 }
 
-function executeModel(
-  model,
-  prompt,
-  routing,
-  env = process.env,
-  { spawn: spawnImpl = spawn, workspace = ROOT } = {}
+// Kills a spawned model-CLI process AND its children. executeModel/
+// executeModelCapture always spawn with `detached: true` on POSIX (own
+// process group, pgid === child.pid), so `-pid` reaches the whole tree, not
+// just the immediate child (e.g. a shell wrapping the real CLI). Windows has
+// no negative-pid group signal, so it shells out to taskkill /T (tree) /F.
+function killProcessTree(
+  child,
+  { platform = process.platform, kill = process.kill, spawnSyncImpl = spawnSync } = {}
 ) {
+  if (!child || !child.pid) return;
+  if (platform === 'win32') {
+    spawnSyncImpl('taskkill', ['/pid', String(child.pid), '/T', '/F'], { stdio: 'ignore' });
+    return;
+  }
+  try {
+    kill(-child.pid, 'SIGKILL');
+  } catch {
+    // Process group already gone, or this child was never its own group
+    // leader (e.g. a fake/injected child in tests) — fall back to a direct kill.
+    try {
+      child.kill?.('SIGKILL');
+    } catch {
+      // Nothing left to kill.
+    }
+  }
+}
+
+// Shared spawn core for executeModel/executeModelCapture: enforces a
+// per-attempt timeout that kills the whole process tree (see REFL-039), and
+// optionally pipes+aggregates stdout for the capture variant.
+function runModelProcessOnce(bin, input, spawnOpts, { spawnImpl, timeoutMs, killTree, capture }) {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawnImpl(bin, input.args, spawnOpts);
+    let settled = false;
+    let output = '';
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      killTree(child);
+      const error = new Error(`Model dispatch timed out after ${timeoutMs}ms`);
+      error.timedOut = true;
+      reject(error);
+    }, timeoutMs);
+
+    if (capture) {
+      child.stdout.on('data', (chunk) => {
+        output += chunk.toString();
+      });
+    }
+    if (input.stdin !== null) child.stdin.write(input.stdin);
+    child.stdin.end();
+    child.on('error', (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.on('close', (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolvePromise(capture ? { code: code || 0, output } : code || 0);
+    });
+  });
+}
+
+// Bounded retry around runModelProcessOnce. Only a timeout is retried — a
+// real non-zero exit is the model's actual answer and must surface
+// immediately, never be silently re-run.
+async function runModelProcessWithRetry(bin, input, spawnOpts, opts) {
+  const { maxAttempts } = opts;
+  let lastError;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      return await runModelProcessOnce(bin, input, spawnOpts, opts);
+    } catch (error) {
+      lastError = error;
+      if (!error?.timedOut || attempt === maxAttempts) throw error;
+    }
+  }
+  throw lastError;
+}
+
+function prepareModelDispatch(model, prompt, routing, env) {
   const commandConfig = routing.commands?.[model];
   if (!commandConfig) {
     throw new Error(`No command config for model: ${model}`);
@@ -677,21 +764,41 @@ function executeModel(
     );
   }
 
-  const input = resolveCommandInput(commandConfig, prompt);
-  const commandEnv = resolveCommandEnv(commandConfig, env);
-  const useShell = shouldUseShell(process.platform, commandConfig);
-  return new Promise((resolvePromise, reject) => {
-    const child = spawnImpl(bin, input.args, {
-      stdio: ['pipe', 'inherit', 'inherit'],
-      shell: useShell,
-      env: commandEnv,
-      cwd: workspace,
-    });
+  return {
+    bin,
+    input: resolveCommandInput(commandConfig, prompt),
+    commandEnv: resolveCommandEnv(commandConfig, env),
+    useShell: shouldUseShell(process.platform, commandConfig),
+  };
+}
 
-    if (input.stdin !== null) child.stdin.write(input.stdin);
-    child.stdin.end();
-    child.on('error', reject);
-    child.on('close', (code) => resolvePromise(code || 0));
+function executeModel(
+  model,
+  prompt,
+  routing,
+  env = process.env,
+  {
+    spawn: spawnImpl = spawn,
+    workspace = ROOT,
+    timeoutMs = DEFAULT_MODEL_TIMEOUT_MS,
+    maxAttempts = DEFAULT_MODEL_MAX_ATTEMPTS,
+    killTree = killProcessTree,
+  } = {}
+) {
+  const { bin, input, commandEnv, useShell } = prepareModelDispatch(model, prompt, routing, env);
+  const spawnOpts = {
+    stdio: ['pipe', 'inherit', 'inherit'],
+    shell: useShell,
+    env: commandEnv,
+    cwd: workspace,
+    detached: process.platform !== 'win32',
+  };
+  return runModelProcessWithRetry(bin, input, spawnOpts, {
+    spawnImpl,
+    timeoutMs,
+    killTree,
+    maxAttempts,
+    capture: false,
   });
 }
 
@@ -703,39 +810,28 @@ function executeModelCapture(
   prompt,
   routing,
   env = process.env,
-  { spawn: spawnImpl = spawn, workspace = ROOT } = {}
+  {
+    spawn: spawnImpl = spawn,
+    workspace = ROOT,
+    timeoutMs = DEFAULT_MODEL_TIMEOUT_MS,
+    maxAttempts = DEFAULT_MODEL_MAX_ATTEMPTS,
+    killTree = killProcessTree,
+  } = {}
 ) {
-  const commandConfig = routing.commands?.[model];
-  if (!commandConfig) {
-    throw new Error(`No command config for model: ${model}`);
-  }
-
-  const bin = env[commandConfig.binEnv] || commandConfig.defaultBin;
-  if (!commandExists(bin)) {
-    throw new Error(
-      `Command not found for model "${model}": ${bin}. Set ${commandConfig.binEnv} or install the CLI.`
-    );
-  }
-
-  const input = resolveCommandInput(commandConfig, prompt);
-  const commandEnv = resolveCommandEnv(commandConfig, env);
-  const useShell = shouldUseShell(process.platform, commandConfig);
-  return new Promise((resolvePromise, reject) => {
-    const child = spawnImpl(bin, input.args, {
-      stdio: ['pipe', 'pipe', 'inherit'],
-      shell: useShell,
-      env: commandEnv,
-      cwd: workspace,
-    });
-
-    let output = '';
-    child.stdout.on('data', (chunk) => {
-      output += chunk.toString();
-    });
-    if (input.stdin !== null) child.stdin.write(input.stdin);
-    child.stdin.end();
-    child.on('error', reject);
-    child.on('close', (code) => resolvePromise({ code: code || 0, output }));
+  const { bin, input, commandEnv, useShell } = prepareModelDispatch(model, prompt, routing, env);
+  const spawnOpts = {
+    stdio: ['pipe', 'pipe', 'inherit'],
+    shell: useShell,
+    env: commandEnv,
+    cwd: workspace,
+    detached: process.platform !== 'win32',
+  };
+  return runModelProcessWithRetry(bin, input, spawnOpts, {
+    spawnImpl,
+    timeoutMs,
+    killTree,
+    maxAttempts,
+    capture: true,
   });
 }
 
@@ -1098,11 +1194,48 @@ function generateRunId(now = new Date()) {
   return `hermes-${iso}`;
 }
 
+const SECRET_TEXT_PATTERNS = [
+  // OpenAI/Anthropic-style API keys (sk-..., sk-ant-..., sk-proj-...).
+  /\bsk-[A-Za-z0-9-_]{10,}\b/g,
+  // GitHub tokens (ghp_, gho_, ghu_, ghs_, ghr_).
+  /\bgh[pousr]_[A-Za-z0-9]{20,}\b/g,
+  // AWS access key IDs.
+  /\bAKIA[0-9A-Z]{16}\b/g,
+  // Bearer auth headers.
+  /\b(Bearer\s+)[A-Za-z0-9\-._~+/]+=*/gi,
+  // key=value / key: value assignments for common secret-ish names.
+  /\b((?:api[_-]?key|secret|token|password|passwd)\s*[:=]\s*)(\S+)/gi,
+];
+
+// The Hermes run ledger (ai-logs/hermes/runs/*.json) stores the raw --task
+// string verbatim. ai-logs/ is gitignored so this isn't a git-history leak,
+// but nothing stopped a credential pasted into a task string from landing on
+// disk in plaintext. Recursively redacts obvious secret shapes from every
+// string field before a record is written.
+function scrubSecrets(value) {
+  if (typeof value === 'string') {
+    return SECRET_TEXT_PATTERNS.reduce((text, pattern) => {
+      if (pattern.source.includes('(')) {
+        // Patterns with a capture group keep the non-secret prefix (e.g. "Bearer ", "api_key=").
+        return text.replace(pattern, (...args) => `${args[1]}[REDACTED]`);
+      }
+      return text.replace(pattern, '[REDACTED]');
+    }, value);
+  }
+  if (Array.isArray(value)) {
+    return value.map(scrubSecrets);
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value).map(([key, val]) => [key, scrubSecrets(val)]));
+  }
+  return value;
+}
+
 function writeRunLedger(record, { root = ROOT, fs = { mkdirSync, writeFileSync } } = {}) {
   const dir = join(root, 'ai-logs', 'hermes', 'runs');
   fs.mkdirSync(dir, { recursive: true });
   const file = join(dir, `${record.runId}.json`);
-  fs.writeFileSync(file, `${JSON.stringify(record, null, 2)}\n`);
+  fs.writeFileSync(file, `${JSON.stringify(scrubSecrets(record), null, 2)}\n`);
   return file;
 }
 
@@ -1748,6 +1881,7 @@ export {
   createWorkflowPlan,
   createRoutingPlan,
   evaluateReadiness,
+  executeModel,
   executeModelCapture,
   executeWorkflow,
   extractFindingsReport,
@@ -1756,6 +1890,7 @@ export {
   getGateRunPlan,
   isCliEntryPoint,
   isProductionFinancial,
+  killProcessTree,
   main,
   parseApprovalSignal,
   parseArgs,
@@ -1765,6 +1900,7 @@ export {
   resolveOwnership,
   runGate,
   runMoaReview,
+  scrubSecrets,
   shouldRunPostflightGate,
   scoreSpecialist,
   validateFindingsReport,

--- a/tests/unit/scripts/orchestrate-reliability.test.mjs
+++ b/tests/unit/scripts/orchestrate-reliability.test.mjs
@@ -1,0 +1,227 @@
+import { Buffer } from 'node:buffer';
+import { EventEmitter } from 'node:events';
+import process from 'node:process';
+import { setTimeout } from 'node:timers';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  executeModel,
+  executeModelCapture,
+  killProcessTree,
+  scrubSecrets,
+  writeRunLedger,
+} from '../../../orchestrate.js';
+
+function makeRouting() {
+  return {
+    commands: {
+      claude: {
+        // Absolute path with a separator makes commandExists() resolve via
+        // existsSync (deterministic, no real subprocess) instead of which/where.
+        defaultBin: process.execPath,
+        binEnv: 'CLAUDE_BIN',
+        args: [],
+        promptDelivery: 'stdin',
+      },
+    },
+  };
+}
+
+function createFakeChild() {
+  const child = new EventEmitter();
+  child.pid = 4242;
+  child.stdin = { write: vi.fn(), end: vi.fn() };
+  child.stdout = new EventEmitter();
+  child.kill = vi.fn();
+  return child;
+}
+
+describe('killProcessTree', () => {
+  it('sends SIGKILL to the negative pid (process group) on POSIX', () => {
+    const kill = vi.fn();
+    killProcessTree({ pid: 555 }, { platform: 'darwin', kill });
+    expect(kill).toHaveBeenCalledWith(-555, 'SIGKILL');
+  });
+
+  it('falls back to child.kill if the process-group kill throws (group already gone)', () => {
+    const kill = vi.fn(() => {
+      throw new Error('ESRCH');
+    });
+    const childKill = vi.fn();
+    killProcessTree({ pid: 555, kill: childKill }, { platform: 'darwin', kill });
+    expect(childKill).toHaveBeenCalledWith('SIGKILL');
+  });
+
+  it('shells out to taskkill /T /F on win32', () => {
+    const spawnSyncImpl = vi.fn();
+    killProcessTree({ pid: 555 }, { platform: 'win32', spawnSyncImpl });
+    expect(spawnSyncImpl).toHaveBeenCalledWith(
+      'taskkill',
+      ['/pid', '555', '/T', '/F'],
+      expect.any(Object)
+    );
+  });
+
+  it('does nothing when given a child with no pid', () => {
+    const kill = vi.fn();
+    killProcessTree(null, { kill });
+    killProcessTree({}, { kill });
+    expect(kill).not.toHaveBeenCalled();
+  });
+});
+
+describe('executeModel timeout + tree-kill', () => {
+  it('kills the process tree and rejects a timed-out attempt', async () => {
+    const child = createFakeChild(); // never emits 'close' — simulates a hang
+    const spawnImpl = vi.fn(() => child);
+    const killTree = vi.fn();
+    const routing = makeRouting();
+
+    await expect(
+      executeModel('claude', 'hello', routing, {}, {
+        spawn: spawnImpl,
+        timeoutMs: 20,
+        killTree,
+        maxAttempts: 1,
+      })
+    ).rejects.toMatchObject({ timedOut: true });
+
+    expect(killTree).toHaveBeenCalledWith(child);
+  });
+
+  it('retries once after a timeout and resolves if the retry succeeds', async () => {
+    const firstChild = createFakeChild(); // hangs
+    const secondChild = createFakeChild();
+    const spawnImpl = vi
+      .fn()
+      .mockImplementationOnce(() => firstChild)
+      .mockImplementationOnce(() => {
+        setTimeout(() => secondChild.emit('close', 0), 1);
+        return secondChild;
+      });
+    const killTree = vi.fn();
+    const routing = makeRouting();
+
+    const result = await executeModel('claude', 'hello', routing, {}, {
+      spawn: spawnImpl,
+      timeoutMs: 20,
+      killTree,
+      maxAttempts: 2,
+    });
+
+    expect(result).toBe(0);
+    expect(spawnImpl).toHaveBeenCalledTimes(2);
+    expect(killTree).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry a normal non-zero exit — only timeouts are retryable', async () => {
+    const child = createFakeChild();
+    const spawnImpl = vi.fn(() => child);
+    const routing = makeRouting();
+
+    const promise = executeModel('claude', 'hello', routing, {}, {
+      spawn: spawnImpl,
+      timeoutMs: 1000,
+      maxAttempts: 3,
+    });
+    child.emit('close', 1);
+
+    await expect(promise).resolves.toBe(1);
+    expect(spawnImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not kill the process or misfire when the model completes normally', async () => {
+    const child = createFakeChild();
+    const spawnImpl = vi.fn(() => child);
+    const killTree = vi.fn();
+    const routing = makeRouting();
+
+    const promise = executeModel('claude', 'hello', routing, {}, {
+      spawn: spawnImpl,
+      timeoutMs: 1000,
+      killTree,
+    });
+    child.emit('close', 0);
+
+    await expect(promise).resolves.toBe(0);
+    expect(killTree).not.toHaveBeenCalled();
+  });
+});
+
+describe('executeModelCapture timeout + tree-kill', () => {
+  it('captures stdout and resolves {code, output}', async () => {
+    const child = createFakeChild();
+    const spawnImpl = vi.fn(() => child);
+    const routing = makeRouting();
+
+    const promise = executeModelCapture('claude', 'hello', routing, {}, {
+      spawn: spawnImpl,
+      timeoutMs: 1000,
+    });
+    child.stdout.emit('data', Buffer.from('partial '));
+    child.stdout.emit('data', Buffer.from('output'));
+    child.emit('close', 0);
+
+    await expect(promise).resolves.toEqual({ code: 0, output: 'partial output' });
+  });
+
+  it('kills the process tree and rejects a timed-out attempt', async () => {
+    const child = createFakeChild();
+    const spawnImpl = vi.fn(() => child);
+    const killTree = vi.fn();
+    const routing = makeRouting();
+
+    await expect(
+      executeModelCapture('claude', 'hello', routing, {}, {
+        spawn: spawnImpl,
+        timeoutMs: 20,
+        killTree,
+        maxAttempts: 1,
+      })
+    ).rejects.toMatchObject({ timedOut: true });
+
+    expect(killTree).toHaveBeenCalledWith(child);
+  });
+});
+
+describe('scrubSecrets', () => {
+  it('redacts an API-key-shaped token embedded in free text', () => {
+    const input = { task: 'call the model using sk-ant-api03-abcdefghijklmnopqrstuvwxyz1234567890' };
+    const result = scrubSecrets(input);
+    expect(result.task).not.toContain('sk-ant-api03-abcdefghijklmnopqrstuvwxyz1234567890');
+    expect(result.task).toContain('[REDACTED]');
+  });
+
+  it('redacts key=value style secrets nested inside an object', () => {
+    const input = { plan: { env: { note: 'export API_KEY=supersecretvalue123' } } };
+    const result = scrubSecrets(input);
+    expect(result.plan.env.note).not.toContain('supersecretvalue123');
+  });
+
+  it('leaves ordinary text and non-string values untouched', () => {
+    const input = { runId: 'hermes-1', exitCode: 0, ok: true, note: 'fix xirr calculation' };
+    const result = scrubSecrets(input);
+    expect(result).toEqual(input);
+  });
+});
+
+describe('writeRunLedger secret scrubbing', () => {
+  it('does not write a raw API key to the ledger file', () => {
+    let written = '';
+    const fs = {
+      mkdirSync: () => {},
+      writeFileSync: (_file, content) => {
+        written = content;
+      },
+    };
+
+    writeRunLedger(
+      { runId: 'test-run', plan: { task: 'use token sk-proj-abcdefghijklmnopqrstuvwx' } },
+      { root: '/tmp/orchestrate-ledger-test', fs }
+    );
+
+    expect(written).not.toContain('sk-proj-abcdefghijklmnopqrstuvwx');
+    expect(written).toContain('[REDACTED]');
+  });
+});


### PR DESCRIPTION
## Summary
- `executeModel`/`executeModelCapture` had no timeout and never killed a hung model CLI's process tree — the exact gap behind the 2026-07-13 orphaned-process OOM (`docs/skills/REFL-039-transport-failure-must-not-invert-model-roles.md`), currently patched by hand via DEV_BRAIN.md's "Lane Hygiene" prose rules instead of code.
- Adds a per-attempt timeout that kills the whole process tree (POSIX: detached process-group `SIGKILL`; Windows: `taskkill /T /F`), and retries once — but only on a timeout, never on a real non-zero exit, so a genuine model failure always surfaces immediately instead of being silently re-run.
- Scrubs obvious secret shapes (API keys, GitHub/AWS tokens, bearer headers, `key=value` secrets) from the run ledger before it's written to `ai-logs/hermes/runs/*.json`, which previously stored the raw `--task` string verbatim.
- Ignores `.remember/` (personal cross-project memory staging notes for an unrelated tool, not a repo deliverable).

Surfaced while auditing an old-machine config bundle for reuse; this addresses the one concrete reliability regression found (full audit trail in `docs/skills/REFL-039-*`). Deliberately scoped: this repo runs on a 48GB/18-core Mac, not the old constrained laptop, so the RAM-specific "one lane at a time" threshold from the old design docs was intentionally NOT ported — the timeout/kill/scrub gap is the RAM-independent part that was actually missing.

## Test plan
- [x] New unit suite `tests/unit/scripts/orchestrate-reliability.test.mjs` (14 tests, TDD — written and watched fail before implementation): `killProcessTree` (POSIX group-kill, Windows taskkill, ESRCH fallback, no-op on missing pid), `executeModel`/`executeModelCapture` (timeout+kill, retry-on-timeout-only, no-retry-on-real-exit, clean-success has no side effects), `scrubSecrets`, `writeRunLedger` scrubbing.
- [x] Existing Hermes routing suite (`tests/unit/routing/hermes-*.test.ts`, 184 tests) — no regressions.
- [x] `npm run check` — 0 new TypeScript errors.
- [x] `npm run lint` on changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)