### PR TITLE
fix(reserves): close Task 15 retroactive-review findings F1 and F2

### DIFF
--- a/client/src/components/fund-results/ReserveIntelligencePanel.tsx
+++ b/client/src/components/fund-results/ReserveIntelligencePanel.tsx
@@ -339,6 +339,10 @@ function DiagnosticsTable({
                   <span className="block text-xs text-presson-textMuted">
                     {fact === undefined ? 'No facts row disclosed' : `Linked: ${fact.companyName}`}
                   </span>
+                  <span className="block text-xs text-presson-textMuted">
+                    Participation basis unavailable: companyId to companyIdentityId mapping is not
+                    disclosed.
+                  </span>
                   <button
                     type="button"
                     className="text-left text-xs font-medium text-pov-charcoal underline underline-offset-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-charcoal-400 focus-visible:ring-offset-2"

--- a/client/src/hooks/useReserveIntelligence.ts
+++ b/client/src/hooks/useReserveIntelligence.ts
@@ -209,7 +209,10 @@ const reserveIntelligenceRunSchema = z
                       companyId: z.number().int().positive(),
                       decisionType: z.string(),
                       decisionStatus: z.string(),
-                      finalPlannedReservesCents: z.string().nullable(),
+                      finalPlannedReservesCents: z
+                        .string()
+                        .regex(/^-?\d+$/)
+                        .nullable(),
                       liveAllocationVersion: z.number().int().nullable(),
                       decidedAt: z.string().datetime().nullable(),
                     })

--- a/tests/unit/components/fund-results/reserve-intelligence-panel.test.tsx
+++ b/tests/unit/components/fund-results/reserve-intelligence-panel.test.tsx
@@ -28,6 +28,20 @@ function mockHook(result: HookResult) {
   useReserveIntelligence.mockReturnValue(result);
 }
 
+const PARTICIPATION_BASIS_UNAVAILABLE =
+  'Participation basis unavailable: companyId to companyIdentityId mapping is not disclosed.';
+
+function expectParticipationBasisDisclosureForEachCompany() {
+  const table = screen.getByRole('table', { name: 'Reserve intelligence diagnostics' });
+  for (const companyName of ['Alpha', 'Beta', 'Gamma']) {
+    const row = within(table).getByText(companyName).closest('tr');
+    expect(row).not.toBeNull();
+    expect(
+      within(row as HTMLTableRowElement).getByText(PARTICIPATION_BASIS_UNAVAILABLE)
+    ).toBeVisible();
+  }
+}
+
 describe('ReserveIntelligencePanel', () => {
   beforeEach(() => {
     useReserveIntelligence.mockReset();
@@ -130,6 +144,16 @@ describe('ReserveIntelligencePanel', () => {
     expect(screen.getByText(/one non-usd cash flow was excluded/i)).toBeInTheDocument();
     expect(screen.getByText(/follow_on.*approved/i)).toBeInTheDocument();
     expect(screen.getByText(/maxpercompany:infinity/i)).toBeInTheDocument();
+    expectParticipationBasisDisclosureForEachCompany();
+  });
+
+  it('renders the per-row participation-basis disclosure under policy 1.0.1', () => {
+    const run = makeReserveIntelligenceRun('financial-facts-policy/1.0.1');
+    mockHook({ data: { kind: 'ready', run }, error: null, isLoading: false });
+
+    render(<ReserveIntelligencePanel fundId={7} />);
+
+    expectParticipationBasisDisclosureForEachCompany();
   });
 
   it('links facts per row, opens evidence, and discloses missing row fallback', async () => {

--- a/tests/unit/hooks/use-reserve-intelligence.test.tsx
+++ b/tests/unit/hooks/use-reserve-intelligence.test.tsx
@@ -88,6 +88,42 @@ describe('useReserveIntelligence', () => {
     expect(result.current.data).toBeUndefined();
   });
 
+  it('rejects a non-integer final planned reserves value', async () => {
+    const run = makeReserveIntelligenceRun();
+    run.result.provenance.marginalNonFactsSources.approvedAllocations[0]!.finalPlannedReservesCents =
+      '12.5';
+    fetchMock.mockResolvedValue(jsonResponse(run));
+
+    const { result } = renderHook(() => useReserveIntelligence(7), { wrapper });
+
+    await waitFor(() => expect(result.current.error?.code).toBe('CONTRACT_PARSE_ERROR'));
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it('accepts a negative integer final planned reserves value', async () => {
+    const run = makeReserveIntelligenceRun();
+    run.result.provenance.marginalNonFactsSources.approvedAllocations[0]!.finalPlannedReservesCents =
+      '-1200';
+    fetchMock.mockResolvedValue(jsonResponse(run));
+
+    const { result } = renderHook(() => useReserveIntelligence(7), { wrapper });
+
+    await waitFor(() => expect(result.current.data?.kind).toBe('ready'));
+    expect(result.current.error).toBeNull();
+  });
+
+  it('accepts a null final planned reserves value', async () => {
+    const run = makeReserveIntelligenceRun();
+    run.result.provenance.marginalNonFactsSources.approvedAllocations[0]!.finalPlannedReservesCents =
+      null;
+    fetchMock.mockResolvedValue(jsonResponse(run));
+
+    const { result } = renderHook(() => useReserveIntelligence(7), { wrapper });
+
+    await waitFor(() => expect(result.current.data?.kind).toBe('ready'));
+    expect(result.current.error).toBeNull();
+  });
+
   it('returns a schema-valid reserve intelligence run', async () => {
     const run = makeReserveIntelligenceRun();
     fetchMock.mockResolvedValue(jsonResponse(run));


### PR DESCRIPTION
## Context

PR #1240 (Task 15, squash `7054599d`) shipped with its T2 MOA review stage skipped — the Hermes dispatch was killed by a harness timeout before the review ran. This session conducted the retroactive MOA review with the exact T2 panel (`terra`/correctness, `luna`/spec-compliance, `qwen`/simplicity-efficiency, invoked directly since the orchestrator's review workflow skips the MOA step by design). Verdict: NOT APPROVED — terra and luna rejected; both accepted findings are closed here. Full evidence: `.claude/artifacts/task15-closeout-evidence.md` (gitignored, on disk).

## F1 — missing per-row participation-basis disclosure (terra + luna, independently converged)

The Task 15 brief's 6.2 decision requires an explicit per-row unavailable-with-reason cell naming the missing `companyId -> companyIdentityId` mapping, and PR #1240's description claims that cell exists — but the shipped table rendered the disclosure only at run level and in the evidence drawer. Each diagnostics-table row now carries the explicit "Participation basis unavailable" line inside the existing Facts-snapshot cell (no new column; the `colSpan={10}` basis line is unaffected). Run-level block and drawer are unchanged. No mapping is derived or guessed.

## F2 — client validator laxer than the shared contract (terra)

`finalPlannedReservesCents` was validated as bare `z.string()` while the shared contract requires `z.string().regex(/^-?\d+$/)`. The browser-safe mirror now enforces the same regex, so malformed values trip `CONTRACT_PARSE_ERROR` instead of rendering. Type-only shared-contract import invariant untouched.

Two qwen minor findings (BigInt currency formatting; per-render `Map`) were recorded and deliberately not actioned — no behavior change, smallest safe diff.

## Verification (run directly, not tooling self-reports)

- Targeted suite (panel, hook, page, drawer, no-moic-imports guard): 5 files / 49 tests passed, TZ=UTC.
- Full client suite sharded: 810 passed | 9 skipped and 755 passed | 5 skipped, both shards exit 0.
- `npm run check`: 0 errors (baseline unchanged). `npm run lint`: clean incl. legacy-calculation-consumers (1540 files) and decimal-string-laundering (96 files) guardrails.
- `npm run build:web`: built in ~7s, no `node:crypto` externalization warning.
- Live smoke (same session): panel exercised end-to-end against a real local Postgres-backed dev stack — feature-disabled 404, no-run 404, and ready state (real facts snapshot + real persisted run, browser render, zero console errors).