### PR TITLE
feat(reserves): expose reserve evidence and overlay diagnostics (PLAN_61 Task 15)

### DIFF
--- a/client/src/components/fund-results/ReserveIntelligencePanel.tsx
+++ b/client/src/components/fund-results/ReserveIntelligencePanel.tsx
@@ -1,0 +1,550 @@
+import { useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { useReserveIntelligence } from '@/hooks/useReserveIntelligence';
+import type { DynamicReserveIntelligenceRunV1 } from '@shared/contracts/dynamic-reserve-intelligence-v1.contract';
+import { DecisionStateBadge, type DecisionState } from './DecisionStateBadge';
+import { FinancialEvidenceDrawer } from './FinancialEvidenceDrawer';
+import type { FinancialEvidence } from './financial-evidence';
+
+type ReserveRun = DynamicReserveIntelligenceRunV1;
+type ReserveCompany = ReserveRun['result']['companies'][number];
+type FactsSnapshot = ReserveRun['result']['provenance']['factsSnapshot'];
+type CompanyFact = FactsSnapshot['payload']['companyActuals']['facts'][number];
+
+const ANALYTICAL_NOTICE =
+  'Analytical only. Derived from the pinned facts snapshot; never written back to the current plan.';
+
+const STAGE_LABELS: Record<ReserveCompany['canonicalStage'], string> = {
+  pre_seed: 'Pre-Seed',
+  seed: 'Seed',
+  series_a: 'Series A',
+  series_b: 'Series B',
+  series_c: 'Series C',
+  series_d: 'Series D+',
+  growth: 'Growth',
+  late_stage: 'Late Stage',
+};
+
+function decisionState(
+  status: ReserveCompany['status'] | ReserveRun['result']['actionability']
+): DecisionState {
+  // Reserve wire states collapse only unavailable/non_actionable into generic not_actionable.
+  if (status === 'actionable' || status === 'indicative') {
+    return status;
+  }
+  return 'not_actionable';
+}
+
+function formatBaseCurrencyCents(value: number | null | undefined): string {
+  if (value === null || value === undefined || !Number.isSafeInteger(value)) {
+    return 'Unavailable';
+  }
+
+  const signedCents = BigInt(value);
+  const magnitudeInCents = signedCents < 0n ? -signedCents : signedCents;
+  const wholeUnits = magnitudeInCents / 100n;
+  const cents = (magnitudeInCents % 100n).toString().padStart(2, '0');
+  const sign = signedCents < 0n ? '-' : '';
+  const groupedWholeUnits = wholeUnits.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+
+  return `${sign}${groupedWholeUnits}.${cents}`;
+}
+
+function formatRatio(value: string | null, suffix = ''): string {
+  return value === null ? 'Unavailable' : `${value}${suffix}`;
+}
+
+function copyHash(hash: string): void {
+  if (!navigator.clipboard) {
+    return;
+  }
+  void navigator.clipboard.writeText(hash).catch(() => undefined);
+}
+
+function RecomputeControl() {
+  return (
+    <div className="flex max-w-sm flex-col items-end gap-1">
+      <Button type="button" variant="outline" disabled aria-describedby="reserve-recompute-reason">
+        Recompute from latest accepted facts
+      </Button>
+      <p id="reserve-recompute-reason" className="text-right text-xs text-presson-textMuted">
+        Recompute command is not available in this client-only release.
+      </p>
+    </div>
+  );
+}
+
+function LoadingState() {
+  return (
+    <CardContent className="space-y-3">
+      <p className="font-medium text-pov-charcoal">Loading reserve intelligence</p>
+      <p className="text-sm text-presson-textMuted">
+        Fetching latest persisted reserve diagnostics.
+      </p>
+      {[0, 1, 2].map((row) => (
+        <div
+          key={row}
+          data-testid="reserve-intelligence-skeleton-row"
+          className="h-8 animate-pulse rounded bg-pov-gray motion-reduce:animate-none"
+        />
+      ))}
+    </CardContent>
+  );
+}
+
+function UnavailableState({
+  title,
+  reason,
+}: {
+  title: 'Reserve intelligence unavailable' | 'No reserve intelligence run yet';
+  reason: string;
+}) {
+  return (
+    <CardContent>
+      <p className="font-medium text-pov-charcoal">{title}</p>
+      <p className="mt-1 text-sm text-presson-textMuted">{reason}</p>
+    </CardContent>
+  );
+}
+
+function ErrorState({ contractMismatch }: { contractMismatch: boolean }) {
+  return (
+    <CardContent role="alert">
+      <p className="font-medium text-pov-charcoal">
+        {contractMismatch
+          ? 'Reserve intelligence contract mismatch'
+          : 'Unable to load reserve intelligence'}
+      </p>
+      <p className="mt-1 text-sm text-presson-textMuted">
+        {contractMismatch
+          ? 'Latest run did not match the client-safe reserve contract, so diagnostics are hidden.'
+          : 'Reserve diagnostics could not be loaded. Existing MOIC rankings remain available.'}
+      </p>
+    </CardContent>
+  );
+}
+
+function evidenceFromReserveRun(run: ReserveRun, fact: CompanyFact): FinancialEvidence {
+  return {
+    source: fact.provenance.core.sourceEngine ?? fact.provenance.core.sourceKind,
+    asOfDate: run.result.provenance.factsSnapshot.asOfDate,
+    contractVersion: run.result.contractVersion,
+    sourceVersion: fact.provenance.core.engineVersion ?? null,
+    factsInputHash: fact.inputHash,
+    assumptionsHash: fact.provenance.core.assumptionsHash ?? null,
+    trustState: fact.provenance.trustState,
+    currencyStatus: fact.currencyStatus,
+    warnings: fact.warnings,
+  };
+}
+
+function EffectiveTermsBasis({ snapshot }: { snapshot: FactsSnapshot }) {
+  if (snapshot.policyVersion !== 'financial-facts-policy/1.1.0') {
+    return (
+      <div className="space-y-1 text-xs text-presson-textMuted">
+        <p>{snapshot.policyVersion} does not disclose effective-terms refs.</p>
+        <p>
+          Per-company basis unavailable: companyId to companyIdentityId mapping is not disclosed.
+        </p>
+      </div>
+    );
+  }
+
+  const basisCounts = { direct: 0, derived: 0, unavailable: 0 };
+  for (const ref of snapshot.payload.valuationRefs) {
+    basisCounts[ref.basis] += 1;
+  }
+
+  return (
+    <div className="space-y-1 text-xs text-presson-textMuted">
+      <p>Participation refs: {snapshot.payload.participationTermRefs.length}</p>
+      <p>
+        Valuation basis: direct {basisCounts.direct}, derived {basisCounts.derived}, unavailable{' '}
+        {basisCounts.unavailable}
+      </p>
+      <p>Per-company basis unavailable: companyId to companyIdentityId mapping is not disclosed.</p>
+    </div>
+  );
+}
+
+function buildUnresolvedFactItems(run: ReserveRun): string[] {
+  const snapshot = run.result.provenance.factsSnapshot;
+  const items = snapshot.consumerEvaluations
+    .filter((evaluation) => evaluation.status === 'blocked')
+    .map(
+      (evaluation) =>
+        `${evaluation.consumer}: ${evaluation.reasons.join(', ') || 'blocked without a reason'}`
+    );
+
+  for (const fact of snapshot.payload.companyActuals.facts) {
+    items.push(...fact.warnings.map((warning) => `${fact.companyName}: ${warning.message}`));
+  }
+  items.push(...snapshot.payload.cashFlowSeries.warnings.map((warning) => warning.message));
+  items.push(...snapshot.payload.marksSeries.warnings.map((warning) => warning.message));
+  for (const period of snapshot.payload.marksSeries.periodNav) {
+    items.push(...period.warnings.map((warning) => `${period.periodEnd}: ${warning.message}`));
+  }
+  items.push(...run.result.fund.disclosedDefaults.map((value) => `Disclosed default: ${value}`));
+  return items;
+}
+
+function buildSelectionDeviationItems(snapshot: FactsSnapshot): string[] {
+  const reserveEvaluation = snapshot.consumerEvaluations.find(
+    (evaluation) => evaluation.consumer === 'reserve'
+  );
+  if (!reserveEvaluation?.reasons.includes('working_value_selection_deviation')) {
+    return [];
+  }
+
+  const items = ['working_value_selection_deviation'];
+  if (snapshot.policyVersion !== 'financial-facts-policy/1.1.0') {
+    return items;
+  }
+
+  const details = snapshot.consumerEvaluations.find(
+    (evaluation) => evaluation.consumer === 'reserve'
+  )?.details;
+  for (const detail of details ?? []) {
+    if (detail.code === 'working_value_selection_deviation') {
+      items.push(detail.message ?? detail.code);
+    }
+  }
+  return items;
+}
+
+function DetailSection({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section className="rounded-md border border-beige-200 bg-pov-gray p-3">
+      <h3 className="text-sm font-semibold text-pov-charcoal">{title}</h3>
+      <div className="mt-2 text-xs text-presson-textMuted">{children}</div>
+    </section>
+  );
+}
+
+function StringList({ items, empty }: { items: readonly string[]; empty: string }) {
+  if (items.length === 0) {
+    return <p>{empty}</p>;
+  }
+  return (
+    <ul className="list-disc space-y-1 pl-5">
+      {items.map((item, index) => (
+        <li key={`${item}-${index}`}>{item}</li>
+      ))}
+    </ul>
+  );
+}
+
+function BasisLine({ run }: { run: ReserveRun }) {
+  const provenance = run.result.provenance;
+  const snapshotHash = provenance.factsSnapshot.snapshotInputHash;
+
+  return (
+    <TableRow data-testid="basis-line" className="bg-pov-gray hover:bg-pov-gray">
+      <TableCell colSpan={10} className="py-3">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-pov-charcoal">
+          <span className="tabular-nums">As of {provenance.asOfDate}</span>
+          <span className="tabular-nums">
+            Snapshot {provenance.financialFactsSnapshotId}: {snapshotHash.slice(0, 12)}
+          </span>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 px-2 text-xs motion-reduce:transition-none"
+            aria-label="Copy full facts snapshot hash"
+            onClick={() => copyHash(snapshotHash)}
+          >
+            Copy full hash
+          </Button>
+          <DecisionStateBadge state={decisionState(run.result.actionability)} />
+          <span>Mode: {provenance.effectiveMode}</span>
+          <span className="whitespace-nowrap">{ANALYTICAL_NOTICE}</span>
+        </div>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function DiagnosticsTable({
+  run,
+  onOpenEvidence,
+}: {
+  run: ReserveRun;
+  onOpenEvidence: (companyId: number, trigger: HTMLButtonElement) => void;
+}) {
+  const factsByCompanyId = new Map(
+    run.result.provenance.factsSnapshot.payload.companyActuals.facts.map((fact) => [
+      fact.companyId,
+      fact,
+    ])
+  );
+
+  return (
+    <Table aria-label="Reserve intelligence diagnostics">
+      <TableHeader>
+        <TableRow>
+          <TableHead>Rank</TableHead>
+          <TableHead>Company</TableHead>
+          <TableHead>Stage</TableHead>
+          <TableHead className="text-right">Marginal MOIC</TableHead>
+          <TableHead className="text-right">Derived allocation</TableHead>
+          <TableHead className="text-right">Overlay planned</TableHead>
+          <TableHead className="text-right">Delta</TableHead>
+          <TableHead className="text-right">Concentration</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead>Facts snapshot</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        <BasisLine run={run} />
+        {run.result.companies.map((company) => {
+          const fact = factsByCompanyId.get(company.companyId);
+          return (
+            <TableRow key={company.companyId}>
+              <TableCell className="tabular-nums">
+                {company.rank === null ? 'Unavailable' : `#${company.rank}`}
+              </TableCell>
+              <TableCell className="font-medium text-pov-charcoal">{company.name}</TableCell>
+              <TableCell>{STAGE_LABELS[company.canonicalStage]}</TableCell>
+              <TableCell className="text-right tabular-nums">
+                {formatRatio(company.marginalMoic, 'x')}
+              </TableCell>
+              <TableCell className="text-right tabular-nums">
+                {formatBaseCurrencyCents(company.systemAllocatedCents)}
+              </TableCell>
+              <TableCell className="text-right tabular-nums">
+                {formatBaseCurrencyCents(company.overlayPlannedCents)}
+              </TableCell>
+              <TableCell className="text-right tabular-nums">
+                {formatBaseCurrencyCents(company.deltaCents)}
+              </TableCell>
+              <TableCell className="text-right tabular-nums">
+                {formatRatio(company.concentration)}
+              </TableCell>
+              <TableCell>
+                <DecisionStateBadge state={decisionState(company.status)} />
+              </TableCell>
+              <TableCell>
+                <div className="space-y-1">
+                  <span className="block text-xs text-presson-textMuted">
+                    {fact === undefined ? 'No facts row disclosed' : `Linked: ${fact.companyName}`}
+                  </span>
+                  <button
+                    type="button"
+                    className="text-left text-xs font-medium text-pov-charcoal underline underline-offset-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-charcoal-400 focus-visible:ring-offset-2"
+                    onClick={(event) => onOpenEvidence(company.companyId, event.currentTarget)}
+                  >
+                    Open reserve facts for {company.name}
+                  </button>
+                </div>
+              </TableCell>
+            </TableRow>
+          );
+        })}
+        <TableRow className="bg-pov-gray/60 font-semibold hover:bg-pov-gray/60">
+          <TableCell colSpan={4}>Fund totals</TableCell>
+          <TableCell className="text-right tabular-nums">
+            {formatBaseCurrencyCents(run.result.fund.totalSystemAllocatedCents)}
+          </TableCell>
+          <TableCell className="text-right tabular-nums">
+            {formatBaseCurrencyCents(run.result.fund.totalOverlayPlannedCents)}
+          </TableCell>
+          <TableCell className="text-right tabular-nums">
+            {formatBaseCurrencyCents(run.result.fund.totalDeltaCents)}
+          </TableCell>
+          <TableCell colSpan={3} />
+        </TableRow>
+      </TableBody>
+    </Table>
+  );
+}
+
+function ReadyState({ run }: { run: ReserveRun }) {
+  const [selectedCompanyId, setSelectedCompanyId] = useState<number | null>(null);
+  const returnFocusRef = useRef<HTMLElement | null>(null);
+  const snapshot = run.result.provenance.factsSnapshot;
+  const selectedCompany = run.result.companies.find(
+    (company) => company.companyId === selectedCompanyId
+  );
+  const selectedFact = snapshot.payload.companyActuals.facts.find(
+    (fact) => fact.companyId === selectedCompanyId
+  );
+  const unresolvedFacts = buildUnresolvedFactItems(run);
+  const selectionDeviations = buildSelectionDeviationItems(snapshot);
+  const constraintItems = run.result.constraintFindings.map(
+    (finding) => `${finding.code}: company ${finding.companyId}`
+  );
+  const exclusionItems = run.result.fund.excluded.map(
+    (entry) => `Company ${entry.companyId}: ${entry.reason}`
+  );
+  const approvedAllocations = run.result.provenance.marginalNonFactsSources.approvedAllocations.map(
+    (allocation) =>
+      `${allocation.decisionType}: ${allocation.decisionStatus}; company ${allocation.companyId}; ` +
+      `planned ${allocation.finalPlannedReservesCents ?? 'Unavailable'}; ` +
+      `version ${allocation.liveAllocationVersion ?? 'Unavailable'}; ` +
+      `decided ${allocation.decidedAt ?? 'Unavailable'}`
+  );
+
+  return (
+    <CardContent className="space-y-4">
+      <DiagnosticsTable
+        run={run}
+        onOpenEvidence={(companyId, trigger) => {
+          returnFocusRef.current = trigger;
+          setSelectedCompanyId(companyId);
+        }}
+      />
+
+      <div className="grid gap-3 md:grid-cols-2">
+        <DetailSection title="Fund diagnostics">
+          <dl className="space-y-1">
+            <div>
+              <dt className="inline">Follow-on capacity: </dt>
+              <dd className="inline tabular-nums">
+                {formatBaseCurrencyCents(run.result.fund.followOnCapacityCents)}
+              </dd>
+            </div>
+            <div>
+              <dt className="inline">Fail-safe: </dt>
+              <dd className="inline">
+                {run.result.fund.failSafe ? 'Active' : 'Inactive'}
+                {run.result.fund.failSafeReason ? ` (${run.result.fund.failSafeReason})` : ''}
+              </dd>
+            </div>
+            <div>
+              <dt className="inline">Overlay supplied: </dt>
+              <dd className="inline">
+                {run.result.provenance.overlay === null
+                  ? 'No'
+                  : `Yes, by ${run.result.provenance.overlayProvenance.suppliedBy ?? 'Unavailable'} at ${run.result.provenance.overlayProvenance.suppliedAt}`}
+              </dd>
+            </div>
+          </dl>
+        </DetailSection>
+
+        <DetailSection title="Constraints and exclusions">
+          <StringList
+            items={[...constraintItems, ...exclusionItems]}
+            empty="No constraints or exclusions disclosed."
+          />
+        </DetailSection>
+
+        <DetailSection title="Unresolved facts">
+          <StringList items={unresolvedFacts} empty="No unresolved facts disclosed." />
+        </DetailSection>
+
+        <DetailSection title="D30 selection deviations">
+          <StringList
+            items={selectionDeviations}
+            empty="No working-value selection deviations disclosed."
+          />
+        </DetailSection>
+
+        <DetailSection title="Decision state">
+          <div className="space-y-2">
+            <p>
+              Run: <DecisionStateBadge state={decisionState(run.result.actionability)} />
+            </p>
+            <p>H9 actionability: {run.result.provenance.h9Actionability}</p>
+            <StringList
+              items={approvedAllocations}
+              empty="No approved allocation decisions disclosed."
+            />
+          </div>
+        </DetailSection>
+
+        <DetailSection title="Effective-terms basis (run-level)">
+          <p className="mb-2 tabular-nums">{snapshot.policyVersion}</p>
+          <EffectiveTermsBasis snapshot={snapshot} />
+        </DetailSection>
+      </div>
+
+      {selectedCompany !== undefined && selectedFact !== undefined ? (
+        <FinancialEvidenceDrawer
+          open
+          onOpenChange={(open) => {
+            if (!open) setSelectedCompanyId(null);
+          }}
+          entityLabel={`${selectedCompany.name} reserve evidence`}
+          evidence={evidenceFromReserveRun(run, selectedFact)}
+          decisionState={decisionState(selectedCompany.status)}
+          proofSlot={<EffectiveTermsBasis snapshot={snapshot} />}
+          returnFocusRef={returnFocusRef}
+        />
+      ) : null}
+
+      {selectedCompany !== undefined && selectedFact === undefined ? (
+        <FinancialEvidenceDrawer
+          open
+          onOpenChange={(open) => {
+            if (!open) setSelectedCompanyId(null);
+          }}
+          entityLabel={`${selectedCompany.name} reserve evidence`}
+          status="empty"
+          evidence={null}
+          decisionState={decisionState(selectedCompany.status)}
+          factsDomainNoun={`${selectedCompany.name} facts row`}
+          returnFocusRef={returnFocusRef}
+        />
+      ) : null}
+    </CardContent>
+  );
+}
+
+export function ReserveIntelligencePanel({ fundId }: { fundId: number }) {
+  const { data, error, isLoading } = useReserveIntelligence(fundId);
+
+  let content: ReactNode;
+  if (isLoading) {
+    content = <LoadingState />;
+  } else if (error) {
+    content = <ErrorState contractMismatch={error.code === 'CONTRACT_PARSE_ERROR'} />;
+  } else if (data?.kind === 'feature-disabled') {
+    content = (
+      <UnavailableState
+        title="Reserve intelligence unavailable"
+        reason="Reserve intelligence is disabled by server configuration."
+      />
+    );
+  } else if (data?.kind === 'no-run') {
+    content = (
+      <UnavailableState
+        title="No reserve intelligence run yet"
+        reason="Feature is enabled, but this fund has no persisted run."
+      />
+    );
+  } else if (data?.kind === 'ready') {
+    content = <ReadyState run={data.run} />;
+  } else {
+    content = <ErrorState contractMismatch={false} />;
+  }
+
+  return (
+    <section aria-label="Reserve intelligence">
+      <Card className="border-beige-200 bg-pov-white">
+        <CardHeader className="flex-row items-start justify-between gap-4 space-y-0">
+          <div className="space-y-1.5">
+            <h2 className="text-lg font-inter font-bold leading-none text-pov-charcoal">
+              Reserve intelligence
+            </h2>
+            <CardDescription>
+              Derived allocation, overlay, constraint, and evidence diagnostics.
+            </CardDescription>
+          </div>
+          <RecomputeControl />
+        </CardHeader>
+        {content}
+      </Card>
+    </section>
+  );
+}

--- a/client/src/hooks/useReserveIntelligence.ts
+++ b/client/src/hooks/useReserveIntelligence.ts
@@ -1,0 +1,314 @@
+import { useQuery } from '@tanstack/react-query';
+import { z } from 'zod';
+import type { DynamicReserveIntelligenceRunV1 } from '@shared/contracts/dynamic-reserve-intelligence-v1.contract';
+
+const sha256Schema = z.string().regex(/^[a-f0-9]{64}$/);
+const centsSchema = z.number().int().safe();
+const nullableCentsSchema = centsSchema.nullable();
+const decimalStringSchema = z.string().regex(/^-?\d+(?:\.\d+)?$/);
+
+const warningSchema = z
+  .object({
+    code: z.string().min(1),
+    severity: z.string().min(1),
+    message: z.string().min(1),
+  })
+  .passthrough();
+
+const companyFactSchema = z
+  .object({
+    companyId: z.number().int().positive(),
+    companyName: z.string().min(1),
+    planningFmvStatus: z.string().min(1),
+    currencyStatus: z.string().min(1),
+    latestPlanningFmvDate: z.string().nullable(),
+    warnings: z.array(warningSchema),
+    inputHash: sha256Schema,
+    provenance: z
+      .object({
+        trustState: z.string().min(1),
+        core: z
+          .object({
+            sourceKind: z.string().min(1),
+            sourceEngine: z.string().min(1).optional(),
+            engineVersion: z.string().min(1).optional(),
+            assumptionsHash: z.string().min(1).optional(),
+          })
+          .passthrough(),
+      })
+      .passthrough(),
+  })
+  .passthrough();
+
+const financialFactsWarningSchema = z
+  .object({
+    code: z.string().min(1),
+    severity: z.string().min(1),
+    message: z.string().min(1),
+  })
+  .passthrough();
+
+const consumerEvaluationSchema = z
+  .object({
+    consumer: z.string().min(1),
+    status: z.enum(['accepted', 'blocked']),
+    reasons: z.array(z.string().min(1)),
+    details: z
+      .array(
+        z
+          .object({
+            code: z.string().min(1),
+            message: z.string().min(1).optional(),
+          })
+          .passthrough()
+      )
+      .optional(),
+  })
+  .passthrough();
+
+const factsSnapshotSchema = z
+  .object({
+    policyVersion: z.enum([
+      'financial-facts-policy/1.0.0',
+      'financial-facts-policy/1.0.1',
+      'financial-facts-policy/1.1.0',
+    ]),
+    asOfDate: z.string().date(),
+    snapshotInputHash: sha256Schema,
+    consumerEvaluations: z.array(consumerEvaluationSchema),
+    payload: z
+      .object({
+        companyActuals: z
+          .object({
+            facts: z.array(companyFactSchema),
+          })
+          .passthrough(),
+        cashFlowSeries: z
+          .object({
+            warnings: z.array(financialFactsWarningSchema),
+          })
+          .passthrough(),
+        marksSeries: z
+          .object({
+            warnings: z.array(financialFactsWarningSchema),
+            periodNav: z.array(
+              z
+                .object({
+                  warnings: z.array(financialFactsWarningSchema),
+                })
+                .passthrough()
+            ),
+          })
+          .passthrough(),
+        participationTermRefs: z.array(z.union([z.string(), z.object({}).passthrough()])),
+        valuationRefs: z
+          .array(
+            z
+              .object({
+                basis: z.enum(['direct', 'derived', 'unavailable']),
+              })
+              .passthrough()
+          )
+          .optional(),
+      })
+      .passthrough(),
+  })
+  .passthrough();
+
+const reserveIntelligenceRunSchema = z
+  .object({
+    snapshotId: z.number().int().positive(),
+    createdAt: z.string().datetime(),
+    result: z
+      .object({
+        contractVersion: z.literal('dynamic-reserve-intelligence-v1'),
+        fundId: z.number().int().positive(),
+        actionability: z.enum(['actionable', 'non_actionable']),
+        companies: z.array(
+          z
+            .object({
+              companyId: z.number().int().positive(),
+              name: z.string().min(1),
+              canonicalStage: z.enum([
+                'pre_seed',
+                'seed',
+                'series_a',
+                'series_b',
+                'series_c',
+                'series_d',
+                'growth',
+                'late_stage',
+              ]),
+              status: z.enum(['actionable', 'indicative', 'unavailable']),
+              rank: z.number().int().positive().nullable(),
+              marginalMoic: decimalStringSchema.nullable(),
+              systemAllocatedCents: centsSchema.nonnegative(),
+              overlayPlannedCents: nullableCentsSchema,
+              deltaCents: nullableCentsSchema,
+              concentration: decimalStringSchema.nullable(),
+            })
+            .passthrough()
+        ),
+        fund: z
+          .object({
+            totalSystemAllocatedCents: centsSchema.nonnegative(),
+            totalOverlayPlannedCents: nullableCentsSchema,
+            totalDeltaCents: nullableCentsSchema,
+            followOnCapacityCents: centsSchema,
+            failSafe: z.boolean(),
+            failSafeReason: z.string().nullable(),
+            excluded: z.array(
+              z
+                .object({
+                  companyId: z.number().int().positive(),
+                  reason: z.enum(['unavailable', 'indicative']),
+                })
+                .passthrough()
+            ),
+            disclosedDefaults: z.array(z.string()),
+          })
+          .passthrough(),
+        constraintFindings: z.array(
+          z
+            .object({
+              code: z.literal('overlay_unknown_company'),
+              companyId: z.number().int().positive(),
+            })
+            .passthrough()
+        ),
+        provenance: z
+          .object({
+            financialFactsSnapshotId: z.number().int().positive(),
+            assumptionsHash: sha256Schema,
+            effectiveMode: z.enum(['shadow', 'on']),
+            h9Actionability: z.string().min(1),
+            overlayProvenance: z
+              .object({
+                suppliedBy: z.number().int().positive().nullable(),
+                suppliedAt: z.string().datetime(),
+              })
+              .passthrough(),
+            overlay: z
+              .array(
+                z
+                  .object({
+                    companyId: z.number().int().positive(),
+                    plannedReserveCents: centsSchema.nonnegative(),
+                  })
+                  .passthrough()
+              )
+              .nullable(),
+            calcVersion: z.string().min(1),
+            asOfDate: z.string().date(),
+            factsSnapshot: factsSnapshotSchema,
+            marginalNonFactsSources: z
+              .object({
+                approvedAllocations: z.array(
+                  z
+                    .object({
+                      companyId: z.number().int().positive(),
+                      decisionType: z.string(),
+                      decisionStatus: z.string(),
+                      finalPlannedReservesCents: z.string().nullable(),
+                      liveAllocationVersion: z.number().int().nullable(),
+                      decidedAt: z.string().datetime().nullable(),
+                    })
+                    .passthrough()
+                ),
+              })
+              .passthrough(),
+          })
+          .passthrough(),
+      })
+      .passthrough(),
+  })
+  .passthrough();
+
+export type ReserveIntelligenceHookError = Error & {
+  code?: 'CONTRACT_PARSE_ERROR';
+  status?: number;
+};
+
+export type ReserveIntelligenceQueryResult =
+  | { kind: 'feature-disabled' }
+  | { kind: 'no-run' }
+  | { kind: 'ready'; run: DynamicReserveIntelligenceRunV1 };
+
+function isReserveIntelligenceRun(value: unknown): value is DynamicReserveIntelligenceRunV1 {
+  return reserveIntelligenceRunSchema.safeParse(value).success;
+}
+
+function getErrorCode(response: unknown): string | null {
+  if (typeof response !== 'object' || response === null || !('error' in response)) {
+    return null;
+  }
+  const error = (response as { error?: unknown }).error;
+  return typeof error === 'string' ? error : null;
+}
+
+function getErrorMessage(response: unknown): string {
+  if (typeof response === 'object' && response !== null && 'message' in response) {
+    const message = (response as { message?: unknown }).message;
+    if (typeof message === 'string' && message.length > 0) {
+      return message;
+    }
+  }
+  return 'Failed to load reserve intelligence';
+}
+
+function buildContractError(status?: number): ReserveIntelligenceHookError {
+  const error = new Error(
+    'Reserve intelligence contract parse failed'
+  ) as ReserveIntelligenceHookError;
+  error.code = 'CONTRACT_PARSE_ERROR';
+  if (status !== undefined) {
+    error.status = status;
+  }
+  return error;
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  return response.json().catch(() => {
+    throw buildContractError(response.status);
+  });
+}
+
+export function useReserveIntelligence(fundId: number | null) {
+  const validFundId = fundId !== null && Number.isInteger(fundId) && fundId > 0 ? fundId : null;
+
+  return useQuery<ReserveIntelligenceQueryResult, ReserveIntelligenceHookError>({
+    queryKey: ['reserve-intelligence-latest', validFundId],
+    queryFn: async () => {
+      if (validFundId === null) {
+        throw new Error('A positive fund ID is required') as ReserveIntelligenceHookError;
+      }
+
+      const response = await fetch(`/api/funds/${validFundId}/moic/reserve-intelligence/latest`, {
+        credentials: 'include',
+      });
+
+      if (response.status === 404) {
+        const body: unknown = await response.json().catch(() => ({}));
+        return getErrorCode(body) === 'RESERVE_INTELLIGENCE_RUN_NOT_FOUND'
+          ? { kind: 'no-run' }
+          : { kind: 'feature-disabled' };
+      }
+
+      if (!response.ok) {
+        const body: unknown = await response.json().catch(() => ({}));
+        const error = new Error(getErrorMessage(body)) as ReserveIntelligenceHookError;
+        error.status = response.status;
+        throw error;
+      }
+
+      const raw = await readJson(response);
+      if (!isReserveIntelligenceRun(raw)) {
+        throw buildContractError(response.status);
+      }
+      return { kind: 'ready', run: raw };
+    },
+    enabled: validFundId !== null,
+    retry: (failureCount, error) =>
+      error.status !== 404 && error.code !== 'CONTRACT_PARSE_ERROR' && failureCount < 2,
+  });
+}

--- a/client/src/pages/fund-model-results-moic-analysis.tsx
+++ b/client/src/pages/fund-model-results-moic-analysis.tsx
@@ -1,6 +1,7 @@
 import { Fragment, useState } from 'react';
 import { AlertTriangle, ChevronRight, Info } from 'lucide-react';
 import { useRoute } from 'wouter';
+import { ReserveIntelligencePanel } from '@/components/fund-results/ReserveIntelligencePanel';
 import { MoicBasisDisclosure, MoicRankabilityBadge } from '@/components/moic/MoicBasisDisclosure';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -575,6 +576,10 @@ export default function FundModelResultsMoicAnalysisPage() {
           <ProvenanceStrip data={data} />
           <RankingsTable rankings={data.rankings} portfolioCompanies={portfolioCompanies} />
         </>
+      ) : null}
+
+      {fundIdResult.status === 'valid' ? (
+        <ReserveIntelligencePanel fundId={fundIdResult.fundId} />
       ) : null}
     </div>
   );

--- a/tests/unit/components/fund-results/reserve-intelligence-panel.test.tsx
+++ b/tests/unit/components/fund-results/reserve-intelligence-panel.test.tsx
@@ -1,0 +1,189 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ReserveIntelligencePanel } from '@/components/fund-results/ReserveIntelligencePanel';
+import type {
+  ReserveIntelligenceHookError,
+  ReserveIntelligenceQueryResult,
+} from '@/hooks/useReserveIntelligence';
+import {
+  makeReserveIntelligenceRun,
+  RESERVE_FACTS_HASH,
+} from '../../fixtures/dynamic-reserve-intelligence';
+
+interface HookResult {
+  data: ReserveIntelligenceQueryResult | undefined;
+  error: ReserveIntelligenceHookError | null;
+  isLoading: boolean;
+}
+
+const useReserveIntelligence = vi.fn<(fundId: number | null) => HookResult>();
+
+vi.mock('@/hooks/useReserveIntelligence', () => ({
+  useReserveIntelligence: (fundId: number | null) => useReserveIntelligence(fundId),
+}));
+
+function mockHook(result: HookResult) {
+  useReserveIntelligence.mockReturnValue(result);
+}
+
+describe('ReserveIntelligencePanel', () => {
+  beforeEach(() => {
+    useReserveIntelligence.mockReset();
+    mockHook({
+      data: { kind: 'feature-disabled' },
+      error: null,
+      isLoading: false,
+    });
+  });
+
+  it('renders server-disabled as unavailable with reason, not error or table', () => {
+    render(<ReserveIntelligencePanel fundId={7} />);
+
+    const panel = screen.getByRole('region', { name: 'Reserve intelligence' });
+    expect(within(panel).getByText('Reserve intelligence unavailable')).toBeInTheDocument();
+    expect(within(panel).getByText(/disabled by server configuration/i)).toBeInTheDocument();
+    expect(within(panel).queryByRole('alert')).not.toBeInTheDocument();
+    expect(within(panel).queryByRole('table')).not.toBeInTheDocument();
+  });
+
+  it('renders no-run separately from the server-disabled state', () => {
+    mockHook({ data: { kind: 'no-run' }, error: null, isLoading: false });
+
+    render(<ReserveIntelligencePanel fundId={7} />);
+
+    expect(screen.getByText('No reserve intelligence run yet')).toBeInTheDocument();
+    expect(screen.getByText(/feature is enabled.*no persisted run/i)).toBeInTheDocument();
+    expect(screen.queryByText(/disabled by server configuration/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
+
+  it('renders loading without a table', () => {
+    mockHook({ data: undefined, error: null, isLoading: true });
+
+    render(<ReserveIntelligencePanel fundId={7} />);
+
+    expect(screen.getByText('Loading reserve intelligence')).toBeInTheDocument();
+    expect(screen.getAllByTestId('reserve-intelligence-skeleton-row')).toHaveLength(3);
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ['contract mismatch', { code: 'CONTRACT_PARSE_ERROR' as const }, /contract mismatch/i],
+    ['load error', { status: 500 }, /unable to load reserve intelligence/i],
+  ])('renders %s as an error distinct from unavailable', (_label, error, copy) => {
+    mockHook({ data: undefined, error, isLoading: false });
+
+    render(<ReserveIntelligencePanel fundId={7} />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent(copy);
+    expect(screen.queryByText(/disabled by server configuration/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
+
+  it('renders one analytical diagnostics table with its D33 basis line inside', () => {
+    const run = makeReserveIntelligenceRun();
+    mockHook({ data: { kind: 'ready', run }, error: null, isLoading: false });
+
+    render(<ReserveIntelligencePanel fundId={7} />);
+
+    const table = screen.getByRole('table', { name: 'Reserve intelligence diagnostics' });
+    const basisLine = within(table).getByTestId('basis-line');
+    expect(table.contains(basisLine)).toBe(true);
+    expect(basisLine.closest('table')).toBe(table);
+    expect(basisLine).toHaveTextContent('2026-07-29');
+    expect(basisLine).toHaveTextContent(RESERVE_FACTS_HASH.slice(0, 12));
+    expect(basisLine).toHaveTextContent('Snapshot 31');
+    expect(basisLine).toHaveTextContent('Not actionable');
+    expect(basisLine).toHaveTextContent('Mode: shadow');
+    expect(basisLine).toHaveTextContent(
+      'Analytical only. Derived from the pinned facts snapshot; never written back to the current plan.'
+    );
+    expect(screen.getAllByRole('table')).toHaveLength(1);
+  });
+
+  it('renders allocations, overlays, deltas, constraints, unresolved facts, and decisions', () => {
+    const run = makeReserveIntelligenceRun();
+    mockHook({ data: { kind: 'ready', run }, error: null, isLoading: false });
+
+    render(<ReserveIntelligencePanel fundId={7} />);
+
+    const table = screen.getByRole('table');
+    const alphaRow = within(table).getByText('Alpha').closest('tr');
+    expect(alphaRow).not.toBeNull();
+    expect(alphaRow).toHaveTextContent('Seed');
+    expect(alphaRow).toHaveTextContent('7,500.00');
+    expect(alphaRow).toHaveTextContent('7,000.00');
+    expect(alphaRow).toHaveTextContent('-500.00');
+    expect(alphaRow).toHaveTextContent('2.5x');
+    expect(screen.getByText(/overlay_unknown_company.*99/i)).toBeInTheDocument();
+    expect(screen.getByText(/envelope_untrusted/i)).toBeInTheDocument();
+    const deviations = screen
+      .getByRole('heading', { name: 'D30 selection deviations' })
+      .closest('section');
+    expect(deviations).not.toBeNull();
+    expect(
+      within(deviations as HTMLElement).getByText(/working_value_selection_deviation/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/reserve selection differs from the default/i)).toBeInTheDocument();
+    expect(screen.getByText(/one non-usd cash flow was excluded/i)).toBeInTheDocument();
+    expect(screen.getByText(/follow_on.*approved/i)).toBeInTheDocument();
+    expect(screen.getByText(/maxpercompany:infinity/i)).toBeInTheDocument();
+  });
+
+  it('links facts per row, opens evidence, and discloses missing row fallback', async () => {
+    const user = userEvent.setup();
+    const run = makeReserveIntelligenceRun();
+    mockHook({ data: { kind: 'ready', run }, error: null, isLoading: false });
+
+    render(<ReserveIntelligencePanel fundId={7} />);
+
+    await user.click(screen.getByRole('button', { name: 'Open reserve facts for Alpha' }));
+    const alphaDrawer = screen.getByRole('dialog', { name: 'Alpha reserve evidence' });
+    expect(within(alphaDrawer).getByText('PARTIAL')).toBeInTheDocument();
+    expect(within(alphaDrawer).getByText(/companyId.*companyIdentityId/i)).toBeInTheDocument();
+    expect(within(alphaDrawer).getByText(/participation refs: 1/i)).toBeInTheDocument();
+    await user.keyboard('{Escape}');
+
+    await user.click(screen.getByRole('button', { name: 'Open reserve facts for Gamma' }));
+    const gammaDrawer = screen.getByRole('dialog', { name: 'Gamma reserve evidence' });
+    expect(within(gammaDrawer).getByText('No Gamma facts row disclosed')).toBeInTheDocument();
+    expect(screen.getByText('No facts row disclosed', { selector: 'span' })).toBeInTheDocument();
+  });
+
+  it.each(['financial-facts-policy/1.0.1' as const, 'financial-facts-policy/1.1.0' as const])(
+    'renders policy version %s without assuming details exist',
+    async (policyVersion) => {
+      const user = userEvent.setup();
+      const run = makeReserveIntelligenceRun(policyVersion);
+      mockHook({ data: { kind: 'ready', run }, error: null, isLoading: false });
+
+      render(<ReserveIntelligencePanel fundId={7} />);
+
+      expect(screen.getByText(policyVersion)).toBeInTheDocument();
+      await user.click(screen.getByRole('button', { name: 'Open reserve facts for Alpha' }));
+      const drawer = screen.getByRole('dialog', { name: 'Alpha reserve evidence' });
+      if (policyVersion === 'financial-facts-policy/1.0.1') {
+        expect(
+          within(drawer).getByText(/does not disclose effective-terms refs/i)
+        ).toBeInTheDocument();
+      } else {
+        expect(within(drawer).getByText(/valuation basis.*derived 1/i)).toBeInTheDocument();
+      }
+    }
+  );
+
+  it('keeps recompute disabled with reason and exposes no apply or write-back action', () => {
+    const run = makeReserveIntelligenceRun();
+    mockHook({ data: { kind: 'ready', run }, error: null, isLoading: false });
+
+    render(<ReserveIntelligencePanel fundId={7} />);
+
+    expect(
+      screen.getByRole('button', { name: 'Recompute from latest accepted facts' })
+    ).toBeDisabled();
+    expect(screen.getByText(/recompute command is not available/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /apply|write back/i })).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/fixtures/dynamic-reserve-intelligence.ts
+++ b/tests/unit/fixtures/dynamic-reserve-intelligence.ts
@@ -1,0 +1,342 @@
+import {
+  DynamicReserveIntelligenceRunV1Schema,
+  type DynamicReserveIntelligenceRunV1,
+} from '../../../shared/contracts/dynamic-reserve-intelligence-v1.contract';
+
+const HASH_A = 'a'.repeat(64);
+const HASH_B = 'b'.repeat(64);
+const HASH_C = 'c'.repeat(64);
+
+type PolicyVersion = 'financial-facts-policy/1.0.1' | 'financial-facts-policy/1.1.0';
+
+function companyFact(companyId: number, companyName: string, withWarning: boolean) {
+  const warnings = withWarning
+    ? [
+        {
+          code: 'PLANNING_FMV_STALE',
+          severity: 'warning',
+          message: `${companyName} planning FMV is stale.`,
+        },
+      ]
+    : [];
+
+  return {
+    fundId: 7,
+    companyId,
+    companyName,
+    investmentIds: [companyId + 100],
+    activeRoundIds: [companyId + 200],
+    approvedPlanningFmvMarkId: null,
+    planningFmvStatus: withWarning ? 'stale' : 'active',
+    initialInvestmentAmount: '1000000.000000',
+    followOnInvestmentAmount: '250000.000000',
+    amountOnlyNonEquityAmount: '0.000000',
+    latestRoundDate: '2026-06-01',
+    latestRoundValuation: '10000000.000000',
+    latestPlanningFmvDate: '2026-07-15',
+    latestPlanningFmvValue: '12000000.000000',
+    currency: 'USD',
+    currencyStatus: 'base_currency',
+    supersedeLineage: [{ roundId: companyId + 200, supersedesRoundId: null }],
+    warnings,
+    provenance: withWarning
+      ? {
+          trustState: 'PARTIAL',
+          core: {
+            sourceKind: 'computed',
+            actionability: 'input_only',
+            sourceEngine: 'rounds-to-model',
+            engineVersion: '1.0.0',
+            inputHash: HASH_A,
+            assumptionsHash: HASH_B,
+            isFinanciallyActionable: false,
+            warnings: [],
+          },
+          structuredWarnings: warnings,
+        }
+      : {
+          trustState: 'LIVE',
+          core: {
+            sourceKind: 'computed',
+            actionability: 'actionable',
+            sourceEngine: 'rounds-to-model',
+            engineVersion: '1.0.0',
+            inputHash: HASH_A,
+            assumptionsHash: HASH_B,
+            isFinanciallyActionable: true,
+            warnings: [],
+          },
+          structuredWarnings: [],
+        },
+    inputHash: companyId === 11 ? HASH_A : HASH_B,
+  };
+}
+
+function sharedFactsPayload() {
+  return {
+    companyActuals: {
+      fundId: 7,
+      asOfDate: '2026-07-29',
+      facts: [companyFact(11, 'Alpha', true), companyFact(12, 'Beta', false)],
+      inputHash: HASH_A,
+    },
+    sourceObservationIds: [101],
+    workingValueSelectionIds: [201],
+    cashFlowSeries: {
+      series: [],
+      totals: {
+        contributions: '1000000.000000',
+        distributions: '250000.000000',
+        recallableDistributions: '0.000000',
+      },
+      warnings: [
+        {
+          code: 'NON_USD_CASH_FLOW_EXCLUDED',
+          severity: 'warning',
+          message: 'One non-USD cash flow was excluded.',
+        },
+      ],
+    },
+    marksSeries: {
+      marks: [],
+      periodNav: [
+        {
+          periodEnd: '2026-06-30',
+          nav: '12000000.000000',
+          warnings: [
+            {
+              code: 'VALUATION_MARK_STALE',
+              severity: 'warning',
+              message: 'Quarter-end NAV contains a stale mark.',
+            },
+          ],
+        },
+      ],
+      warnings: [
+        {
+          code: 'VALUATION_MARK_STALE',
+          severity: 'warning',
+          message: 'One valuation mark is stale.',
+        },
+      ],
+    },
+    vehicleRoster: [],
+  };
+}
+
+function factsSnapshot(policyVersion: PolicyVersion) {
+  const common = {
+    fundId: 7,
+    asOfDate: '2026-07-29',
+    knowledgeCutoff: '2026-07-29T19:00:00.000Z',
+    vehicleScope: 'fund_all',
+    vehicleIds: [1],
+    selectionSetHash: HASH_A,
+    sourceFactsInputHash: HASH_B,
+    snapshotInputHash: HASH_C,
+    actorId: 17,
+    createdAt: '2026-07-29T19:05:00.000Z',
+  };
+
+  if (policyVersion === 'financial-facts-policy/1.0.1') {
+    return {
+      ...common,
+      policyVersion,
+      payloadSchemaId: 'financial-facts-payload/1',
+      consumerEvaluations: [
+        {
+          consumer: 'reserve',
+          status: 'blocked',
+          reasons: ['working_value_selection_deviation'],
+        },
+      ],
+      payload: {
+        ...sharedFactsPayload(),
+        participationTermRefs: [],
+      },
+    };
+  }
+
+  return {
+    ...common,
+    policyVersion,
+    payloadSchemaId: 'financial-facts-payload/2',
+    consumerEvaluations: [
+      {
+        consumer: 'reserve',
+        status: 'blocked',
+        reasons: ['working_value_selection_deviation', 'mixed_term_versions'],
+        details: [
+          {
+            code: 'working_value_selection_deviation',
+            companyIds: [11],
+            message: 'Reserve selection differs from the default working value.',
+          },
+        ],
+      },
+    ],
+    payload: {
+      ...sharedFactsPayload(),
+      positionRefs: [],
+      positionComponentRefs: [
+        {
+          vehicleId: 1,
+          companyIdentityId: 501,
+          kind: 'priced',
+          participationId: 701,
+          participationVersion: 2,
+          financingTrancheId: 801,
+          trancheVersion: 3,
+        },
+      ],
+      ownershipRefs: [],
+      valuationRefs: [
+        {
+          basis: 'derived',
+          vehicleId: 1,
+          companyIdentityId: 501,
+          directMarkId: null,
+          directSourceObservationId: null,
+          ownershipSnapshotId: 901,
+          derivedTrancheId: 801,
+          derivedTrancheVersion: 3,
+          derivedParticipationId: 701,
+          derivedParticipationVersion: 2,
+        },
+      ],
+      participationTermRefs: [
+        {
+          participationId: 701,
+          participationVersion: 2,
+          financingTrancheId: 801,
+          trancheVersion: 3,
+        },
+      ],
+      observationRefs: [
+        {
+          observationId: 101,
+          domain: 'participation_terms',
+          status: 'accepted',
+          effectiveDate: '2026-07-15',
+        },
+      ],
+    },
+  };
+}
+
+export function makeReserveIntelligenceRun(
+  policyVersion: PolicyVersion = 'financial-facts-policy/1.1.0'
+): DynamicReserveIntelligenceRunV1 {
+  return DynamicReserveIntelligenceRunV1Schema.parse({
+    snapshotId: 41,
+    createdAt: '2026-07-29T20:00:00.000Z',
+    result: {
+      contractVersion: 'dynamic-reserve-intelligence-v1',
+      fundId: 7,
+      actionability: 'non_actionable',
+      companies: [
+        {
+          companyId: 11,
+          name: 'Alpha',
+          canonicalStage: 'seed',
+          status: 'actionable',
+          rank: 1,
+          marginalMoic: '2.5',
+          systemAllocatedCents: 750_000,
+          overlayPlannedCents: 700_000,
+          deltaCents: -50_000,
+          concentration: '0.75',
+        },
+        {
+          companyId: 12,
+          name: 'Beta',
+          canonicalStage: 'series_a',
+          status: 'indicative',
+          rank: 2,
+          marginalMoic: '1.25',
+          systemAllocatedCents: 250_000,
+          overlayPlannedCents: 300_000,
+          deltaCents: 50_000,
+          concentration: '0.25',
+        },
+        {
+          companyId: 13,
+          name: 'Gamma',
+          canonicalStage: 'series_b',
+          status: 'unavailable',
+          rank: null,
+          marginalMoic: null,
+          systemAllocatedCents: 0,
+          overlayPlannedCents: null,
+          deltaCents: null,
+          concentration: null,
+        },
+      ],
+      fund: {
+        totalSystemAllocatedCents: 1_000_000,
+        totalOverlayPlannedCents: 1_000_000,
+        totalDeltaCents: 0,
+        followOnCapacityCents: 2_000_000,
+        failSafe: true,
+        failSafeReason: 'envelope_untrusted',
+        excluded: [
+          { companyId: 12, reason: 'indicative' },
+          { companyId: 13, reason: 'unavailable' },
+        ],
+        disclosedDefaults: ['maxPerCompany:Infinity'],
+        neutralPolicies: [{ stage: 'seed', reserveMultiple: 1, weight: 1 }],
+      },
+      constraintFindings: [{ code: 'overlay_unknown_company', companyId: 99 }],
+      provenance: {
+        financialFactsSnapshotId: 31,
+        factsInputHash: HASH_A,
+        assumptionsHash: HASH_B,
+        envelopeInputHash: HASH_C,
+        effectiveMode: 'shadow',
+        h9Actionability: 'input_only',
+        overlayProvenance: {
+          suppliedBy: 17,
+          suppliedAt: '2026-07-29T19:30:00.000Z',
+        },
+        overlay: [
+          { companyId: 11, plannedReserveCents: 700_000 },
+          { companyId: 12, plannedReserveCents: 300_000 },
+        ],
+        idempotencyKey: 'reserve-run-31',
+        requestHash: HASH_A,
+        calcVersion: 'reserve-intel-v1',
+        asOfDate: '2026-07-29',
+        factsSnapshot: factsSnapshot(policyVersion),
+        marginalNonFactsSources: {
+          sourceSnapshotDate: '2026-07-29',
+          baseCurrency: 'USD',
+          companies: [],
+          approvedAllocations: [
+            {
+              companyId: 11,
+              decisionType: 'follow_on',
+              decisionStatus: 'approved',
+              finalPlannedReservesCents: '700000',
+              liveAllocationVersion: 3,
+              decidedAt: '2026-07-28T00:00:00.000Z',
+              updatedAt: '2026-07-28T00:00:00.000Z',
+            },
+          ],
+          publishedAssumptions: null,
+        },
+        envelopeSources: {
+          fund: {
+            sizeDollars: '100000000',
+            deployedCapitalDollars: '50000000',
+            managementFeeRate: '0.02',
+            baseCurrency: 'USD',
+          },
+          investments: [],
+          config: null,
+        },
+      },
+    },
+  });
+}
+
+export const RESERVE_FACTS_HASH = HASH_C;

--- a/tests/unit/hooks/use-reserve-intelligence.test.tsx
+++ b/tests/unit/hooks/use-reserve-intelligence.test.tsx
@@ -1,0 +1,103 @@
+import type { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useReserveIntelligence } from '../../../client/src/hooks/useReserveIntelligence';
+import { makeReserveIntelligenceRun } from '../fixtures/dynamic-reserve-intelligence';
+
+const fetchMock = vi.fn<typeof fetch>();
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('useReserveIntelligence', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('loads the exact latest-run path with included credentials', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(makeReserveIntelligenceRun()));
+
+    const { result } = renderHook(() => useReserveIntelligence(7), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(fetchMock).toHaveBeenCalledWith('/api/funds/7/moic/reserve-intelligence/latest', {
+      credentials: 'include',
+    });
+  });
+
+  it.each([null, 0, -1, 1.5])('does not fetch for invalid fund id %s', (fundId) => {
+    const { result } = renderHook(() => useReserveIntelligence(fundId), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('maps the server-disabled 404 body to feature-disabled without error', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ error: 'not_found' }, 404));
+
+    const { result } = renderHook(() => useReserveIntelligence(7), { wrapper });
+
+    await waitFor(() => expect(result.current.data?.kind).toBe('feature-disabled'));
+    expect(result.current.error).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps the no-persisted-run 404 body to no-run without error', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ error: 'RESERVE_INTELLIGENCE_RUN_NOT_FOUND' }, 404));
+
+    const { result } = renderHook(() => useReserveIntelligence(7), { wrapper });
+
+    await waitFor(() => expect(result.current.data?.kind).toBe('no-run'));
+    expect(result.current.error).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails safe to feature-disabled for an unrecognized 404 code', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ error: 'FUND_SCOPE_NOT_FOUND' }, 404));
+
+    const { result } = renderHook(() => useReserveIntelligence(7), { wrapper });
+
+    await waitFor(() => expect(result.current.data?.kind).toBe('feature-disabled'));
+    expect(result.current.error).toBeNull();
+  });
+
+  it('surfaces malformed success bodies as contract parse errors', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ snapshotId: 41, result: {} }));
+
+    const { result } = renderHook(() => useReserveIntelligence(7), { wrapper });
+
+    await waitFor(() => expect(result.current.error?.code).toBe('CONTRACT_PARSE_ERROR'));
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it('returns a schema-valid reserve intelligence run', async () => {
+    const run = makeReserveIntelligenceRun();
+    fetchMock.mockResolvedValue(jsonResponse(run));
+
+    const { result } = renderHook(() => useReserveIntelligence(7), { wrapper });
+
+    await waitFor(() => expect(result.current.data?.kind).toBe('ready'));
+    if (result.current.data?.kind !== 'ready') {
+      throw new Error('Expected ready reserve intelligence state');
+    }
+    expect(result.current.data.run).toEqual(run);
+  });
+});

--- a/tests/unit/pages/fund-model-results-moic-analysis.test.tsx
+++ b/tests/unit/pages/fund-model-results-moic-analysis.test.tsx
@@ -12,6 +12,11 @@ import {
   FundMoicFactsBasisV1Schema,
   type FundMoicFactsBasisV1,
 } from '../../../shared/contracts/fund-moic-v1.contract';
+import type {
+  ReserveIntelligenceHookError,
+  ReserveIntelligenceQueryResult,
+} from '../../../client/src/hooks/useReserveIntelligence';
+import { makeReserveIntelligenceRun } from '../fixtures/dynamic-reserve-intelligence';
 
 type HookError = { code: string };
 type HookResult = {
@@ -28,6 +33,13 @@ const usePortfolioCompanies = vi.fn<
       plannedReservesCents: number;
       deployedReservesCents: number;
     }>;
+  }
+>();
+const useReserveIntelligence = vi.fn<
+  (fundId: number | null) => {
+    data: ReserveIntelligenceQueryResult | undefined;
+    error: ReserveIntelligenceHookError | null;
+    isLoading: boolean;
   }
 >();
 
@@ -59,6 +71,10 @@ vi.mock('../../../client/src/hooks/use-moic', () => ({
 
 vi.mock('../../../client/src/hooks/use-fund-data', () => ({
   usePortfolioCompanies: (fundId: number | undefined) => usePortfolioCompanies(fundId),
+}));
+
+vi.mock('../../../client/src/hooks/useReserveIntelligence', () => ({
+  useReserveIntelligence: (fundId: number | null) => useReserveIntelligence(fundId),
 }));
 
 const canonicalFixture = {
@@ -171,6 +187,12 @@ describe('FundModelResultsMoicAnalysisPage', () => {
         { id: 103, plannedReservesCents: 120_000_000, deployedReservesCents: 80_000_000 },
         { id: 104, plannedReservesCents: 110_000_000, deployedReservesCents: 70_000_000 },
       ],
+    });
+    useReserveIntelligence.mockReset();
+    useReserveIntelligence.mockReturnValue({
+      data: { kind: 'feature-disabled' },
+      error: null,
+      isLoading: false,
     });
   });
 
@@ -507,5 +529,35 @@ describe('FundModelResultsMoicAnalysisPage', () => {
       expect(skeleton).toHaveClass('tabular-nums', 'motion-reduce:animate-none');
     }
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
+
+  it('keeps reserve diagnostics visible when the rankings query fails', () => {
+    mockHook({
+      data: null,
+      error: { code: 'LOAD_ERROR' },
+      isLoading: false,
+    });
+    useReserveIntelligence.mockReturnValue({
+      data: { kind: 'ready', run: makeReserveIntelligenceRun() },
+      error: null,
+      isLoading: false,
+    });
+
+    renderPage();
+
+    expect(screen.getByText('Unable to load MOIC rankings')).toBeInTheDocument();
+    expect(
+      screen.getByRole('table', { name: 'Reserve intelligence diagnostics' })
+    ).toBeInTheDocument();
+  });
+
+  it('keeps rankings visible when reserve intelligence is unavailable', () => {
+    mockHook({ data: makeV2(), error: null, isLoading: false });
+
+    renderPage();
+
+    expect(screen.getByRole('table')).toHaveAccessibleName('');
+    expect(screen.getByText('Reserve intelligence unavailable')).toBeInTheDocument();
+    expect(useReserveIntelligence).toHaveBeenCalledWith(7);
   });
 });


### PR DESCRIPTION
## PLAN_61 Task 15 — Reserve diagnostics in the existing results workspace

Client-side surface over the deterministic reserve-intelligence engine shipped by Task 14 (#1238, squash `e8c2356a`). **No server change** — this PR consumes the API surface Task 14 already shipped.

Plan source pinned and integrity-verified: `33dddbd3PLAN_61.md`, 2094 lines, sha256 prefix `31931e6c97996133`, Task 15 at line 1567.

### What shipped

- **`ReserveIntelligencePanel`** renders derived allocation, overlay, deltas, constraints, unresolved facts, D30 selection deviations, and decision state, mounted in the MOIC analysis workspace **independently of the rankings query** so neither surface can hide the other.
- **D33 provenance-in-content**: as-of date, facts-snapshot short hash, snapshot id, status, mode, and the analytical-only notice render in a `data-testid="basis-line"` row **inside** the diagnostics table. The test asserts descendancy two ways — `table.contains(basisLine)` and `basisLine.closest('table') === table` — not mere presence.
- **Analytical-only**: no apply and no write-back affordance; a test asserts the absence of any such control, mirroring the server-side invariant that a run never writes back to `CurrentPlanVersion`.
- **`useReserveIntelligence`** discriminates the three distinct meanings of a 404 rather than collapsing them (see below).
- Per-company rows link to their facts snapshot by joining `companyActuals.facts[]` on `companyId`, with an explicit fallback where no facts row exists.

### Two decisions that need your call

**1. D21 recompute button — rendered disabled-with-reason.** The plan (line 1584) requires a "Recompute from latest accepted facts" button calling `POST /api/funds/:fundId/recompute-from-facts`. **That endpoint does not exist** — verified absent across `server/`, `shared/`, `client/src/`, `tests/`. The plan defines it in its API-decisions section (line 605) but no task's file list creates it. Rendered in the disabled-with-reason state the plan's own rule 5 already mandates, naming the missing command. Reversible: when the endpoint lands, only the disabled predicate changes. **No server endpoint was built.**

**2. Per-row `participationId` basis is not derivable — documented degradation of a plan rule.** The plan requires linking every company row to its "computed effective-terms basis (`participationId` + versions)". Verified blockers:

- Those refs exist **only under policy `1.1.0`**; under `1.0.0`/`1.0.1`, `participationTermRefs` is `z.array(z.string()).length(0)` — always empty.
- `positionComponentRefs`/`valuationRefs` are keyed by **`companyIdentityId`** (`company_identities.id`, its own serial PK with a *nullable* `source_portfolio_company_id`), while reserve rows are keyed by **`companyId`** (`portfolio_companies.id`).
- `companyActuals.facts[]` carries `companyId` but no `companyIdentityId`, and the reserve service operates purely in `companyId` space. **No join bridge exists in the Task 14 payload.**

Per-row *facts-snapshot* linkage works fully. The participation basis degrades to a run-level block (narrowed to `1.1.0`) plus an explicit per-row unavailable cell naming the missing `companyId -> companyIdentityId` mapping. No mapping is guessed and `companyId === companyIdentityId` is never assumed. Reversible without a server change once the payload carries the identity.

### Plan Review Gate

Brief at `.claude/artifacts/wave-h-task15-brief.md` (gitignored) passed a `codex exec --sandbox read-only` review. Eleven findings, each independently re-verified against source before disposition: **11 accepted, 0 rejected** (one accepted with a narrowed rationale). Two would have broken this PR:

- **`node:crypto` bundle leak.** The brief originally told the implementer to `safeParse` with the shared schema in a client hook. That chain reaches `shared/lib/canonical-hash.ts` -> `node:crypto`, and is **not tree-shakeable** because the facts-snapshot contract evaluates `EMPTY_SELECTION_SET_HASH` at module scope. There is no `crypto` polyfill in `vite.config.ts` and no existing client precedent. Client code now imports shared contracts **type-only** and validates with a browser-safe local schema; tests use the real schema (Node resolves `node:crypto`), which guards against drift. `npm run build:web` added as a mandatory gate — `npm run check` does not catch this class of failure.
- **Existing page assertions.** `tests/unit/pages/fund-model-results-moic-analysis.test.tsx:371` uses singular `getByRole('table')`, and lines 456/472/493/509 assert **no table** exists. Mounting the panel would have broken all five. Resolved by constraining the panel so only its `ready` state renders a `<table>`, and defaulting the new page-test mock to `feature-disabled` (the production default).

A third correction: D33's "facts-snapshot short hash" is `factsSnapshot.snapshotInputHash` (declared on all three union members, so no policy narrowing needed), **not** `provenance.factsInputHash` — which traces to the actuals-facts response hash (`facts-reserve-input-adapter.ts:163`), a different value.

### The three meanings of a 404

`FEATURES.marginalReserveMoic` defaults to **false**, so the unavailable path is the production default and is the best-tested branch. But a 404 is not one state:

| `body.error` | Meaning |
| --- | --- |
| `not_found` | Feature flag off |
| `RESERVE_INTELLIGENCE_RUN_NOT_FOUND` | Feature on, no run computed yet (`dynamic-reserve-intelligence-service.ts:613-620`) |
| `FundScopeError.code` | Fund scope failure |

The hook distinguishes `feature-disabled` from `no-run` with different reason copy, and fails safe to `feature-disabled` on an unrecognized code. No client feature flag was added — the server gate is authoritative and a duplicate client gate would drift.

### Verification (all run locally, exit 0)

| Gate | Result |
| --- | --- |
| Targeted (panel, hook, page, drawer, MOIC-decoupling guard) | **5 files / 45 tests passed** (baseline was 22; 23 new, 0 regressions) |
| `npm run check` | 0 new TypeScript errors |
| `npm run lint` | Clean, incl. decimal-string-laundering and legacy-calculation-consumers guardrails |
| `npm run build:web` | Built in 6.95s, no crypto externalization |
| Full client suite, sharded | **196 files / 1561 tests passed**, 2 files + 14 tests skipped |
| Pre-push `baseline:check` | 0 errors, client/server/shared compiled separately |

`npm run calc-gate` is not the gate here — no calculation code changed.

### Scope

Matches the plan's file list, with two deliberate deviations:

- **`tests/unit/fixtures/dynamic-reserve-intelligence.ts` added.** Sanctioned by the brief; the fixture validates itself with the real `DynamicReserveIntelligenceRunV1Schema.parse`, which is what keeps the browser-safe client validator honest. A `tests/unit/hooks/` test was also added — mocked-hook panel tests cannot cover URL, credentials, id gating, or the two 404 bodies.
- **`FinancialEvidenceDrawer.tsx` was NOT modified**, though the plan's file list anticipated it. Its existing `proofSlot` seam already covers the per-row evidence requirement, so no edit was needed. Adding a gratuitous change to satisfy a file list would have risked its 11 passing tests for no behavior gain (DEV_BRAIN hard rule 4, smallest safe diff).

Untracked `HANDOFF.json` / `HANDOFF.md` were left exactly as found.

### Residual risks

- The reserve panel has never been exercised against a live enabled backend — `ENABLE_MARGINAL_RESERVE_MOIC` is false by default and was not enabled here. Every `ready`-state assertion rests on schema-validated fixtures, not a live response.
- The MOA review stage did not complete: the Hermes dispatch was killed at the harness 10-minute ceiling (SIGTERM/143) after the owner had written its files. Preflight passed; the review and postflight never ran. Every gate in the table above was therefore run by me directly rather than reported by the tooling.
- The per-row participation gap (decision 2) leaves part of a plan rule unsatisfied by design. If you want it closed, it needs a payload change on the server side — out of scope for this task.

**Not merged.** Merge authorization is reserved to you; auto-merge was not armed.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZFDDRwCB51Rt4vhzoJPEJ
