### PR TITLE
feat: add fund view context contract

### DIFF
--- a/client/src/lib/fund-view-context.ts
+++ b/client/src/lib/fund-view-context.ts
@@ -1,0 +1,10 @@
+import {
+  FundViewContextV1Schema,
+  type FundViewContextV1,
+} from '@shared/contracts/fund-view-context-v1.contract';
+
+export type { FundViewContextV1 };
+
+export function parseFundViewContextV1(candidate: unknown): FundViewContextV1 {
+  return FundViewContextV1Schema.parse(candidate);
+}

--- a/shared/contracts/fund-view-context-v1.contract.ts
+++ b/shared/contracts/fund-view-context-v1.contract.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+import { PortfolioCompaniesModeSchema } from './portfolio-meta.contract';
+
+export const FundViewContextV1Schema = z
+  .object({
+    contractVersion: z.literal('fund-view-context-v1'),
+    fundId: z.number().int().positive().nullable(),
+    vehicleId: z.number().int().positive().nullable(),
+    asOfDate: z.string().date().nullable(),
+    currentPlanVersionId: z.string().min(1).nullable(),
+    viewPreset: PortfolioCompaniesModeSchema,
+  })
+  .strict();
+
+export type FundViewContextV1 = z.infer<typeof FundViewContextV1Schema>;

--- a/tests/unit/contract/fund-view-context-v1.contract.test.ts
+++ b/tests/unit/contract/fund-view-context-v1.contract.test.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+import { describe, expect, it } from 'vitest';
+
+import { FundViewContextV1Schema } from '../../../shared/contracts/fund-view-context-v1.contract';
+
+function validFundViewContext() {
+  return {
+    contractVersion: 'fund-view-context-v1',
+    fundId: 7,
+    vehicleId: 11,
+    asOfDate: '2026-07-29',
+    currentPlanVersionId: 'plan-version-1',
+    viewPreset: 'historical',
+  };
+}
+
+describe('FundViewContextV1 contract', () => {
+  it('parses a valid fund-view context', () => {
+    const candidate = validFundViewContext();
+
+    expect(FundViewContextV1Schema.parse(candidate)).toEqual(candidate);
+  });
+
+  it.each(['fundId', 'vehicleId', 'asOfDate', 'currentPlanVersionId'] as const)(
+    'accepts null for %s',
+    (field) => {
+      const parsed = FundViewContextV1Schema.parse({
+        ...validFundViewContext(),
+        [field]: null,
+      });
+
+      expect(parsed[field]).toBeNull();
+    }
+  );
+
+  it('rejects a view preset outside the shared live/historical vocabulary', () => {
+    expect(() =>
+      FundViewContextV1Schema.parse({
+        ...validFundViewContext(),
+        viewPreset: 'forecast',
+      })
+    ).toThrow(z.ZodError);
+  });
+
+  it('rejects unknown top-level keys', () => {
+    expect(() =>
+      FundViewContextV1Schema.parse({
+        ...validFundViewContext(),
+        unexpected: true,
+      })
+    ).toThrow(z.ZodError);
+  });
+});

--- a/tests/unit/lib/fund-view-context.test.ts
+++ b/tests/unit/lib/fund-view-context.test.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+import { describe, expect, it } from 'vitest';
+
+import { parseFundViewContextV1 } from '../../../client/src/lib/fund-view-context';
+
+function validFundViewContext() {
+  return {
+    contractVersion: 'fund-view-context-v1',
+    fundId: 7,
+    vehicleId: null,
+    asOfDate: '2026-07-29',
+    currentPlanVersionId: 'plan-version-1',
+    viewPreset: 'live',
+  };
+}
+
+describe('parseFundViewContextV1', () => {
+  it('returns the parsed value for a valid candidate', () => {
+    const candidate = validFundViewContext();
+
+    expect(parseFundViewContextV1(candidate)).toEqual(candidate);
+  });
+
+  it('throws a ZodError for an invalid candidate', () => {
+    expect(() =>
+      parseFundViewContextV1({
+        ...validFundViewContext(),
+        fundId: 0,
+      })
+    ).toThrow(z.ZodError);
+  });
+});


### PR DESCRIPTION
## Summary

- add strict `fund-view-context-v1` shared contract for `fundId`, `vehicleId`, `asOfDate`, `currentPlanVersionId`, and shared `viewPreset`
- add pure client parser that delegates to shared Zod schema and re-exports inferred type
- add unit coverage for valid parsing, nullable fields, preset rejection, unknown-key rejection, and parser error propagation

## Why

Lane 20A needs a versioned, reusable fund-view context boundary before later provider and route integration. This stage intentionally adds contract and validation stub only; no React provider, route wiring, build configuration, or financial calculation logic changed.

## Impact

No runtime consumer is wired yet. Later Lane 20 work can import one validated context shape without duplicating point-in-time view vocabulary.

## Verification

- `npm run check` — PASS, 0 TypeScript errors
- `TZ=UTC npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/contract/fund-view-context-v1.contract.test.ts tests/unit/lib/fund-view-context.test.ts` — PASS, 2 files / 9 tests
- changed-file ESLint and Prettier — PASS
- pre-commit and pre-push repository hooks — PASS
- full `TZ=UTC npm test` — baseline-only failure: `tests/unit/services/monte-carlo-actuals-inputs.test.ts` has the same 2 failing tests / 3 hash assertions before and after this diff. Post-change total: 844 files passed, 1 failed; 10,121 tests passed, 2 failed. New 2 files / 9 tests all pass.

## Review

Reviewer: Claude
Run ID: `hermes-2026-07-29T18-42-43-830Z`