### PR TITLE
docs(economics): record posted Deviation register comment URL

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -9335,6 +9335,6 @@ characterization lane, by design.
   default terms under the strict catch-up ruling of 2026-07-30 —
   `prefCatchUp: true` seed-refuses even with hurdle basis `'none'` —
   credit-facility phase [pending re-ratification], payload-only persistence,
-  union shape) is recorded in the spec's Deviation register — the user approved
-  posting the register on #1176 (2026-07-30); it posts once these documents are
-  committed.
+  union shape) is recorded in the spec's Deviation register — posted to #1176 on
+  2026-07-30 after these documents landed on main:
+  https://github.com/nikhillinit/Updog_restore/issues/1176#issuecomment-5129260472

--- a/docs/superpowers/specs/2026-07-30-task163-deal-by-deal-scoping-design.md
+++ b/docs/superpowers/specs/2026-07-30-task163-deal-by-deal-scoping-design.md
@@ -889,9 +889,10 @@ schema V1.1 plus engine/methodology version bump plan.
 
 Five ratified departures from issue #1176's Task 16.3 text plus one pending
 decision, in one place. Approval column: "ratified" = user-ratified 2026-07-30;
-"[PENDING]" = requires a user action. Posting to #1176: user-approved 2026-07-30
-(escalation E3, revised); the comment posts after the citing documents are
-committed, and the comment URL is recorded here once posted.
+"[PENDING]" = requires a user action. Posting to #1176: POSTED 2026-07-30
+(escalation E3, revised text) after commit `3298e10c` landed the citing
+documents:
+https://github.com/nikhillinit/Updog_restore/issues/1176#issuecomment-5129260472
 
 1. Exit gate "genuine Decimal-derived boundaries" -> amended to decimal-string
    boundaries plus `indicative` cap until the Decimal-native core certifies


### PR DESCRIPTION
Follow-up to #1245: the Task 16.3 Deviation register was posted to issue #1176 after that PR merged. This records the comment URL (https://github.com/nikhillinit/Updog_restore/issues/1176#issuecomment-5129260472) in the spec register preamble and the ADR-065 consequence line, closing the E3 posting loop. Docs-only, two lines of substance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)