### PR TITLE
chore: remove stale ai-brain gitignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -278,9 +278,6 @@ _archive/
 # Hermes run ledger (ephemeral runtime state)
 ai-logs/
 
-# ~/.ai-brain staging notes (personal cross-project memory, not a repo deliverable)
-.remember/
-
 # Skill staging directories (source material, not deployed)
 uiux-skill/
 


### PR DESCRIPTION
## Summary
- Removes the redundant \`.remember/\` gitignore entry (and its now-inaccurate "ai-brain staging notes" comment) added in PR #1232.
- The \`~/.ai-brain\` tool it referenced was reverted this session (collided with the live \`.remember/\` rolling-notes tool). \`.remember/\`'s own nested \`.gitignore\` (\`*\`) already covers exclusion on its own — verified \`git status\` still shows it fully ignored with the root-level entry removed.

## Test plan
- [x] \`git status --porcelain --ignored\` confirms \`.remember/*\` still reported as ignored after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)