### PR TITLE
fix: repair stale local imports

### DIFF
--- a/scripts/backtest.ts
+++ b/scripts/backtest.ts
@@ -13,7 +13,7 @@ import { DeterministicReserveEngine } from '../client/src/core/reserves/Determin
 import { ConstrainedReserveEngine } from '../client/src/core/reserves/ConstrainedReserveEngine.js';
 import { MlClient } from '../server/core/reserves/mlClient.js';
 import { MarketScoreComputer } from '../server/core/market/score.js';
-import { db } from '../server/db/client.js';
+import { db } from '../server/db.js';
 import { marketIndicators, pacingScores } from '../server/db/schema/market.js';
 import { reserveDecisions } from '../server/db/schema/reserves.js';
 import { eq, and, gte, lte } from 'drizzle-orm';
@@ -88,7 +88,7 @@ interface EngineMetrics {
 
 export class BacktestRunner {
   private marketScorer = new MarketScoreComputer();
-  
+
   constructor(private config: BacktestConfig) {}
 
   async run(): Promise<BacktestResult> {
@@ -121,7 +121,7 @@ export class BacktestRunner {
 
     for (const engineType of this.config.engines) {
       logger.info(`Running backtest for ${engineType} engine`);
-      
+
       const engineResults = await this.runEngineBacktest(
         engineType,
         companies,
@@ -147,7 +147,7 @@ export class BacktestRunner {
   private async loadCompanies(): Promise<Company[]> {
     if (this.config.companiesFile) {
       const content = await fs.readFile(this.config.companiesFile, 'utf-8');
-      return this.parseCsv(content).map(row => ({
+      return this.parseCsv(content).map((row) => ({
         id: row.id,
         fundId: row.fundId,
         name: row.name,
@@ -193,7 +193,7 @@ export class BacktestRunner {
   private async loadRealizedUsage(): Promise<RealizedUsage[]> {
     if (this.config.realizedFile) {
       const content = await fs.readFile(this.config.realizedFile, 'utf-8');
-      return this.parseCsv(content).map(row => ({
+      return this.parseCsv(content).map((row) => ({
         companyId: row.companyId,
         periodStart: row.periodStart,
         periodEnd: row.periodEnd,
@@ -225,13 +225,13 @@ export class BacktestRunner {
     const periods: Array<{ start: string; end: string }> = [];
     const start = new Date(this.config.from);
     const end = new Date(this.config.to);
-    
+
     let current = new Date(start);
-    
+
     while (current <= end) {
       const periodStart = new Date(current);
       const periodEnd = new Date(current);
-      
+
       if (this.config.period === 'quarter') {
         // Set to end of quarter
         const quarter = Math.floor(periodStart.getMonth() / 3);
@@ -243,13 +243,13 @@ export class BacktestRunner {
         periodEnd.setMonth(periodEnd.getMonth() + 1, 0);
         current.setMonth(current.getMonth() + 1);
       }
-      
+
       periods.push({
         start: periodStart.toISOString().split('T')[0],
         end: periodEnd.toISOString().split('T')[0],
       });
     }
-    
+
     return periods;
   }
 
@@ -262,48 +262,33 @@ export class BacktestRunner {
     });
 
     return {
-      rules: new FeatureFlaggedReserveEngine(
-        deterministicEngine,
-        constrainedEngine,
-        mlClient,
-        {
-          useMl: false,
-          mode: 'rules',
-          mlWeight: 0,
-          enableABTest: false,
-          abTestPercentage: 0,
-          fallbackOnError: true,
-          logAllDecisions: false, // Disable logging during backtest
-        }
-      ),
-      ml: new FeatureFlaggedReserveEngine(
-        deterministicEngine,
-        constrainedEngine,
-        mlClient,
-        {
-          useMl: true,
-          mode: 'ml',
-          mlWeight: 1,
-          enableABTest: false,
-          abTestPercentage: 100,
-          fallbackOnError: true,
-          logAllDecisions: false,
-        }
-      ),
-      hybrid: new FeatureFlaggedReserveEngine(
-        deterministicEngine,
-        constrainedEngine,
-        mlClient,
-        {
-          useMl: true,
-          mode: 'hybrid',
-          mlWeight: 0.7,
-          enableABTest: false,
-          abTestPercentage: 100,
-          fallbackOnError: true,
-          logAllDecisions: false,
-        }
-      ),
+      rules: new FeatureFlaggedReserveEngine(deterministicEngine, constrainedEngine, mlClient, {
+        useMl: false,
+        mode: 'rules',
+        mlWeight: 0,
+        enableABTest: false,
+        abTestPercentage: 0,
+        fallbackOnError: true,
+        logAllDecisions: false, // Disable logging during backtest
+      }),
+      ml: new FeatureFlaggedReserveEngine(deterministicEngine, constrainedEngine, mlClient, {
+        useMl: true,
+        mode: 'ml',
+        mlWeight: 1,
+        enableABTest: false,
+        abTestPercentage: 100,
+        fallbackOnError: true,
+        logAllDecisions: false,
+      }),
+      hybrid: new FeatureFlaggedReserveEngine(deterministicEngine, constrainedEngine, mlClient, {
+        useMl: true,
+        mode: 'hybrid',
+        mlWeight: 0.7,
+        enableABTest: false,
+        abTestPercentage: 100,
+        fallbackOnError: true,
+        logAllDecisions: false,
+      }),
     };
   }
 
@@ -323,9 +308,10 @@ export class BacktestRunner {
       for (const company of companies) {
         // Find realized usage for this company and period
         const realized = realizedUsage.find(
-          r => r.companyId === company.id && 
-               r.periodStart === period.start &&
-               r.periodEnd === period.end
+          (r) =>
+            r.companyId === company.id &&
+            r.periodStart === period.start &&
+            r.periodEnd === period.end
         );
 
         if (!realized) continue; // Skip if no realized data
@@ -368,7 +354,6 @@ export class BacktestRunner {
             latencyMs: decision.latencyMs || 0,
             outcome: realized.outcome,
           });
-
         } catch (error) {
           logger.warn('Backtest prediction failed', {
             company: company.id,
@@ -396,20 +381,32 @@ export class BacktestRunner {
         const indicator = indicators[0];
         const scoreResult = this.marketScorer.computeMarketScore({
           vix: indicator.vix ? parseFloat(indicator.vix.toString()) : undefined,
-          fedFundsRate: indicator.fedFundsRate ? parseFloat(indicator.fedFundsRate.toString()) : undefined,
-          ust10yYield: indicator.ust10yYield ? parseFloat(indicator.ust10yYield.toString()) : undefined,
+          fedFundsRate: indicator.fedFundsRate
+            ? parseFloat(indicator.fedFundsRate.toString())
+            : undefined,
+          ust10yYield: indicator.ust10yYield
+            ? parseFloat(indicator.ust10yYield.toString())
+            : undefined,
           ipoCount30d: indicator.ipoCount30d || undefined,
-          creditSpreadBaa: indicator.creditSpreadBaa ? parseFloat(indicator.creditSpreadBaa.toString()) : undefined,
+          creditSpreadBaa: indicator.creditSpreadBaa
+            ? parseFloat(indicator.creditSpreadBaa.toString())
+            : undefined,
         });
 
         return {
           asOfDate,
           marketScore: scoreResult.score,
           vix: indicator.vix ? parseFloat(indicator.vix.toString()) : undefined,
-          fedFundsRate: indicator.fedFundsRate ? parseFloat(indicator.fedFundsRate.toString()) : undefined,
-          ust10yYield: indicator.ust10yYield ? parseFloat(indicator.ust10yYield.toString()) : undefined,
+          fedFundsRate: indicator.fedFundsRate
+            ? parseFloat(indicator.fedFundsRate.toString())
+            : undefined,
+          ust10yYield: indicator.ust10yYield
+            ? parseFloat(indicator.ust10yYield.toString())
+            : undefined,
           ipoCount30d: indicator.ipoCount30d || undefined,
-          creditSpreadBaa: indicator.creditSpreadBaa ? parseFloat(indicator.creditSpreadBaa.toString()) : undefined,
+          creditSpreadBaa: indicator.creditSpreadBaa
+            ? parseFloat(indicator.creditSpreadBaa.toString())
+            : undefined,
         };
       }
     } catch (error) {
@@ -418,12 +415,15 @@ export class BacktestRunner {
 
     // Fallback to synthetic market conditions
     const baseDate = new Date(asOfDate);
-    const dayOfYear = Math.floor((baseDate.getTime() - new Date(baseDate.getFullYear(), 0, 0).getTime()) / (1000 * 60 * 60 * 24));
-    
+    const dayOfYear = Math.floor(
+      (baseDate.getTime() - new Date(baseDate.getFullYear(), 0, 0).getTime()) /
+        (1000 * 60 * 60 * 24)
+    );
+
     // Generate somewhat realistic synthetic data with seasonality
-    const vix = 20 + Math.sin(dayOfYear / 365 * 2 * Math.PI) * 5 + (Math.random() - 0.5) * 10;
-    const fedFunds = 2.5 + Math.sin(dayOfYear / 365 * 2 * Math.PI) * 1.5;
-    
+    const vix = 20 + Math.sin((dayOfYear / 365) * 2 * Math.PI) * 5 + (Math.random() - 0.5) * 10;
+    const fedFunds = 2.5 + Math.sin((dayOfYear / 365) * 2 * Math.PI) * 1.5;
+
     const scoreResult = this.marketScorer.computeMarketScore({
       vix: Math.max(10, Math.min(40, vix)),
       fedFundsRate: Math.max(0, Math.min(6, fedFunds)),
@@ -459,16 +459,16 @@ export class BacktestRunner {
       };
     }
 
-    const errors = results.map(r => r.error);
-    const absErrors = errors.map(e => Math.abs(e));
-    const percentErrors = results.map(r => Math.abs(r.percentError));
-    const latencies = results.map(r => r.latencyMs);
+    const errors = results.map((r) => r.error);
+    const absErrors = errors.map((e) => Math.abs(e));
+    const percentErrors = results.map((r) => Math.abs(r.percentError));
+    const latencies = results.map((r) => r.latencyMs);
 
     // Sort for percentiles
     const sortedLatencies = [...latencies].sort((a, b) => a - b);
 
-    const shortfalls = results.filter(r => r.error < 0).length;
-    const overReserves = results.filter(r => r.error > r.actual * 0.25).length;
+    const shortfalls = results.filter((r) => r.error < 0).length;
+    const overReserves = results.filter((r) => r.error > r.actual * 0.25).length;
 
     const mse = errors.reduce((sum, e) => sum + e * e, 0) / errors.length;
     const mae = absErrors.reduce((sum, e) => sum + e, 0) / absErrors.length;
@@ -490,33 +490,41 @@ export class BacktestRunner {
 
   private generateRecommendations(engineResults: Record<string, EngineMetrics>): string[] {
     const recommendations: string[] = [];
-    
+
     const engines = Object.entries(engineResults);
     if (engines.length === 0) return recommendations;
 
     // Find best engine by RMSE
-    const bestRmse = engines.reduce((best, [name, metrics]) => 
+    const bestRmse = engines.reduce((best, [name, metrics]) =>
       metrics.rmse < best.metrics.rmse ? { name, metrics } : best
     );
 
-    recommendations.push(`Best accuracy: ${bestRmse.name} (RMSE: ${bestRmse.metrics.rmse.toFixed(0)})`);
+    recommendations.push(
+      `Best accuracy: ${bestRmse.name} (RMSE: ${bestRmse.metrics.rmse.toFixed(0)})`
+    );
 
     // Check latency
-    const bestLatency = engines.reduce((best, [name, metrics]) => 
+    const bestLatency = engines.reduce((best, [name, metrics]) =>
       metrics.avgLatencyMs < best.metrics.avgLatencyMs ? { name, metrics } : best
     );
 
     if (bestLatency.name !== bestRmse.name) {
-      recommendations.push(`Best latency: ${bestLatency.name} (${bestLatency.metrics.avgLatencyMs.toFixed(0)}ms avg)`);
+      recommendations.push(
+        `Best latency: ${bestLatency.name} (${bestLatency.metrics.avgLatencyMs.toFixed(0)}ms avg)`
+      );
     }
 
     // Risk recommendations
     engines.forEach(([name, metrics]) => {
       if (metrics.shortfallRate > 20) {
-        recommendations.push(`⚠️  ${name} has high shortfall rate (${metrics.shortfallRate.toFixed(1)}%)`);
+        recommendations.push(
+          `⚠️  ${name} has high shortfall rate (${metrics.shortfallRate.toFixed(1)}%)`
+        );
       }
       if (metrics.overReserveRate > 30) {
-        recommendations.push(`💰 ${name} tends to over-allocate (${metrics.overReserveRate.toFixed(1)}%)`);
+        recommendations.push(
+          `💰 ${name} tends to over-allocate (${metrics.overReserveRate.toFixed(1)}%)`
+        );
       }
     });
 
@@ -525,10 +533,10 @@ export class BacktestRunner {
 
   private parseCsv(content: string): Array<Record<string, string>> {
     const lines = content.trim().split('\n');
-    const headers = lines[0].split(',').map(h => h.trim());
-    
-    return lines.slice(1).map(line => {
-      const values = line.split(',').map(v => v.trim());
+    const headers = lines[0].split(',').map((h) => h.trim());
+
+    return lines.slice(1).map((line) => {
+      const values = line.split(',').map((v) => v.trim());
       const row: Record<string, string> = {};
       headers.forEach((header, i) => {
         row[header] = values[i] || '';
@@ -538,11 +546,7 @@ export class BacktestRunner {
   }
 
   private async saveResults(results: BacktestResult): Promise<void> {
-    await fs.writeFile(
-      this.config.outputFile!,
-      JSON.stringify(results, null, 2),
-      'utf-8'
-    );
+    await fs.writeFile(this.config.outputFile!, JSON.stringify(results, null, 2), 'utf-8');
     logger.info(`Backtest results saved to ${this.config.outputFile}`);
   }
 }
@@ -566,7 +570,7 @@ async function main() {
   const config: BacktestConfig = {
     from: values.from!,
     to: values.to!,
-    engines: (values.engine as string).split(',').map(e => e.trim()) as any[],
+    engines: (values.engine as string).split(',').map((e) => e.trim()) as any[],
     fundId: values.fundId,
     companiesFile: values.companiesFile,
     realizedFile: values.realizedFile,
@@ -584,10 +588,10 @@ async function main() {
   console.log('');
 
   const runner = new BacktestRunner(config);
-  
+
   try {
     const results = await runner.run();
-    
+
     console.log('📊 Results Summary');
     console.log('─'.repeat(50));
     console.log(`Total Periods: ${results.summary.totalPeriods}`);
@@ -610,12 +614,11 @@ async function main() {
     if (results.recommendations.length > 0) {
       console.log('💡 Recommendations');
       console.log('─'.repeat(50));
-      results.recommendations.forEach(rec => console.log(`  ${rec}`));
+      results.recommendations.forEach((rec) => console.log(`  ${rec}`));
       console.log('');
     }
 
     console.log('✅ Backtest completed successfully');
-
   } catch (error) {
     console.error('❌ Backtest failed:', error instanceof Error ? error.message : String(error));
     process.exit(1);
@@ -623,7 +626,7 @@ async function main() {
 }
 
 if (require.main === module) {
-  main().catch(error => {
+  main().catch((error) => {
     console.error('Fatal error:', error);
     process.exit(1);
   });

--- a/scripts/normalize-stages.ts
+++ b/scripts/normalize-stages.ts
@@ -27,7 +27,7 @@
  */
 
 import { Client, QueryResult } from 'pg';
-import { normalizeInvestmentStage } from '@shared/schemas/investment-stages';
+import { normalizeInvestmentStage } from '../server/utils/stage-utils.js';
 
 // ============================================================================
 // Configuration

--- a/tests/unit/circuit-breaker.test.ts
+++ b/tests/unit/circuit-breaker.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { CircuitBreakerCache } from '../../server/infra/circuit-breaker-cache';
-import type { Cache } from '../../server/infra/cache';
+
+type Cache = ConstructorParameters<typeof CircuitBreakerCache>[0];
 
 // Mock cache implementation for testing
 class MockCache implements Cache {

--- a/workers/cohort-worker.ts
+++ b/workers/cohort-worker.ts
@@ -1,4 +1,3 @@
-import { mapAsync } from '../../utils/async-iteration';
 import { Worker } from 'bullmq';
 import { logger } from '../lib/logger';
 import { resilientLimit } from '@shared/utils/resilientLimit';
@@ -22,7 +21,7 @@ const processCohortCompanies = async (companies: any[]) => {
 
   try {
     const results = await Promise.all(
-      await mapAsync(companies, (company) =>
+      companies.map((company) =>
         limit(async () => {
           // Simulate cohort analysis per company
           await new Promise((resolve) => setTimeout(resolve, 100));


### PR DESCRIPTION
## Summary

Repairs stale local import paths across four files, primarily `server/db/client.js` -> `server/db.js` (the former no longer exists), plus incidental formatting cleanup picked up by the same touch.

Verified independently before opening:
- `server/db.ts` exists; `server/db/client.ts` does not.
- No other file in the tree still references the stale `server/db/client` path.
- `npm run check` passes clean (0 new TypeScript errors).
- Targeted test for the touched files (`tests/unit/circuit-breaker.test.ts`) passes (9/9).

## Files changed

- `scripts/backtest.ts`
- `scripts/normalize-stages.ts`
- `tests/unit/circuit-breaker.test.ts`
- `workers/cohort-worker.ts`