### PR TITLE
fix(hermes): remove auto-timeout, add signal-forwarding + relaunch-cleanup

### DIFF
--- a/DEV_BRAIN.md
+++ b/DEV_BRAIN.md
@@ -152,16 +152,16 @@ Transport rules for Hermes lane dispatch, one per observed 2026-07-13 failure:
 1. Invoke `node orchestrate.js --phase production` directly (npm shim can 126).
 2. Keyword-light `--task` string; payload details go in a temp-file brief
    pointer (multi-line payloads mangle; financial keywords self-classify).
-3. Unique launcher script per run; kill the prior orchestrate process tree
-   before relaunch; purge >6h orphaned node/cmd processes after runs (orphan
-   accumulation caused the 2026-07-13 OOM).
-4. ONE lane at a time while free RAM < 4 GB; no detached lane stacking.
-5. Long-running dispatch = a single synchronous background invocation, never
+3. Relaunch cleanup is automated: before live dispatch, `orchestrate.js` checks
+   its PID file, kills a live prior process tree, and records its current PID.
+   Periodic >6h orphaned Node-process sweeps remain manual and separate because
+   relaunch cleanup runs only on the next invocation, not on a timer.
+4. Long-running dispatch = a single synchronous background invocation, never
    nohup+poll; long CLI calls run inside subagent synchronous Bash, not
    session-level background tasks.
-6. Hermes postflight verifies only `npm run check` — the review phase reruns
+5. Hermes postflight verifies only `npm run check` — the review phase reruns
    targeted and full test suites independently.
-7. Degraded-environment vitest: client project runs use `--maxWorkers=1`; write
+6. Degraded-environment vitest: client project runs use `--maxWorkers=1`; write
    outputs to files, never pipe through `tail`.
 
 ## Hard Rules

--- a/orchestrate.js
+++ b/orchestrate.js
@@ -33,14 +33,7 @@ const DEFAULT_DEBATE = {
   synthesis: 'claude',
 };
 
-// REFL-039 (2026-07-13 OOM): orphaned model-CLI processes accumulated across
-// lane sessions with no automated bound. These two defaults are the safety
-// net that prose "Lane Hygiene" rules stood in for — a timeout kills a hung
-// dispatch's whole process tree; one retry absorbs a transient hang without
-// masking a genuine model failure (only timeouts are retried, never a real
-// non-zero exit).
-const DEFAULT_MODEL_TIMEOUT_MS = 10 * 60 * 1000;
-const DEFAULT_MODEL_MAX_ATTEMPTS = 2;
+const currentModelChildren = new Set();
 
 function normalizeEntrypointPath(value) {
   return String(value || '')
@@ -694,23 +687,28 @@ function killProcessTree(
   }
 }
 
-// Shared spawn core for executeModel/executeModelCapture: enforces a
-// per-attempt timeout that kills the whole process tree (see REFL-039), and
-// optionally pipes+aggregates stdout for the capture variant.
-function runModelProcessOnce(bin, input, spawnOpts, { spawnImpl, timeoutMs, killTree, capture }) {
+function forwardTerminationSignal(
+  signal,
+  { killTree = killProcessTree, exit = process.exit } = {}
+) {
+  for (const child of currentModelChildren) {
+    killTree(child);
+  }
+  exit(signal === 'SIGINT' ? 130 : 143);
+}
+
+// Shared spawn core for executeModel/executeModelCapture. Optionally
+// pipes+aggregates stdout for the capture variant.
+function runModelProcessOnce(bin, input, spawnOpts, { spawnImpl, capture }) {
   return new Promise((resolvePromise, reject) => {
     const child = spawnImpl(bin, input.args, spawnOpts);
+    currentModelChildren.add(child);
     let settled = false;
     let output = '';
 
-    const timer = setTimeout(() => {
-      if (settled) return;
-      settled = true;
-      killTree(child);
-      const error = new Error(`Model dispatch timed out after ${timeoutMs}ms`);
-      error.timedOut = true;
-      reject(error);
-    }, timeoutMs);
+    const clearCurrentChild = () => {
+      currentModelChildren.delete(child);
+    };
 
     if (capture) {
       child.stdout.on('data', (chunk) => {
@@ -722,33 +720,16 @@ function runModelProcessOnce(bin, input, spawnOpts, { spawnImpl, timeoutMs, kill
     child.on('error', (error) => {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
+      clearCurrentChild();
       reject(error);
     });
     child.on('close', (code) => {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
+      clearCurrentChild();
       resolvePromise(capture ? { code: code || 0, output } : code || 0);
     });
   });
-}
-
-// Bounded retry around runModelProcessOnce. Only a timeout is retried — a
-// real non-zero exit is the model's actual answer and must surface
-// immediately, never be silently re-run.
-async function runModelProcessWithRetry(bin, input, spawnOpts, opts) {
-  const { maxAttempts } = opts;
-  let lastError;
-  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-    try {
-      return await runModelProcessOnce(bin, input, spawnOpts, opts);
-    } catch (error) {
-      lastError = error;
-      if (!error?.timedOut || attempt === maxAttempts) throw error;
-    }
-  }
-  throw lastError;
 }
 
 function prepareModelDispatch(model, prompt, routing, env) {
@@ -777,13 +758,7 @@ function executeModel(
   prompt,
   routing,
   env = process.env,
-  {
-    spawn: spawnImpl = spawn,
-    workspace = ROOT,
-    timeoutMs = DEFAULT_MODEL_TIMEOUT_MS,
-    maxAttempts = DEFAULT_MODEL_MAX_ATTEMPTS,
-    killTree = killProcessTree,
-  } = {}
+  { spawn: spawnImpl = spawn, workspace = ROOT } = {}
 ) {
   const { bin, input, commandEnv, useShell } = prepareModelDispatch(model, prompt, routing, env);
   const spawnOpts = {
@@ -793,11 +768,8 @@ function executeModel(
     cwd: workspace,
     detached: process.platform !== 'win32',
   };
-  return runModelProcessWithRetry(bin, input, spawnOpts, {
+  return runModelProcessOnce(bin, input, spawnOpts, {
     spawnImpl,
-    timeoutMs,
-    killTree,
-    maxAttempts,
     capture: false,
   });
 }
@@ -810,13 +782,7 @@ function executeModelCapture(
   prompt,
   routing,
   env = process.env,
-  {
-    spawn: spawnImpl = spawn,
-    workspace = ROOT,
-    timeoutMs = DEFAULT_MODEL_TIMEOUT_MS,
-    maxAttempts = DEFAULT_MODEL_MAX_ATTEMPTS,
-    killTree = killProcessTree,
-  } = {}
+  { spawn: spawnImpl = spawn, workspace = ROOT } = {}
 ) {
   const { bin, input, commandEnv, useShell } = prepareModelDispatch(model, prompt, routing, env);
   const spawnOpts = {
@@ -826,11 +792,8 @@ function executeModelCapture(
     cwd: workspace,
     detached: process.platform !== 'win32',
   };
-  return runModelProcessWithRetry(bin, input, spawnOpts, {
+  return runModelProcessOnce(bin, input, spawnOpts, {
     spawnImpl,
-    timeoutMs,
-    killTree,
-    maxAttempts,
     capture: true,
   });
 }
@@ -1203,6 +1166,8 @@ const SECRET_TEXT_PATTERNS = [
   /\bAKIA[0-9A-Z]{16}\b/g,
   // Bearer auth headers.
   /\b(Bearer\s+)[A-Za-z0-9\-._~+/]+=*/gi,
+  // JSON-quoted key:value assignments for common secret-ish names.
+  /("(?:api[_-]?key|secret|token|password|passwd)"\s*:\s*")((?:\\.|[^"\\])+)(?=")/gi,
   // key=value / key: value assignments for common secret-ish names.
   /\b((?:api[_-]?key|secret|token|password|passwd)\s*[:=]\s*)(\S+)/gi,
 ];
@@ -1237,6 +1202,68 @@ function writeRunLedger(record, { root = ROOT, fs = { mkdirSync, writeFileSync }
   const file = join(dir, `${record.runId}.json`);
   fs.writeFileSync(file, `${JSON.stringify(scrubSecrets(record), null, 2)}\n`);
   return file;
+}
+
+function isProcessAlive(pid, kill = process.kill) {
+  try {
+    kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === 'EPERM';
+  }
+}
+
+function prepareRelaunchCleanup({
+  root = ROOT,
+  fs = { existsSync, mkdirSync, readFileSync, writeFileSync },
+  isProcessAlive: checkProcessAlive = isProcessAlive,
+  platform = process.platform,
+  killTree = killProcessTree,
+  signalProcess = process.kill,
+  currentPid = process.pid,
+} = {}) {
+  const dir = join(root, 'ai-logs', 'hermes');
+  const pidFile = join(dir, 'orchestrate.pid');
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+  } catch {
+    return null;
+  }
+
+  let previousPid = null;
+  try {
+    if (fs.existsSync(pidFile)) {
+      previousPid = Number(fs.readFileSync(pidFile, 'utf8').trim());
+    }
+  } catch {
+    previousPid = null;
+  }
+
+  if (
+    Number.isInteger(previousPid) &&
+    previousPid > 0 &&
+    previousPid !== currentPid &&
+    checkProcessAlive(previousPid)
+  ) {
+    try {
+      if (platform === 'win32') {
+        killTree({ pid: previousPid });
+      } else {
+        // SIGTERM lets the prior orchestrator forward termination to every
+        // detached model process group before it exits.
+        signalProcess(previousPid, 'SIGTERM');
+      }
+    } catch {
+      // Prior process exited after the liveness check.
+    }
+  }
+
+  try {
+    fs.writeFileSync(pidFile, `${currentPid}\n`);
+  } catch {
+    return null;
+  }
+  return pidFile;
 }
 
 function getGateRunPlan(plan, { skipPreflightGate = false } = {}) {
@@ -1751,7 +1778,18 @@ async function main(argv = process.argv.slice(2), env = process.env, io = proces
     return 0;
   }
 
-  if ((options.workflowProvided || autoWorkflow) && liveExecution && plan.workflow) {
+  const willExecuteWorkflow =
+    (options.workflowProvided || autoWorkflow) && liveExecution && plan.workflow;
+  const relaunchCleanup = deps.prepareRelaunchCleanup || prepareRelaunchCleanup;
+  relaunchCleanup({
+    root: deps.root,
+    fs: deps.pidFs,
+    isProcessAlive: deps.isProcessAlive,
+    signalProcess: deps.signalProcess,
+    currentPid: deps.currentPid,
+  });
+
+  if (willExecuteWorkflow) {
     // Preflight gate parity with the non-workflow path: a failing gate (e.g.
     // npm run check) must abort BEFORE spawning the owner/reviewer CLIs, unless
     // explicitly skipped. executeWorkflow only runs the gate postflight.
@@ -1860,6 +1898,8 @@ async function main(argv = process.argv.slice(2), env = process.env, io = proces
 }
 
 if (isCliEntryPoint(import.meta.url, process.argv)) {
+  process.on('SIGINT', () => forwardTerminationSignal('SIGINT'));
+  process.on('SIGTERM', () => forwardTerminationSignal('SIGTERM'));
   main(process.argv.slice(2))
     .then((code) => {
       process.exitCode = code;
@@ -1886,6 +1926,7 @@ export {
   executeWorkflow,
   extractFindingsReport,
   findingKey,
+  forwardTerminationSignal,
   generateRunId,
   getGateRunPlan,
   isCliEntryPoint,
@@ -1894,6 +1935,7 @@ export {
   main,
   parseApprovalSignal,
   parseArgs,
+  prepareRelaunchCleanup,
   recommendWorkflow,
   resolveEffectivePhase,
   resolveGate,

--- a/tests/regressions/REFL-039.test.ts
+++ b/tests/regressions/REFL-039.test.ts
@@ -24,6 +24,11 @@ describe('REFL-039: DEV_BRAIN.md orchestration guardrails', () => {
     const devBrain = await readDevBrain();
     expect(devBrain).toMatch(/## Lane Hygiene/);
     expect(devBrain).toMatch(/node orchestrate\.js --phase production/);
-    expect(devBrain).toMatch(/ONE lane at a time/);
+    expect(devBrain).toMatch(/Relaunch cleanup is automated/);
+    expect(devBrain).toMatch(
+      /Periodic >6h orphaned Node-process sweeps remain manual and separate/
+    );
+    expect(devBrain).not.toMatch(/ONE lane at a time|free RAM < 4 GB/);
+    expect(devBrain).not.toMatch(/node\/cmd processes/i);
   });
 });

--- a/tests/unit/routing/hermes-routing.test.ts
+++ b/tests/unit/routing/hermes-routing.test.ts
@@ -13,7 +13,7 @@ import {
   generateRunId,
   getGateRunPlan,
   isCliEntryPoint,
-  main,
+  main as orchestrateMain,
   parseApprovalSignal,
   parseArgs,
   recommendWorkflow,
@@ -23,6 +23,14 @@ import {
   runGate,
   scoreSpecialist,
 } from '../../../orchestrate.js';
+
+function main(...args: Parameters<typeof orchestrateMain>) {
+  const [argv, env, io, deps = {}] = args;
+  return orchestrateMain(argv, env, io, {
+    prepareRelaunchCleanup: () => undefined,
+    ...deps,
+  });
+}
 
 const routing = {
   defaults: {
@@ -406,6 +414,57 @@ describe('Hermes routing helpers', () => {
     expect(code).toBe(0);
     expect(roles).toContain('owner');
     expect(roles).toContain('reviewer');
+  });
+
+  test.each([
+    {
+      label: 'executeModel',
+      argv: ['--phase', 'research', '--task', 'trace reserve engine flow'],
+      injectedRunner: {
+        executeModel: async () => 0,
+      },
+    },
+    {
+      label: 'runStep',
+      argv: ['--phase', 'production', '--task', 'ship the change', '--workflow', 'pair', '--live'],
+      injectedRunner: {
+        runStep: async ({ step }) => ({
+          code: 0,
+          output: `${step.role}-output`,
+          approved: step.role === 'reviewer',
+        }),
+      },
+    },
+  ])('main prepares relaunch cleanup when $label is injected', async ({ argv, injectedRunner }) => {
+    const writes: Array<[string, string]> = [];
+    const pidFs = {
+      existsSync: () => false,
+      mkdirSync: () => undefined,
+      readFileSync: () => '',
+      writeFileSync: (file: string, content: string) => writes.push([file, content]),
+    };
+
+    const code = await orchestrateMain(
+      argv,
+      process.env,
+      {
+        stdout: { write: () => undefined },
+        stderr: { write: () => undefined },
+      },
+      {
+        routing,
+        brain: 'DEV_BRAIN',
+        soul: 'SOUL',
+        gateRunner: () => ({ status: 0 }),
+        writeRunLedger: null,
+        pidFs,
+        currentPid: 5678,
+        ...injectedRunner,
+      }
+    );
+
+    expect(code).toBe(0);
+    expect(writes).toEqual([[`${process.cwd()}/ai-logs/hermes/orchestrate.pid`, '5678\n']]);
   });
 
   test('main aborts a live workflow when the preflight gate fails, before any model runs', async () => {

--- a/tests/unit/routing/hermes-tier-routing.test.ts
+++ b/tests/unit/routing/hermes-tier-routing.test.ts
@@ -395,6 +395,7 @@ describe('main --tier plumbing', () => {
         moaRunner,
         gateRunner,
         writeRunLedger: null,
+        prepareRelaunchCleanup: () => undefined,
       }
     );
     expect(code).toBe(0);

--- a/tests/unit/scripts/orchestrate-reliability.test.mjs
+++ b/tests/unit/scripts/orchestrate-reliability.test.mjs
@@ -1,14 +1,15 @@
 import { Buffer } from 'node:buffer';
 import { EventEmitter } from 'node:events';
 import process from 'node:process';
-import { setTimeout } from 'node:timers';
 
 import { describe, expect, it, vi } from 'vitest';
 
 import {
   executeModel,
   executeModelCapture,
+  forwardTerminationSignal,
   killProcessTree,
+  prepareRelaunchCleanup,
   scrubSecrets,
   writeRunLedger,
 } from '../../../orchestrate.js';
@@ -71,123 +72,204 @@ describe('killProcessTree', () => {
   });
 });
 
-describe('executeModel timeout + tree-kill', () => {
-  it('kills the process tree and rejects a timed-out attempt', async () => {
-    const child = createFakeChild(); // never emits 'close' — simulates a hang
-    const spawnImpl = vi.fn(() => child);
-    const killTree = vi.fn();
-    const routing = makeRouting();
-
-    await expect(
-      executeModel('claude', 'hello', routing, {}, {
-        spawn: spawnImpl,
-        timeoutMs: 20,
-        killTree,
-        maxAttempts: 1,
-      })
-    ).rejects.toMatchObject({ timedOut: true });
-
-    expect(killTree).toHaveBeenCalledWith(child);
-  });
-
-  it('retries once after a timeout and resolves if the retry succeeds', async () => {
-    const firstChild = createFakeChild(); // hangs
-    const secondChild = createFakeChild();
-    const spawnImpl = vi
-      .fn()
-      .mockImplementationOnce(() => firstChild)
-      .mockImplementationOnce(() => {
-        setTimeout(() => secondChild.emit('close', 0), 1);
-        return secondChild;
-      });
-    const killTree = vi.fn();
-    const routing = makeRouting();
-
-    const result = await executeModel('claude', 'hello', routing, {}, {
-      spawn: spawnImpl,
-      timeoutMs: 20,
-      killTree,
-      maxAttempts: 2,
-    });
-
-    expect(result).toBe(0);
-    expect(spawnImpl).toHaveBeenCalledTimes(2);
-    expect(killTree).toHaveBeenCalledTimes(1);
-  });
-
-  it('does not retry a normal non-zero exit — only timeouts are retryable', async () => {
-    const child = createFakeChild();
-    const spawnImpl = vi.fn(() => child);
-    const routing = makeRouting();
-
-    const promise = executeModel('claude', 'hello', routing, {}, {
-      spawn: spawnImpl,
-      timeoutMs: 1000,
-      maxAttempts: 3,
-    });
-    child.emit('close', 1);
-
-    await expect(promise).resolves.toBe(1);
-    expect(spawnImpl).toHaveBeenCalledTimes(1);
-  });
-
+describe('executeModel', () => {
   it('does not kill the process or misfire when the model completes normally', async () => {
+    vi.useFakeTimers();
     const child = createFakeChild();
     const spawnImpl = vi.fn(() => child);
     const killTree = vi.fn();
     const routing = makeRouting();
 
-    const promise = executeModel('claude', 'hello', routing, {}, {
-      spawn: spawnImpl,
-      timeoutMs: 1000,
-      killTree,
-    });
-    child.emit('close', 0);
+    try {
+      const promise = executeModel(
+        'claude',
+        'hello',
+        routing,
+        {},
+        {
+          spawn: spawnImpl,
+          killTree,
+        }
+      );
+      const completion = expect(promise).resolves.toBe(0);
 
-    await expect(promise).resolves.toBe(0);
-    expect(killTree).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(10 * 60 * 1000);
+      child.emit('close', 0);
+
+      await completion;
+      expect(killTree).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 
-describe('executeModelCapture timeout + tree-kill', () => {
+describe('executeModelCapture', () => {
   it('captures stdout and resolves {code, output}', async () => {
     const child = createFakeChild();
     const spawnImpl = vi.fn(() => child);
     const routing = makeRouting();
 
-    const promise = executeModelCapture('claude', 'hello', routing, {}, {
-      spawn: spawnImpl,
-      timeoutMs: 1000,
-    });
+    const promise = executeModelCapture(
+      'claude',
+      'hello',
+      routing,
+      {},
+      {
+        spawn: spawnImpl,
+      }
+    );
     child.stdout.emit('data', Buffer.from('partial '));
     child.stdout.emit('data', Buffer.from('output'));
     child.emit('close', 0);
 
     await expect(promise).resolves.toEqual({ code: 0, output: 'partial output' });
   });
+});
 
-  it('kills the process tree and rejects a timed-out attempt', async () => {
+describe('forwardTerminationSignal', () => {
+  it.each([
+    ['SIGINT', 130],
+    ['SIGTERM', 143],
+  ])('forwards %s to the registered model process tree and exits', async (signal, exitCode) => {
     const child = createFakeChild();
     const spawnImpl = vi.fn(() => child);
-    const killTree = vi.fn();
     const routing = makeRouting();
+    const killTree = vi.fn();
+    const exit = vi.fn();
+    const modelRun = executeModel('claude', 'hello', routing, {}, { spawn: spawnImpl });
 
-    await expect(
-      executeModelCapture('claude', 'hello', routing, {}, {
-        spawn: spawnImpl,
-        timeoutMs: 20,
-        killTree,
-        maxAttempts: 1,
-      })
-    ).rejects.toMatchObject({ timedOut: true });
+    forwardTerminationSignal(signal, { killTree, exit });
 
     expect(killTree).toHaveBeenCalledWith(child);
+    expect(exit).toHaveBeenCalledWith(exitCode);
+    child.emit('close', 0);
+    await modelRun;
+  });
+
+  it('forwards termination to every concurrently registered model process tree', async () => {
+    const firstChild = createFakeChild();
+    const secondChild = createFakeChild();
+    const spawnImpl = vi
+      .fn()
+      .mockImplementationOnce(() => firstChild)
+      .mockImplementationOnce(() => secondChild);
+    const routing = makeRouting();
+    const killTree = vi.fn();
+    const exit = vi.fn();
+    const firstRun = executeModel('claude', 'first', routing, {}, { spawn: spawnImpl });
+    const secondRun = executeModel('claude', 'second', routing, {}, { spawn: spawnImpl });
+
+    forwardTerminationSignal('SIGTERM', { killTree, exit });
+
+    expect(killTree).toHaveBeenCalledTimes(2);
+    expect(killTree).toHaveBeenCalledWith(firstChild);
+    expect(killTree).toHaveBeenCalledWith(secondChild);
+    expect(exit).toHaveBeenCalledWith(143);
+    firstChild.emit('close', 0);
+    secondChild.emit('close', 0);
+    await Promise.all([firstRun, secondRun]);
+  });
+});
+
+describe('prepareRelaunchCleanup', () => {
+  it('requests SIGTERM from a live prior orchestrator and overwrites the PID file', () => {
+    const pidFile = '/repo/ai-logs/hermes/orchestrate.pid';
+    const writes = [];
+    const fs = {
+      existsSync: vi.fn((file) => file === pidFile),
+      mkdirSync: vi.fn(),
+      readFileSync: vi.fn(() => '1234\n'),
+      writeFileSync: vi.fn((file, content) => writes.push([file, content])),
+    };
+    const isProcessAlive = vi.fn(() => true);
+    const killTree = vi.fn();
+    const signalProcess = vi.fn();
+
+    const result = prepareRelaunchCleanup({
+      root: '/repo',
+      fs,
+      isProcessAlive,
+      killTree,
+      signalProcess,
+      currentPid: 5678,
+    });
+
+    expect(result).toBe(pidFile);
+    expect(isProcessAlive).toHaveBeenCalledWith(1234);
+    expect(signalProcess).toHaveBeenCalledWith(1234, 'SIGTERM');
+    expect(killTree).not.toHaveBeenCalled();
+    expect(fs.mkdirSync).toHaveBeenCalledWith('/repo/ai-logs/hermes', { recursive: true });
+    expect(writes).toEqual([[pidFile, '5678\n']]);
+  });
+
+  it('kills a live prior orchestrator process tree on win32', () => {
+    const pidFile = '/repo/ai-logs/hermes/orchestrate.pid';
+    const writes = [];
+    const fs = {
+      existsSync: vi.fn((file) => file === pidFile),
+      mkdirSync: vi.fn(),
+      readFileSync: vi.fn(() => '1234\n'),
+      writeFileSync: vi.fn((file, content) => writes.push([file, content])),
+    };
+    const isProcessAlive = vi.fn(() => true);
+    const killTree = vi.fn();
+    const signalProcess = vi.fn();
+
+    const result = prepareRelaunchCleanup({
+      root: '/repo',
+      fs,
+      isProcessAlive,
+      killTree,
+      signalProcess,
+      currentPid: 5678,
+      platform: 'win32',
+    });
+
+    expect(result).toBe(pidFile);
+    expect(isProcessAlive).toHaveBeenCalledWith(1234);
+    expect(killTree).toHaveBeenCalledWith({ pid: 1234 });
+    expect(signalProcess).not.toHaveBeenCalled();
+    expect(fs.mkdirSync).toHaveBeenCalledWith('/repo/ai-logs/hermes', { recursive: true });
+    expect(writes).toEqual([[pidFile, '5678\n']]);
+  });
+
+  it.each([
+    {
+      operation: 'create the PID directory',
+      fs: {
+        mkdirSync: () => {
+          throw new Error('read-only directory');
+        },
+      },
+    },
+    {
+      operation: 'write the current PID',
+      fs: {
+        existsSync: () => false,
+        mkdirSync: () => undefined,
+        readFileSync: () => '',
+        writeFileSync: () => {
+          throw new Error('read-only PID file');
+        },
+      },
+    },
+  ])('treats inability to $operation as best-effort cleanup', ({ fs }) => {
+    expect(() =>
+      prepareRelaunchCleanup({
+        root: '/repo',
+        fs,
+        currentPid: 5678,
+      })
+    ).not.toThrow();
   });
 });
 
 describe('scrubSecrets', () => {
   it('redacts an API-key-shaped token embedded in free text', () => {
-    const input = { task: 'call the model using sk-ant-api03-abcdefghijklmnopqrstuvwxyz1234567890' };
+    const input = {
+      task: 'call the model using sk-ant-api03-abcdefghijklmnopqrstuvwxyz1234567890',
+    };
     const result = scrubSecrets(input);
     expect(result.task).not.toContain('sk-ant-api03-abcdefghijklmnopqrstuvwxyz1234567890');
     expect(result.task).toContain('[REDACTED]');
@@ -197,6 +279,22 @@ describe('scrubSecrets', () => {
     const input = { plan: { env: { note: 'export API_KEY=supersecretvalue123' } } };
     const result = scrubSecrets(input);
     expect(result.plan.env.note).not.toContain('supersecretvalue123');
+  });
+
+  it('redacts JSON-quoted key:value secrets', () => {
+    const input = { task: 'dispatch with {"token":"obviouslyfakesecretvalue123"}' };
+    const result = scrubSecrets(input);
+    expect(result.task).not.toContain('obviouslyfakesecretvalue123');
+    expect(result.task).toContain('[REDACTED]');
+  });
+
+  it('redacts a complete JSON-quoted secret containing an escaped quote', () => {
+    const input = {
+      task: String.raw`dispatch with {"password":"obviouslyfakeprefix\"obviouslyfakesuffix"}`,
+    };
+    const result = scrubSecrets(input);
+
+    expect(result.task).toBe(String.raw`dispatch with {"password":"[REDACTED]"}`);
   });
 
   it('leaves ordinary text and non-string values untouched', () => {


### PR DESCRIPTION
## Summary

Follow-up to #1232. Corrects reviewer comments 3671563725, 3671563731,
3671563734 on that PR.

PR #1232 added a hardcoded 10-minute auto-timeout on model dispatch plus a
retry-on-timeout wrapper. That was the wrong fix: reviewer comment
3671563731 flagged that a hardcoded cap conflicts with DEV_BRAIN.md's own
documented support for long-running dispatches, and re-reading REFL-039
directly shows its actual verified fixes were about **relaunch cleanup
discipline** ("kill the prior orchestrate process tree before relaunch"),
not a runtime cap on an otherwise-healthy in-flight dispatch. Finding 2's
correct disposition is **removal**, not configurability.

- **Remove the auto-timeout entirely.** `DEFAULT_MODEL_TIMEOUT_MS`,
  `DEFAULT_MODEL_MAX_ATTEMPTS`, and `runModelProcessWithRetry` are gone. A
  model dispatch now runs to natural completion — nothing kills it based on
  elapsed time.
- **Signal forwarding.** In-flight model children are tracked in
  `currentModelChildren`; `SIGINT`/`SIGTERM` to the `orchestrate.js` parent
  now calls `killProcessTree` on every registered child via
  `forwardTerminationSignal` before exiting. This is now the primary way a
  runaway dispatch actually stops.
- **Relaunch cleanup, automated.** `prepareRelaunchCleanup` checks a PID
  file at the start of every live dispatch; if a prior orchestrator is
  still alive it's cleaned up before a new model spawns (SIGTERM on POSIX,
  so the prior process's own handler forwards to its registered children;
  `killProcessTree` directly on Windows, since Windows model children
  aren't detached into a separate process group). This automates what
  DEV_BRAIN.md Lane Hygiene item 3 previously asked a human to do manually.
- **JSON-quoted secret redaction.** `scrubSecrets`/`SECRET_TEXT_PATTERNS`
  now also redact JSON-object-form credentials
  (`{"token":"..."}`, including escaped-quote values), not just the
  previously-handled unquoted `token=value` / `token: value` forms.
- **DEV_BRAIN.md Lane Hygiene** items 3–4 only: item 3 rewritten to
  describe the now-automated relaunch cleanup; item 4 (RAM-floor rule sized
  for a since-replaced Windows laptop) removed outright — nothing enforces
  it programmatically and this machine has 48GB RAM / 18 cores.

## Test plan

- [x] TDD throughout: 4 timeout/retry tests removed (behavior no longer
      exists), new tests added for `forwardTerminationSignal` (including
      concurrent children), `prepareRelaunchCleanup` (POSIX + win32
      branches + best-effort error handling), and JSON-quoted secret
      redaction (including escaped-quote values).
- [x] `tests/unit/scripts/orchestrate-reliability.test.mjs` — 19/19 passed
- [x] `tests/unit/routing/*` + `tests/regressions/REFL-039.test.ts` — 193/193 passed
- [x] `npm run check` — 0 new TypeScript errors
- [x] `npm run lint` — clean on all changed files
- [x] Full suite: server project 8574 passed / 2 pre-existing failures
      (unrelated `monte-carlo-actuals-inputs.test.ts` snapshot-hash
      mismatches, confirmed present on `main` at `cff84979` before this
      branch); client project 1538/1538 passed.

## Residual risk

The Windows `SIGTERM`-via-`process.on` semantics for the POSIX branch of
`prepareRelaunchCleanup` are reasoned from documented Node.js behavior
(Windows doesn't reliably invoke a target process's own signal handler),
not empirically verified on a live Windows box this session — hence the
explicit win32 branch that avoids relying on it. `killProcessTree`'s
existing POSIX/win32 branches are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)