### PR TITLE
fix(release): close production activation gate

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -8,9 +8,9 @@ on:
         type: string
         required: true
       deployment_url:
-        description: Staged Vercel production deployment URL for expected_sha
+        description: Legacy compatibility input; ignored by governed release
         type: string
-        required: true
+        required: false
 
 permissions:
   contents: read
@@ -53,9 +53,108 @@ jobs:
       expected_sha: ${{ inputs.expected_sha }}
     secrets: inherit
 
+  stage-production:
+    name: Create Staged Production Deployment
+    needs: schema-audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: Production
+    outputs:
+      deployment_url: ${{ steps.deploy.outputs.deployment_url }}
+    steps:
+      - name: Re-fence live main before staging
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if ! LIVE_MAIN="$(gh api "repos/${REPO}/commits/main" --jq '.sha')"; then
+            echo "::error::Could not resolve live main HEAD; refusing to stage (fail-closed)."
+            exit 1
+          fi
+          if [[ ! "$LIVE_MAIN" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Unexpected live main SHA '${LIVE_MAIN}'; refusing to stage (fail-closed)."
+            exit 1
+          fi
+          if [[ "$LIVE_MAIN" != "$EXPECTED_SHA" ]]; then
+            echo "::error::main advanced from ${EXPECTED_SHA} to ${LIVE_MAIN} during this release run; refusing to stage a stale target. Re-dispatch Release Production for the current main SHA."
+            exit 1
+          fi
+          echo "Live main still equals release target ${EXPECTED_SHA}; staging authorized."
+
+      - name: Checkout exact release commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.expected_sha }}
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '20.19.0'
+
+      - name: Verify checked-out release commit
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+        run: |
+          set -euo pipefail
+          ACTUAL_SHA="$(git rev-parse HEAD)"
+          if [[ "$ACTUAL_SHA" != "$EXPECTED_SHA" || "$GITHUB_SHA" != "$EXPECTED_SHA" ]]; then
+            echo "::error::Checked-out SHA does not match expected_sha."
+            exit 1
+          fi
+
+      - name: Create staged production deployment
+        id: deploy
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          : "${VERCEL_TOKEN:?VERCEL_TOKEN is required}"
+          : "${VERCEL_ORG_ID:?VERCEL_ORG_ID is required}"
+          : "${VERCEL_PROJECT_ID:?VERCEL_PROJECT_ID is required}"
+          DEPLOYMENT_URL="$(
+            npx --yes vercel@55.0.0 deploy \
+              --prod \
+              --skip-domain \
+              --yes \
+              --meta githubDeployment=1 \
+              --meta githubCommitRef=main \
+              --meta "githubCommitSha=${EXPECTED_SHA}"
+          )"
+          export DEPLOYMENT_URL
+          node <<'NODE'
+          const fs = require('node:fs');
+          const raw = process.env.DEPLOYMENT_URL ?? '';
+          const validShape =
+            /^https:\/\/[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.vercel\.app$/.test(raw);
+          if (!validShape) {
+            console.error('Vercel deploy must return one bare HTTPS vercel.app deployment URL.');
+            process.exit(1);
+          }
+          const url = new URL(raw);
+          const validUrl =
+            url.protocol === 'https:' &&
+            url.username === '' &&
+            url.password === '' &&
+            url.port === '' &&
+            url.pathname === '/' &&
+            url.search === '' &&
+            url.hash === '';
+          if (!validUrl) {
+            console.error('Staged deployment URL failed strict validation.');
+            process.exit(1);
+          }
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `deployment_url=${raw}\n`);
+          console.log('Staged production deployment created.');
+          NODE
+
   validate-deployment:
     name: Validate Staged Deployment Identity
-    needs: schema-audit
+    needs: stage-production
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: Production
@@ -86,7 +185,7 @@ jobs:
       - name: Normalize and verify exact staged deployment
         id: verify
         env:
-          DEPLOYMENT_URL: ${{ inputs.deployment_url }}
+          DEPLOYMENT_URL: ${{ needs.stage-production.outputs.deployment_url }}
           EXPECTED_SHA: ${{ inputs.expected_sha }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
@@ -135,6 +234,7 @@ jobs:
             deployment.projectId === process.env.VERCEL_PROJECT_ID &&
             deployment.meta?.githubCommitSha === process.env.EXPECTED_SHA &&
             deployment.meta?.githubCommitRef === 'main' &&
+            deployment.meta?.githubDeployment === '1' &&
             deploymentHost === requestedHost;
           if (!valid) {
             console.error('Staged deployment does not match the exact production release target.');
@@ -247,15 +347,14 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
-        # Vercel can auto-promote the merge-created deployment before this step runs
-        # (#1091); a bare `vercel promote` then 409s "already the current production
-        # deployment" and skips post-promotion smoke. Treat that case as a no-op
-        # success ONLY after independently confirming, via the Vercel API, that the
-        # deployment serving PRODUCTION_URL is the exact staged deployment this run
-        # verified. Any other promote failure stays fatal.
+        # A retry or concurrent governed release can find the verified deployment
+        # already serving production. Treat that promote failure as a no-op success
+        # ONLY after independently confirming, via the Vercel API, that PRODUCTION_URL
+        # resolves to the exact staged deployment this run verified. Any other
+        # promote failure stays fatal.
         run: |
           set -euo pipefail
-          if npx --yes vercel@55.0.0 promote "$DEPLOYMENT_URL" --yes --timeout=5m --token="$VERCEL_TOKEN"; then
+          if npx --yes vercel@55.0.0 promote "$DEPLOYMENT_URL" --yes --timeout=5m; then
             echo "Promoted $DEPLOYMENT_URL"
             exit 0
           fi

--- a/docs/BUILD_READINESS.md
+++ b/docs/BUILD_READINESS.md
@@ -1,6 +1,6 @@
 ---
 status: ACTIVE
-last_updated: 2026-07-12
+last_updated: 2026-07-30
 ---
 
 # Build Readiness Verification Report
@@ -89,17 +89,36 @@ DB-backed partial-drift reconciliation proof), a clean production schema audit
 (exactly one `SKIP` decision per manifest; workflow success alone is
 insufficient), and an authenticated smoke against the deployed application.
 
-`.github/workflows/release-production.yml` enforces the order against one exact
-main SHA: full release proof, clean production schema audit, authenticated smoke
-against the staged production deployment, Vercel promotion, then authenticated
-smoke against the canonical production URL. Both smoke passes require health,
-metrics, and dedicated login credentials before Playwright starts, so missing
-credentials cannot produce a skipped green run.
+`.github/workflows/release-production.yml` requires the exact current `main` SHA
+at dispatch, then enforces this order: full release proof, clean production
+schema audit, creation of a production-target Vercel deployment without domain
+assignment, exact deployment identity validation, authenticated staged smoke,
+Vercel promotion, then authenticated smoke against the canonical production URL.
+The workflow creates this staged deployment from the exact checked-out SHA with
+the pinned Vercel CLI only after the schema audit is clean. It rechecks live
+`main` before staging, deployment validation, staged smoke, and promotion.
+Post-promotion smoke validates the promoted deployment through the canonical
+alias rather than rechecking `main`. Both smoke passes require health, metrics,
+and dedicated login credentials before Playwright starts, so missing credentials
+cannot produce a skipped green run.
 
-Vercel's `Auto-assign Custom Production Domains` setting must remain disabled;
-otherwise the Git integration can bypass this workflow and serve a main-branch
-build before the schema audit. `Production` holds the promotion token and smoke
-credentials, while `production-schema` holds only `PRODUCTION_DATABASE_URL`.
+`vercel.json` owns the invariant `github.autoAlias=false`. It disables automatic
+alias assignment in version control so the Vercel Git integration cannot bypass
+the governed workflow and serve a main-branch build before the schema audit. Do
+not replace this code-owned control with a dashboard-only setting.
+
+The required post-merge production activation sequence is:
+
+```text
+schema apply when required -> clean audit -> stage production target -> validate identity -> staged smoke -> promote -> production smoke
+```
+
+`Release Production` must target the exact current `main` SHA. After the clean
+audit, it creates and validates the staged Vercel production deployment itself;
+caller-provided deployment URLs are ignored. The release workflow reads its
+deployment/promotion token and smoke credentials from `Production`; the
+prod-schema-reconcile workflow reads only `PRODUCTION_DATABASE_URL` from
+`production-schema`.
 
 ## Surface Status
 

--- a/docs/runbooks/rollback.md
+++ b/docs/runbooks/rollback.md
@@ -1,24 +1,90 @@
 ---
 status: ACTIVE
-last_updated: 2026-01-19
+last_updated: 2026-07-30
 ---
 
-# Rollback Procedure & Verification Checklist
+# Governed Production Forward Rollback
 
-## Auto-triggers
-- Burn-rate > 14.4× (1h) or p-value < 0.01 on canary; critical user flow down.
+Production rollback uses a new revert commit on `main`, then the existing
+`Release Production` workflow. It never deploys a detached historical commit,
+runs a down migration, flushes caches, or mutates production from a local
+script.
 
-## Execution
-- Record rollback tuple (git SHA + migration hash).
-- `scripts/rollback-verify.sh <SHA> <MIG_HASH>`
-- Flush caches; restart services.
+## Trigger and ownership
 
-## Verification (must pass)
-- `/ready` returns 200 for all deps
-- Wizard smoke test passes
-- Error rate < 1% for 10 minutes
-- Schema version matches target
-- Last deploy SHA attached to incident
+- Incident commander declares rollback when a critical user flow is unavailable
+  or release health breaches its approved rollback threshold.
+- Release owner coordinates revert review, merge, governed release, and evidence
+  capture.
+- Schema owner confirms compatibility before merge when reverted code touches
+  persisted data.
 
-## Post-mortem
-- 48h, blameless; list remediations and owners.
+## Required invariants
+
+1. Revert faulty application changes with a reviewed PR and merge that revert to
+   `main`.
+2. Treat resulting live `main` commit as rollback target. Do not reuse faulty
+   release's parent SHA or deploy from local checkout.
+3. Preserve current production schema. Confirm reverted application is backward
+   compatible with every already-applied migration and data shape.
+4. Do not run migration-down SQL. If current schema is incompatible with
+   reverted application, first merge a forward-compatible application repair;
+   escalate any later schema cleanup as separate reviewed forward migration.
+5. Use `.github/workflows/release-production.yml` as sole production mutation
+   path. `scripts/rollback-verify.sh` verifies evidence only.
+
+## Execute
+
+1. Open revert PR naming incident, faulty merge, affected application surfaces,
+   and intended rollback behavior.
+2. Record schema compatibility proof in PR:
+   - reverted readers tolerate current columns, tables, constraints, and
+     indexes;
+   - reverted writers remain valid against current schema;
+   - no migration-down or destructive DDL is required;
+   - any irreversible data change and resulting limitation is stated.
+3. Merge revert PR to `main`.
+4. Resolve exact live `main` SHA:
+
+   ```bash
+   REPOSITORY="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
+   REVERT_MAIN_SHA="$(gh api "repos/${REPOSITORY}/commits/main" --jq '.sha')"
+   ```
+
+5. Dispatch `Release Production` from `main` with
+   `expected_sha=${REVERT_MAIN_SHA}`. Do not use Vercel CLI or another
+   production mutation path.
+
+   ```bash
+   gh workflow run release-production.yml \
+     --ref main \
+     --field "expected_sha=${REVERT_MAIN_SHA}"
+   ```
+
+6. Wait for governed workflow to complete. It must retain exact live-`main`
+   fencing and pass release proof, clean production schema audit, staged
+   deployment identity validation, authenticated staged smoke, promotion, and
+   authenticated post-promotion smoke.
+7. Record numeric GitHub Actions run ID, then verify exact evidence:
+
+   ```bash
+   scripts/rollback-verify.sh "$REVERT_MAIN_SHA" "$RELEASE_RUN_ID"
+   ```
+
+   Any missing, ambiguous, stale, skipped, incomplete, or failed evidence is a
+   rollback verification failure.
+
+## Closeout evidence
+
+Attach following to incident:
+
+- revert PR and merged revert commit;
+- schema backward-compatibility review and explicit no-down-migration decision;
+- exact live `main` SHA used as `expected_sha`;
+- successful `Release Production` run URL;
+- successful staged identity, authenticated staged smoke, promotion, and
+  authenticated post-promotion smoke job URLs;
+- remaining impact, irreversible data limitations, and follow-up owners.
+
+Complete blameless postmortem within 48 hours. Track remediation owners and due
+dates outside this runbook.

--- a/docs/skills/REFL-041-production-activation-requires-schema-provisioning-proof.md
+++ b/docs/skills/REFL-041-production-activation-requires-schema-provisioning-proof.md
@@ -3,8 +3,8 @@ type: reflection
 id: REFL-041
 title: Production Activation Requires Schema Provisioning Proof
 status: VERIFIED
-date: 2026-07-27
-version: 1
+date: 2026-07-30
+version: 2
 severity: high
 wizard_steps: []
 error_codes: [ERR_SCHEMA_ACTIVATION_ORDER, ERR_UNPROVISIONED_DEPENDENCY]
@@ -18,6 +18,7 @@ keywords:
     exact-sha,
     manifest-apply,
     authenticated-smoke,
+    governed-promotion,
   ]
 test_file: tests/regressions/REFL-041.test.ts
 superseded_by: null
@@ -135,6 +136,25 @@ Use one of two safe release shapes:
    production. Merge route readers/writers only after the manifest is already
    `SKIP (shape-ok)`.
 
+This repository uses governed-only promotion. `vercel.json` owns the invariant
+`github.autoAlias=false`; do not replace it with a dashboard-only setting. The
+required post-merge activation sequence is:
+
+```text
+schema apply when required -> clean audit -> stage production target -> validate identity -> staged smoke -> promote -> production smoke
+```
+
+`Release Production` requires the exact current `main` SHA at dispatch and
+rechecks live `main` before staging, deployment validation, staged smoke, and
+promotion. After a clean schema audit, the workflow checks out the exact SHA and
+creates its own production-target Vercel deployment without assigning domains.
+It then validates that deployment's project, SHA, branch, metadata, target,
+host, and ready state before smoke. Caller-provided deployment URLs are ignored.
+Post-promotion smoke validates the promoted deployment through the canonical
+alias rather than rechecking `main`. Schema apply remains a separate, explicit
+action when audit identifies an authorized missing forward migration. Release
+dispatch follows only after a clean audit.
+
 Both shapes require:
 
 1. Pin exact application SHA and expected production database identity.
@@ -199,6 +219,8 @@ The governed recovery minimized blast radius:
 
 - Treat production manifest `SKIP (shape-ok)` as evidence required before
   activating any schema-backed consumer.
+- Preserve `vercel.json.github.autoAlias=false` as the code-owned activation
+  invariant.
 - Record exact SHA, database identity, manifest, delta tuple, transaction
   result, final audit, and authenticated canary as one release proof chain.
 - Split schema provisioning from feature activation when hosting auto-promotion
@@ -224,15 +246,15 @@ The governed recovery minimized blast radius:
 
 | Action                                                                                                                                                                                       | Owner                  | Due                                        | Binary success measure                                                                                                             | Status |
 | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- | ------ |
-| Make every production-serving path respect schema proof: either disable Vercel merge auto-promotion or require schema-first dormant PRs.                                                     | Release owner          | Before next schema-backed route activation | No schema-backed consumer can serve before exact-target manifest audit is clean.                                                   | OPEN   |
+| Make every production-serving path respect schema proof: disable Vercel merge auto-aliasing and require governed promotion after schema proof.                                               | Release owner          | Before next schema-backed route activation | `vercel.json.github.autoAlias=false`; governed exact-SHA release requires clean schema audit before staged smoke and promotion.    | DONE   |
 | Harden `prod-schema-reconcile` apply authorization with expected database identity, expected manifest, exact allowed delta kinds/names, and one advisory-lock audit/apply decision boundary. | Schema/reconcile owner | Before next production schema apply        | Negative tests reject wrong database, extra manifest/table, shape repair, drop, or audit/apply drift; intended exact tuple passes. | OPEN   |
 | Add authenticated read-only internal-analysis production canary and pin its manifest/migration mapping.                                                                                      | Feature owner          | This reflection closeout                   | `REFL-041.test.ts` passes and production smoke requires `200` plus JSON `drafts` from `/api/funds/1/internal-analysis/drafts`.     | DONE   |
 
 **Follow-up:** Review at the next schema-backed release gate. Current
-completion: `1/3` (33%). Required before that activation: `3/3` (100%),
-exceeding the retrospective action-completion target of 80%. Open actions do not
-roll forward silently; release owner must block activation or explicitly
-re-scope with new evidence.
+completion: `2/3` (67%). Production activation remains blocked until the
+required sequence completes for the exact release SHA. Remaining reconcile
+authorization hardening does not roll forward silently; schema/reconcile owner
+must block any apply or explicitly re-scope it with new evidence.
 
 ## 3. Evidence
 
@@ -252,5 +274,8 @@ re-scope with new evidence.
   to the exact six-table production manifest and requires an authenticated
   read-only internal-analysis canary in
   `tests/smoke/production-boundaries.spec.ts`.
+- **Activation guard:** `vercel.json.github.autoAlias=false` prevents the Git
+  integration from automatically assigning production aliases; the governed
+  workflow owns staged smoke, promotion, and production smoke.
 - **Related:** REFL-040 (cross-worktree environment parity); Task 11 governed
   schema/release closeout.

--- a/scripts/DEPLOYMENT_AUTOMATION_README.md
+++ b/scripts/DEPLOYMENT_AUTOMATION_README.md
@@ -1,6 +1,7 @@
 # Deployment Automation Scripts
 
-Complete automation for deploying CODEX fixes to staging and production with comprehensive smoke tests and security monitoring.
+Complete automation for deploying CODEX fixes to staging and production with
+comprehensive smoke tests and security monitoring.
 
 ## 📋 Overview
 
@@ -9,7 +10,7 @@ These PowerShell scripts automate the entire deployment pipeline:
 1. **Deploy to Staging** → Automated deployment with health checks
 2. **Smoke Tests** → Verify all CODEX fixes work correctly
 3. **Monitor Logs** → Security checks and password masking verification
-4. **Deploy to Production** → Safe production rollout with rollback support
+4. **Release Production** → Dispatch governed exact-`main` release workflow
 
 ---
 
@@ -27,7 +28,7 @@ These PowerShell scripts automate the entire deployment pipeline:
 # 3. Monitor logs for security issues
 .\scripts\monitor-logs.ps1 -Environment staging -Minutes 5
 
-# 4. Deploy to production (after verification)
+# 4. Dispatch governed production release (after verification)
 .\scripts\deploy-production.ps1
 ```
 
@@ -40,15 +41,18 @@ These PowerShell scripts automate the entire deployment pipeline:
 Deploys code to Vercel staging environment with automated checks.
 
 #### Usage
+
 ```powershell
 .\scripts\deploy-staging.ps1 [-SkipBuild] [-Verbose]
 ```
 
 #### Parameters
+
 - `-SkipBuild` - Skip build and tests (use for hotfixes)
 - `-Verbose` - Show detailed output
 
 #### What It Does
+
 1. ✅ Pre-deployment checks (git status, branch verification)
 2. 🧪 Runs unit tests (125 tests)
 3. 🔨 Builds application
@@ -57,6 +61,7 @@ Deploys code to Vercel staging environment with automated checks.
 6. 🔐 Checks logs for password masking
 
 #### Example
+
 ```powershell
 # Standard deployment
 .\scripts\deploy-staging.ps1
@@ -75,45 +80,54 @@ Deploys code to Vercel staging environment with automated checks.
 Comprehensive smoke tests verifying all CODEX fixes.
 
 #### Usage
+
 ```powershell
 .\scripts\smoke-test.ps1 -BaseUrl "https://your-app.vercel.app" [-Verbose]
 ```
 
 #### Parameters
+
 - `-BaseUrl` (required) - Deployment URL to test
 - `-Verbose` - Show detailed output
 
 #### Test Suites
 
 **Suite 1: Health & Infrastructure**
+
 - ✅ Health endpoint responds
 - ✅ Redis connection verified
 
 **Suite 2: Fee Calculations (P0 Fix)**
+
 - ⚠️ Manual verification required
 - Navigate to fund setup UI and verify:
   - 2% annual fee → 20% total drag (not 0.2%)
   - Fee calculations use fractions correctly
 
 **Suite 3: Reserve API (P1 Fix - Date Schema)**
+
 - ✅ Accepts ISO date strings (`"2023-10-27T10:00:00.000Z"`)
 - ✅ Returns reserve allocations
 - ✅ Handles portfolio of 4+ companies
 
 **Suite 4: Pagination (P1 Fix - Portfolio Truncation)**
+
 - ✅ Respects `limit` parameter (was hard-coded to 3)
 - ✅ Returns all companies when limit > portfolio size
 - ✅ Pagination works correctly
 
 **Suite 5: Query Parameters (P2 Fix)**
+
 - ✅ Boolean strings parsed (`"true"` → `true`)
 - ✅ Enum values case-insensitive (`"HIGH"` → `"high"`)
 
 **Suite 6: Security**
+
 - ✅ No passwords in API responses
 - ✅ Redis credentials masked in logs
 
 #### Example
+
 ```powershell
 # Run all smoke tests
 .\scripts\smoke-test.ps1 -BaseUrl "https://updog-staging.vercel.app"
@@ -123,6 +137,7 @@ Comprehensive smoke tests verifying all CODEX fixes.
 ```
 
 #### Exit Codes
+
 - `0` - All tests passed
 - `1` - One or more tests failed
 
@@ -133,11 +148,13 @@ Comprehensive smoke tests verifying all CODEX fixes.
 Monitors deployment logs and performs security checks.
 
 #### Usage
+
 ```powershell
 .\scripts\monitor-logs.ps1 [-Environment staging|production] [-Minutes 5] [-Follow] [-CheckSecurity]
 ```
 
 #### Parameters
+
 - `-Environment` - Which environment to monitor (default: `staging`)
 - `-Minutes` - Time window in minutes (default: `5`)
 - `-Follow` - Continuous monitoring (Ctrl+C to stop)
@@ -166,6 +183,7 @@ Monitors deployment logs and performs security checks.
    - ❌ Detects "Redis Client Error" messages
 
 #### Examples
+
 ```powershell
 # Monitor staging for last 5 minutes
 .\scripts\monitor-logs.ps1 -Environment staging
@@ -184,59 +202,27 @@ Monitors deployment logs and performs security checks.
 
 ### **4. deploy-production.ps1**
 
-Safe production deployment with rollback support.
+Fail-closed dispatcher for `.github/workflows/release-production.yml`. It reads
+exact live `main` SHA from GitHub, validates SHA shape, and dispatches governed
+release with that SHA. Workflow owns release proof, schema audit, staged
+production-target creation, identity validation, smoke, promotion, and
+post-promotion smoke.
 
 #### Usage
+
 ```powershell
-.\scripts\deploy-production.ps1 [-SkipSmokeTest] [-Force]
+.\scripts\deploy-production.ps1
 ```
-
-#### Parameters
-- `-SkipSmokeTest` - Skip smoke tests after deployment
-- `-Force` - Skip safety confirmations (use with caution!)
-
-#### Safety Features
-
-**Pre-deployment Confirmations**
-1. ✅ Smoke tests passed in staging?
-2. ✅ Team members notified?
-3. ✅ Type "DEPLOY" to confirm
-
-**Rollback Protection**
-- Captures current production URL before deployment
-- Provides rollback command if anything fails
-- Automatic rollback instructions if health checks fail
 
 #### What It Does
-1. 📋 Pre-deployment checks
-2. 🧪 Final test suite run
-3. 🔨 Production build
-4. 🚀 Deploy to Vercel production
-5. ✅ Post-deployment verification (health + Redis)
-6. 🧪 Smoke tests (unless skipped)
-7. 📊 Initial monitoring
 
-#### Examples
-```powershell
-# Standard production deployment
-.\scripts\deploy-production.ps1
+1. Resolves repository with authenticated GitHub CLI.
+2. Resolves exact live `main` SHA through GitHub API.
+3. Rejects missing or malformed SHA.
+4. Dispatches `release-production.yml` from `main` with `expected_sha`.
 
-# Skip smoke tests (if already verified)
-.\scripts\deploy-production.ps1 -SkipSmokeTest
-
-# Force deployment (no confirmations)
-.\scripts\deploy-production.ps1 -Force
-```
-
-#### Rollback
-If deployment fails or issues are detected:
-
-```powershell
-# Rollback to previous deployment
-vercel rollback <previous-url> --yes
-```
-
-The script automatically provides the rollback command in case of failure.
+No skip or force options exist. Script never invokes Vercel production commands;
+governed workflow is sole production-mutation path.
 
 ---
 
@@ -363,12 +349,14 @@ client.on('connect', () => {
 Use this checklist for each deployment:
 
 ### **Pre-Deployment**
+
 - [ ] All CODEX fixes merged to main branch
 - [ ] 125 unit tests passing locally
 - [ ] TypeScript compiles without errors
 - [ ] Environment variables configured in Vercel
 
 ### **Staging Deployment**
+
 - [ ] Run `.\scripts\deploy-staging.ps1`
 - [ ] Verify deployment URL works
 - [ ] Run `.\scripts\smoke-test.ps1` with staging URL
@@ -377,6 +365,7 @@ Use this checklist for each deployment:
 - [ ] No security issues detected
 
 ### **Production Deployment**
+
 - [ ] Team notified of deployment
 - [ ] All staging tests passed
 - [ ] Run `.\scripts\deploy-production.ps1`
@@ -387,6 +376,7 @@ Use this checklist for each deployment:
 - [ ] No errors in production logs
 
 ### **Post-Deployment**
+
 - [ ] Monitor error rates in Vercel dashboard
 - [ ] Check Redis connection metrics
 - [ ] Verify no password exposure in logs
@@ -397,20 +387,22 @@ Use this checklist for each deployment:
 
 ## 🎯 What Each Script Verifies
 
-| Fix | Script | Verification Method |
-|-----|--------|-------------------|
-| **P0 - Fee Calculation** | smoke-test.ps1 | Manual UI verification required |
-| **P1 - Redis Factory** | deploy-staging.ps1<br>monitor-logs.ps1 | Health endpoint<br>Log password masking |
-| **P1 - Portfolio Truncation** | smoke-test.ps1 | API returns >3 companies |
-| **P1 - Date Schema** | smoke-test.ps1 | API accepts ISO strings |
-| **P2 - Query Params** | smoke-test.ps1 | Boolean/enum parsing |
+| Fix                           | Script                                 | Verification Method                     |
+| ----------------------------- | -------------------------------------- | --------------------------------------- |
+| **P0 - Fee Calculation**      | smoke-test.ps1                         | Manual UI verification required         |
+| **P1 - Redis Factory**        | deploy-staging.ps1<br>monitor-logs.ps1 | Health endpoint<br>Log password masking |
+| **P1 - Portfolio Truncation** | smoke-test.ps1                         | API returns >3 companies                |
+| **P1 - Date Schema**          | smoke-test.ps1                         | API accepts ISO strings                 |
+| **P2 - Query Params**         | smoke-test.ps1                         | Boolean/enum parsing                    |
 
 ---
 
 ## 📚 Additional Resources
 
-- [CODEX_FIXES_COMPLETE.md](../CODEX_FIXES_COMPLETE.md) - Complete fix documentation
-- [REDIS_FACTORY_UPGRADE_SUMMARY.md](../REDIS_FACTORY_UPGRADE_SUMMARY.md) - Redis-specific details
+- [CODEX_FIXES_COMPLETE.md](../CODEX_FIXES_COMPLETE.md) - Complete fix
+  documentation
+- [REDIS_FACTORY_UPGRADE_SUMMARY.md](../REDIS_FACTORY_UPGRADE_SUMMARY.md) -
+  Redis-specific details
 - [Vercel Documentation](https://vercel.com/docs) - Deployment platform docs
 
 ---
@@ -427,6 +419,5 @@ If you encounter issues:
 
 ---
 
-**Generated**: 2025-01-04
-**Version**: 1.0.0
-**Compatibility**: Windows PowerShell 5.1+, PowerShell Core 7+
+**Generated**: 2025-01-04 **Version**: 1.0.0 **Compatibility**: Windows
+PowerShell 5.1+, PowerShell Core 7+

--- a/scripts/deploy-production.ps1
+++ b/scripts/deploy-production.ps1
@@ -1,193 +1,35 @@
-# Deploy to Production - Automated Script
-# Purpose: Deploy to production with safety checks and rollback plan
-
-param(
-    [switch]$SkipSmokeTest = $false,
-    [switch]$Force = $false
-)
+# Dispatch governed production release for exact live main.
 
 $ErrorActionPreference = "Stop"
 
-Write-Host "🚀 Production Deployment Script" -ForegroundColor Cyan
-Write-Host "================================" -ForegroundColor Cyan
-Write-Host ""
-Write-Host "⚠️  WARNING: This will deploy to PRODUCTION!" -ForegroundColor Red
-Write-Host ""
-
-# Safety confirmation
-if (-not $Force) {
-    Write-Host "Please confirm the following:" -ForegroundColor Yellow
-    Write-Host "  1. All smoke tests passed in staging? (y/n): " -NoNewline
-    $smokeTestsPassed = Read-Host
-    if ($smokeTestsPassed -ne "y") {
-        Write-Host "❌ Deployment cancelled. Run smoke tests first." -ForegroundColor Red
-        exit 1
-    }
-
-    Write-Host "  2. All team members notified? (y/n): " -NoNewline
-    $teamNotified = Read-Host
-    if ($teamNotified -ne "y") {
-        Write-Host "⚠️  Please notify team before production deployment" -ForegroundColor Yellow
-        $continue = Read-Host "  Continue anyway? (y/n)"
-        if ($continue -ne "y") {
-            exit 1
-        }
-    }
-
-    Write-Host "  3. Ready to deploy? Type 'DEPLOY' to confirm: " -NoNewline
-    $confirmation = Read-Host
-    if ($confirmation -ne "DEPLOY") {
-        Write-Host "❌ Deployment cancelled" -ForegroundColor Red
-        exit 1
-    }
-}
-
-Write-Host ""
-Write-Host "✅ Proceeding with production deployment..." -ForegroundColor Green
-Write-Host ""
-
-# Step 1: Pre-deployment checks
-Write-Host "📋 Step 1: Pre-deployment Checks" -ForegroundColor Yellow
-Write-Host ""
-
-# Get current production deployment (for rollback)
-Write-Host "  Fetching current production deployment info..." -ForegroundColor White
-$currentProduction = vercel ls --prod --meta environment=production | Select-String -Pattern "https://.*\.vercel\.app" | Select-Object -First 1
-Write-Host "  Current production: $currentProduction" -ForegroundColor Gray
-Write-Host "  (Saved for potential rollback)" -ForegroundColor Gray
-Write-Host ""
-
-# Run final tests
-Write-Host "  Running final test suite..." -ForegroundColor White
-npm run test:unit -- tests/unit/units.test.ts tests/unit/unit-schemas.test.ts tests/unit/fees.test.ts tests/unit/redis-factory.test.ts
-
-if ($LASTEXITCODE -ne 0) {
-    Write-Host "  ❌ Tests failed! Aborting deployment." -ForegroundColor Red
-    exit 1
-}
-Write-Host "  ✅ Tests passed" -ForegroundColor Green
-Write-Host ""
-
-# Step 2: Build
-Write-Host "🔨 Step 2: Production Build" -ForegroundColor Yellow
-Write-Host ""
-
-Write-Host "  Building for production..." -ForegroundColor White
-$env:NODE_ENV = "production"
-npm run build
-
-if ($LASTEXITCODE -ne 0) {
-    Write-Host "  ❌ Build failed! Aborting deployment." -ForegroundColor Red
-    exit 1
-}
-Write-Host "  ✅ Build completed" -ForegroundColor Green
-Write-Host ""
-
-# Step 3: Deploy
-Write-Host "🚀 Step 3: Deploying to Production" -ForegroundColor Yellow
-Write-Host ""
-
-$deploymentStartTime = Get-Date
-Write-Host "  Deployment started at: $deploymentStartTime" -ForegroundColor White
-Write-Host "  Deploying to Vercel production..." -ForegroundColor White
-
-vercel --prod --yes
-
-if ($LASTEXITCODE -ne 0) {
-    Write-Host "  ❌ Deployment failed!" -ForegroundColor Red
-    Write-Host ""
-    Write-Host "Rollback instructions:" -ForegroundColor Yellow
-    Write-Host "  vercel rollback $currentProduction --yes" -ForegroundColor White
+if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+    Write-Error "GitHub CLI (gh) is required."
     exit 1
 }
 
-$deploymentEndTime = Get-Date
-$deploymentDuration = $deploymentEndTime - $deploymentStartTime
-
-# Get new production URL
-$productionUrl = vercel ls --prod | Select-String -Pattern "https://.*\.vercel\.app" | Select-Object -First 1
-
-Write-Host "  ✅ Deployed in $($deploymentDuration.TotalSeconds) seconds" -ForegroundColor Green
-Write-Host "  Production URL: $productionUrl" -ForegroundColor White
-Write-Host ""
-
-# Step 4: Post-deployment verification
-Write-Host "✅ Step 4: Post-deployment Verification" -ForegroundColor Yellow
-Write-Host ""
-
-Write-Host "  Waiting 10 seconds for deployment to stabilize..." -ForegroundColor White
-Start-Sleep -Seconds 10
-
-Write-Host "  Checking health endpoint..." -ForegroundColor White
-try {
-    $healthCheck = Invoke-RestMethod -Uri "$productionUrl/api/health" -TimeoutSec 10
-    if ($healthCheck.status -eq "healthy") {
-        Write-Host "  ✅ Health check passed" -ForegroundColor Green
-    } else {
-        Write-Host "  ⚠️  Health check returned: $($healthCheck.status)" -ForegroundColor Yellow
-    }
-
-    if ($healthCheck.redis -and $healthCheck.redis.status -eq "connected") {
-        Write-Host "  ✅ Redis connected" -ForegroundColor Green
-    } else {
-        Write-Host "  ⚠️  Redis status: $($healthCheck.redis.status)" -ForegroundColor Yellow
-    }
-} catch {
-    Write-Host "  ❌ Health check failed: $($_.Exception.Message)" -ForegroundColor Red
-    Write-Host ""
-    Write-Host "⚠️  Deployment succeeded but health check failed!" -ForegroundColor Yellow
-    Write-Host "Consider rolling back:" -ForegroundColor Yellow
-    Write-Host "  vercel rollback $currentProduction --yes" -ForegroundColor White
+$repository = gh repo view --json nameWithOwner --jq ".nameWithOwner"
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($repository)) {
+    Write-Error "Could not resolve current GitHub repository."
+    exit 1
 }
-Write-Host ""
+$repository = $repository.Trim()
 
-# Step 5: Run smoke tests (if not skipped)
-if (-not $SkipSmokeTest) {
-    Write-Host "🧪 Step 5: Running Production Smoke Tests" -ForegroundColor Yellow
-    Write-Host ""
-
-    & "$PSScriptRoot\smoke-test.ps1" -BaseUrl $productionUrl
-
-    if ($LASTEXITCODE -ne 0) {
-        Write-Host ""
-        Write-Host "⚠️  Smoke tests failed!" -ForegroundColor Yellow
-        Write-Host "Production is deployed but may have issues." -ForegroundColor Yellow
-        Write-Host ""
-        Write-Host "Rollback command:" -ForegroundColor Yellow
-        Write-Host "  vercel rollback $currentProduction --yes" -ForegroundColor White
-    }
+$expectedSha = gh api "repos/$repository/commits/main" --jq ".sha"
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($expectedSha)) {
+    Write-Error "Could not resolve live main SHA."
+    exit 1
 }
-Write-Host ""
+$expectedSha = $expectedSha.Trim()
 
-# Step 6: Monitor
-Write-Host "📊 Step 6: Initial Monitoring" -ForegroundColor Yellow
-Write-Host ""
-
-Write-Host "  Fetching initial production logs..." -ForegroundColor White
-& "$PSScriptRoot\monitor-logs.ps1" -Environment production -Minutes 2
-
-Write-Host ""
-
-# Success summary
-Write-Host "✅ Production Deployment Complete!" -ForegroundColor Green
-Write-Host "===================================" -ForegroundColor Green
-Write-Host ""
-Write-Host "  Deployment URL: $productionUrl" -ForegroundColor White
-Write-Host "  Previous deployment: $currentProduction" -ForegroundColor Gray
-Write-Host "  Deployment time: $($deploymentDuration.TotalSeconds) seconds" -ForegroundColor White
-Write-Host ""
-Write-Host "Post-deployment checklist:" -ForegroundColor Yellow
-Write-Host "  ✅ Health check passed" -ForegroundColor Green
-Write-Host "  ✅ Redis connected" -ForegroundColor Green
-if (-not $SkipSmokeTest) {
-    Write-Host "  ✅ Smoke tests passed" -ForegroundColor Green
+if ($expectedSha -notmatch "^[0-9a-f]{40}$") {
+    Write-Error "Live main returned invalid SHA '$expectedSha'."
+    exit 1
 }
-Write-Host ""
-Write-Host "Monitoring:" -ForegroundColor Yellow
-Write-Host "  - Continuous logs: .\scripts\monitor-logs.ps1 -Follow -Environment production" -ForegroundColor White
-Write-Host "  - Vercel dashboard: https://vercel.com/dashboard" -ForegroundColor White
-Write-Host ""
-Write-Host "Rollback (if needed):" -ForegroundColor Yellow
-Write-Host "  vercel rollback $currentProduction --yes" -ForegroundColor White
-Write-Host ""
-Write-Host "🎉 Deployment successful! Monitor closely for the next 30 minutes." -ForegroundColor Cyan
+
+gh workflow run release-production.yml --ref main --field "expected_sha=$expectedSha" --repo $repository
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Release Production dispatch failed."
+    exit 1
+}
+
+Write-Host "Release Production dispatched for exact live main SHA $expectedSha."

--- a/scripts/prod-schema-apply-policy.mjs
+++ b/scripts/prod-schema-apply-policy.mjs
@@ -1,7 +1,11 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { ReconcileError, splitSqlStatements } from './reconcile-prod-schema.mjs';
+import {
+  ReconcileError,
+  splitSqlStatements,
+  validateNonNullColumnAddPolicy,
+} from './reconcile-prod-schema.mjs';
 
 const DANGEROUS_STATEMENT_PATTERNS = [
   {
@@ -52,17 +56,29 @@ export function assertApplyPolicyForManifests({
 
   for (const manifest of manifests) {
     if (!applying.has(manifest.name)) continue;
+    const manifestSql = [];
     for (const sqlFile of manifest.sqlFiles ?? []) {
       const sql = fs.readFileSync(path.resolve(rootDir, sqlFile), 'utf8');
-      violations.push(...validateSqlApplyPolicy({ manifest, sqlFile, sql }));
+      manifestSql.push(sql);
+      violations.push(...validateSqlStatementPolicy({ manifest, sqlFile, sql }));
     }
+    violations.push(
+      ...validateNonNullColumnAddPolicy(
+        manifest,
+        manifestSql.map((sql, index) => ({
+          path: manifest.sqlFiles[index],
+          sql,
+        }))
+      )
+    );
     if ((manifest.dropObjects ?? []).length > 0) {
       violations.push({
         manifest: manifest.name,
         file: '<dropObjects>',
         kind: 'drop-objects',
         statement: 'dropObjects',
-        reason: 'dropObjects are explicit removals and cannot run in additive-safe production apply',
+        reason:
+          'dropObjects are explicit removals and cannot run in additive-safe production apply',
       });
     }
   }
@@ -78,6 +94,13 @@ export function assertApplyPolicyForManifests({
 }
 
 export function validateSqlApplyPolicy({ manifest, sqlFile, sql }) {
+  return [
+    ...validateSqlStatementPolicy({ manifest, sqlFile, sql }),
+    ...validateNonNullColumnAddPolicy(manifest, [{ path: sqlFile, sql }]),
+  ];
+}
+
+function validateSqlStatementPolicy({ manifest, sqlFile, sql }) {
   const statements = splitSqlStatements(sql)
     .map((statement) => stripSqlComments(statement).trim())
     .filter(Boolean);
@@ -140,7 +163,11 @@ function validateStatementApplyPolicy({ manifest, sqlFile, statement }) {
   }
 
   for (const dropToken of findDropTokens(statement)) {
-    if (!recognizedDropSpans.some((span) => dropToken.index >= span.start && dropToken.index < span.end)) {
+    if (
+      !recognizedDropSpans.some(
+        (span) => dropToken.index >= span.start && dropToken.index < span.end
+      )
+    ) {
       violations.push({
         manifest: manifest.name,
         file: sqlFile,
@@ -213,9 +240,7 @@ function extractDropNotNulls(statement) {
   if (!tableName) return [];
 
   return [
-    ...statement.matchAll(
-      /\bALTER\s+COLUMN\s+"?([a-z_][a-z0-9_]*)"?\s+DROP\s+NOT\s+NULL\b/gi
-    ),
+    ...statement.matchAll(/\bALTER\s+COLUMN\s+"?([a-z_][a-z0-9_]*)"?\s+DROP\s+NOT\s+NULL\b/gi),
   ].map((match) => ({
     table: tableName,
     column: match[1],

--- a/scripts/prod-schema-manifests/19-user-identity-grants-revocation.json
+++ b/scripts/prod-schema-manifests/19-user-identity-grants-revocation.json
@@ -4,6 +4,15 @@
   "missingTablePolicy": "create_or_repair",
   "sqlFiles": ["migrations/0031_user_identity_grants_revocation.sql"],
   "allowedCreateTables": ["user_fund_grants", "revoked_tokens"],
+  "applyPolicy": {
+    "allowNonNullColumnAdds": [
+      { "table": "users", "column": "role" },
+      { "table": "users", "column": "is_active" },
+      { "table": "users", "column": "password_updated_at" },
+      { "table": "users", "column": "created_at" },
+      { "table": "users", "column": "updated_at" }
+    ]
+  },
   "expectedTables": [
     {
       "name": "users",

--- a/scripts/prod-schema-manifests/19-user-identity-grants-revocation.json
+++ b/scripts/prod-schema-manifests/19-user-identity-grants-revocation.json
@@ -1,0 +1,53 @@
+{
+  "name": "user-identity-grants-revocation",
+  "order": 19,
+  "missingTablePolicy": "create_or_repair",
+  "sqlFiles": ["migrations/0031_user_identity_grants_revocation.sql"],
+  "allowedCreateTables": ["user_fund_grants", "revoked_tokens"],
+  "expectedTables": [
+    {
+      "name": "users",
+      "sharedTable": true,
+      "columns": [
+        { "name": "role", "type": "varchar", "nullable": false },
+        { "name": "is_active", "type": "boolean", "nullable": false },
+        {
+          "name": "password_updated_at",
+          "type": "timestamptz",
+          "nullable": false
+        },
+        { "name": "created_at", "type": "timestamptz", "nullable": false },
+        { "name": "updated_at", "type": "timestamptz", "nullable": false }
+      ],
+      "constraints": ["users_role_check"]
+    },
+    {
+      "name": "user_fund_grants",
+      "columns": [
+        { "name": "user_id", "type": "integer", "nullable": false },
+        { "name": "fund_id", "type": "integer", "nullable": false },
+        { "name": "created_at", "type": "timestamptz", "nullable": false }
+      ],
+      "constraints": [
+        "user_fund_grants_pkey",
+        "user_fund_grants_user_id_users_id_fk",
+        "user_fund_grants_fund_id_funds_id_fk"
+      ]
+    },
+    {
+      "name": "revoked_tokens",
+      "columns": [
+        { "name": "jti", "type": "varchar", "nullable": false },
+        { "name": "user_id", "type": "integer", "nullable": false },
+        { "name": "revoked_at", "type": "timestamptz", "nullable": false },
+        { "name": "expires_at", "type": "timestamptz", "nullable": false },
+        { "name": "reason", "type": "varchar", "nullable": true }
+      ],
+      "constraints": [
+        "revoked_tokens_pkey",
+        "revoked_tokens_user_id_users_id_fk"
+      ],
+      "indexes": ["revoked_tokens_expires_at_idx"]
+    }
+  ]
+}

--- a/scripts/prod-schema-manifests/20-company-scenario-create-requests.json
+++ b/scripts/prod-schema-manifests/20-company-scenario-create-requests.json
@@ -1,0 +1,39 @@
+{
+  "name": "company-scenario-create-requests",
+  "order": 20,
+  "missingTablePolicy": "create_or_repair",
+  "sqlFiles": ["migrations/0033_company_scenario_create_requests.sql"],
+  "allowedCreateTables": ["company_scenario_create_requests"],
+  "expectedTables": [
+    {
+      "name": "company_scenario_create_requests",
+      "columns": [
+        { "name": "id", "type": "integer", "nullable": false },
+        { "name": "fund_id", "type": "integer", "nullable": false },
+        { "name": "company_id", "type": "integer", "nullable": false },
+        { "name": "scenario_id", "type": "uuid", "nullable": true },
+        { "name": "idempotency_key", "type": "varchar", "nullable": false },
+        { "name": "request_hash", "type": "character", "nullable": false },
+        { "name": "created_by", "type": "integer", "nullable": true },
+        { "name": "status", "type": "varchar", "nullable": false },
+        { "name": "response_status", "type": "integer", "nullable": true },
+        { "name": "response_body", "type": "jsonb", "nullable": true },
+        { "name": "created_at", "type": "timestamptz", "nullable": false },
+        { "name": "updated_at", "type": "timestamptz", "nullable": false }
+      ],
+      "constraints": [
+        "company_scenario_create_requests_pkey",
+        "company_scenario_create_requests_fund_idempotency_key_unique",
+        "company_scenario_create_requests_status_check",
+        "company_scenario_create_requests_fund_id_funds_id_fk",
+        "company_scenario_create_requests_company_id_portfoliocompanies_id_fk",
+        "company_scenario_create_requests_scenario_id_scenarios_id_fk",
+        "company_scenario_create_requests_created_by_users_id_fk"
+      ],
+      "indexes": [
+        "company_scenario_create_requests_company_idx",
+        "company_scenario_create_requests_scenario_idx"
+      ]
+    }
+  ]
+}

--- a/scripts/prod-schema-manifests/21-business-time-comparison-lineage.json
+++ b/scripts/prod-schema-manifests/21-business-time-comparison-lineage.json
@@ -1,0 +1,74 @@
+{
+  "name": "business-time-comparison-lineage",
+  "order": 21,
+  "missingTablePolicy": "existing_table_required",
+  "sqlFiles": ["migrations/0034_business_time_comparison_lineage.sql"],
+  "allowedCreateTables": [],
+  "expectedTables": [
+    {
+      "name": "calc_runs",
+      "sharedTable": true,
+      "columns": [
+        {
+          "name": "model_inputs_as_of_date",
+          "type": "date",
+          "nullable": true
+        },
+        {
+          "name": "comparison_lineage_version",
+          "type": "varchar",
+          "nullable": true
+        }
+      ],
+      "constraints": ["calc_runs_comparison_lineage_check"]
+    },
+    {
+      "name": "fund_scenario_calculation_runs",
+      "sharedTable": true,
+      "columns": [
+        {
+          "name": "model_inputs_as_of_date",
+          "type": "date",
+          "nullable": true
+        },
+        {
+          "name": "comparison_lineage_version",
+          "type": "varchar",
+          "nullable": true
+        },
+        { "name": "hash_kind", "type": "varchar", "nullable": true }
+      ],
+      "constraints": [
+        "fund_scenario_calculation_runs_hash_kind_check",
+        "fund_scenario_calculation_runs_typed_input_hash_check",
+        "fund_scenario_calculation_runs_comparison_lineage_check"
+      ],
+      "indexes": ["fund_scenario_calc_runs_active_dedup_idx"],
+      "indexDefinitions": [
+        {
+          "name": "fund_scenario_calc_runs_active_dedup_idx",
+          "expectedDefinition": {
+            "exactDefinition": "CREATE UNIQUE INDEX fund_scenario_calc_runs_active_dedup_idx ON public.fund_scenario_calculation_runs USING btree (scenario_set_id, source_config_id, source_config_version, COALESCE(hash_kind, 'scenario-input-hash-v1'::character varying), input_hash) WHERE ((status)::text = ANY ((ARRAY['queued'::character varying, 'running'::character varying, 'completed'::character varying])::text[]))",
+            "orderedFragments": [
+              "CREATE UNIQUE INDEX",
+              "ON public.fund_scenario_calculation_runs",
+              "scenario_set_id",
+              "source_config_id",
+              "source_config_version",
+              "COALESCE(hash_kind",
+              "input_hash",
+              "WHERE",
+              "status"
+            ],
+            "stringLiterals": [
+              "scenario-input-hash-v1",
+              "queued",
+              "running",
+              "completed"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/reconcile-prod-schema.mjs
+++ b/scripts/reconcile-prod-schema.mjs
@@ -64,7 +64,8 @@ export function parseReconcileArgs(argv, env = process.env) {
   const args = [...argv];
   const apply = args.includes('--apply');
   const yes = args.includes('--yes');
-  const manifestDir = valueAfter(args, '--manifest-dir') ?? env.UPDOG_SCHEMA_MANIFEST_DIR ?? DEFAULT_MANIFEST_DIR;
+  const manifestDir =
+    valueAfter(args, '--manifest-dir') ?? env.UPDOG_SCHEMA_MANIFEST_DIR ?? DEFAULT_MANIFEST_DIR;
   const expectedDatabase =
     valueAfter(args, '--expect-db') ?? env.UPDOG_EXPECTED_DATABASE ?? env.PGDATABASE ?? null;
 
@@ -95,15 +96,21 @@ export function isPoolerUrl(connectionString) {
 
 export function assertDirectDatabaseUrl(connectionString) {
   if (!connectionString || connectionString === 'memory://') {
-    throw new ReconcileError('DATABASE_URL is missing or memory://; set it to the target database', {
-      kind: 'missing-database-url',
-    });
+    throw new ReconcileError(
+      'DATABASE_URL is missing or memory://; set it to the target database',
+      {
+        kind: 'missing-database-url',
+      }
+    );
   }
 
   if (isPoolerUrl(connectionString)) {
-    throw new ReconcileError('Refusing pooled database URL; DDL requires the direct Neon endpoint', {
-      kind: 'pooler-url-refused',
-    });
+    throw new ReconcileError(
+      'Refusing pooled database URL; DDL requires the direct Neon endpoint',
+      {
+        kind: 'pooler-url-refused',
+      }
+    );
   }
 }
 
@@ -170,11 +177,14 @@ function manifestLabel(manifest) {
 function validateManifestKeys(manifest) {
   for (const key of Object.keys(manifest ?? {})) {
     if (!KNOWN_MANIFEST_KEYS.has(key)) {
-      throw new ReconcileError(`Manifest ${manifestLabel(manifest)} has unsupported top-level key ${key}`, {
-        kind: 'unknown-manifest-key',
-        manifest: manifestLabel(manifest),
-        key,
-      });
+      throw new ReconcileError(
+        `Manifest ${manifestLabel(manifest)} has unsupported top-level key ${key}`,
+        {
+          kind: 'unknown-manifest-key',
+          manifest: manifestLabel(manifest),
+          key,
+        }
+      );
     }
   }
 }
@@ -198,7 +208,47 @@ function validateMissingTablePolicyValue(manifest) {
 function validateManifest(manifest) {
   validateManifestKeys(manifest);
   validateMissingTablePolicyValue(manifest);
+  validateExpectedTables(manifest);
   validateApplyPolicy(manifest);
+}
+
+function validateExpectedTables(manifest) {
+  for (const table of manifest?.expectedTables ?? []) {
+    const indexes = new Set(table.indexes ?? []);
+    const seenDefinitions = new Set();
+
+    for (const indexDefinition of table.indexDefinitions ?? []) {
+      assertSafeIdentifier(String(indexDefinition.name ?? ''));
+      const expectedDefinition = indexDefinition.expectedDefinition;
+      if (
+        !indexes.has(indexDefinition.name) ||
+        seenDefinitions.has(indexDefinition.name) ||
+        !expectedDefinition ||
+        typeof expectedDefinition.exactDefinition !== 'string' ||
+        expectedDefinition.exactDefinition.trim().length === 0 ||
+        !Array.isArray(expectedDefinition.orderedFragments) ||
+        expectedDefinition.orderedFragments.length === 0 ||
+        expectedDefinition.orderedFragments.some(
+          (fragment) => typeof fragment !== 'string' || fragment.trim().length === 0
+        ) ||
+        !Array.isArray(expectedDefinition.stringLiterals) ||
+        expectedDefinition.stringLiterals.some(
+          (literal) => typeof literal !== 'string' || literal.length === 0
+        )
+      ) {
+        throw new ReconcileError(
+          `Manifest ${manifestLabel(manifest)} indexDefinitions target ${table.name}.${String(indexDefinition.name)} must name an expected index exactly once and provide an exact definition, ordered fragments, and string literals`,
+          {
+            kind: 'invalid-index-definition',
+            manifest: manifestLabel(manifest),
+            table: table.name,
+            name: indexDefinition.name,
+          }
+        );
+      }
+      seenDefinitions.add(indexDefinition.name);
+    }
+  }
 }
 
 function validateApplyPolicy(manifest) {
@@ -210,11 +260,14 @@ function validateApplyPolicy(manifest) {
   const knownPolicyKeys = new Set(['allowDropNotNull', 'allowConstraintReplacements']);
   for (const key of Object.keys(applyPolicy ?? {})) {
     if (!knownPolicyKeys.has(key)) {
-      throw new ReconcileError(`Manifest ${manifestLabel(manifest)} has unsupported applyPolicy key ${key}`, {
-        kind: 'invalid-apply-policy',
-        manifest: manifestLabel(manifest),
-        key,
-      });
+      throw new ReconcileError(
+        `Manifest ${manifestLabel(manifest)} has unsupported applyPolicy key ${key}`,
+        {
+          kind: 'invalid-apply-policy',
+          manifest: manifestLabel(manifest),
+          key,
+        }
+      );
     }
   }
 
@@ -225,11 +278,14 @@ function validateApplyPolicy(manifest) {
     assertSafeIdentifier(String(target.column ?? ''));
     const key = `${target.table}.${target.column}`;
     if (seenDropNotNull.has(key)) {
-      throw new ReconcileError(`Manifest ${manifestLabel(manifest)} has duplicate applyPolicy target ${key}`, {
-        kind: 'invalid-apply-policy',
-        manifest: manifestLabel(manifest),
-        target: key,
-      });
+      throw new ReconcileError(
+        `Manifest ${manifestLabel(manifest)} has duplicate applyPolicy target ${key}`,
+        {
+          kind: 'invalid-apply-policy',
+          manifest: manifestLabel(manifest),
+          target: key,
+        }
+      );
     }
     seenDropNotNull.add(key);
     const expectedColumn = tables
@@ -276,11 +332,14 @@ function validateApplyPolicy(manifest) {
     }
     const key = `${target.table}.${target.name}`;
     if (seenConstraintReplacement.has(key)) {
-      throw new ReconcileError(`Manifest ${manifestLabel(manifest)} has duplicate applyPolicy target ${key}`, {
-        kind: 'invalid-apply-policy',
-        manifest: manifestLabel(manifest),
-        target: key,
-      });
+      throw new ReconcileError(
+        `Manifest ${manifestLabel(manifest)} has duplicate applyPolicy target ${key}`,
+        {
+          kind: 'invalid-apply-policy',
+          manifest: manifestLabel(manifest),
+          target: key,
+        }
+      );
     }
     seenConstraintReplacement.add(key);
     const constraints = tables.get(target.table)?.constraints ?? [];
@@ -463,9 +522,9 @@ export async function auditManifest(client, manifest) {
           columns: columns.get(expectedTable.name) ?? new Map(),
           constraints: tableConstraints,
           indexes,
-          constraintReplacements: (
-            manifest.applyPolicy?.allowConstraintReplacements ?? []
-          ).filter((replacement) => replacement.table === expectedTable.name),
+          constraintReplacements: (manifest.applyPolicy?.allowConstraintReplacements ?? []).filter(
+            (replacement) => replacement.table === expectedTable.name
+          ),
           missingTablePolicy,
         })
       );
@@ -536,6 +595,10 @@ async function loadPresentDropConstraints(client, constraintDrops) {
 }
 
 export function decideObjectAction({ tablePresent, deltas, populated, missingTablePolicy }) {
+  if (deltas.some((delta) => delta.humanReviewRequired === true)) {
+    return ACTION_REFUSE_FOR_HUMAN;
+  }
+
   if (!tablePresent) {
     if (missingTablePolicy === MISSING_TABLE_POLICY_EXISTING_REQUIRED) {
       return ACTION_REFUSE_FOR_HUMAN;
@@ -702,7 +765,9 @@ export async function runReconciliation({
 
     for (const prepared of manifestsNeedingApply) {
       if (await hasCommittedLedger(client, prepared.manifest.name, prepared.checksum)) {
-        stdout.write(`\nSkipping ${prepared.manifest.name}: committed ledger row already exists.\n`);
+        stdout.write(
+          `\nSkipping ${prepared.manifest.name}: committed ledger row already exists.\n`
+        );
         continue;
       }
 
@@ -759,6 +824,8 @@ async function auditTable({
   missingTablePolicy,
 }) {
   const deltas = [];
+  const indexTableMismatches = findIndexTableMismatches(expectedTable, indexes);
+  deltas.push(...indexTableMismatches);
 
   if (!tablePresent) {
     deltas.push({ kind: 'missing-table', name: expectedTable.name, additiveSafe: true });
@@ -805,8 +872,7 @@ async function auditTable({
       typeof expectedColumn.nullable === 'boolean' &&
       actualColumn.nullable !== expectedColumn.nullable
     ) {
-      const widensToNullable =
-        actualColumn.nullable === false && expectedColumn.nullable === true;
+      const widensToNullable = actualColumn.nullable === false && expectedColumn.nullable === true;
       deltas.push({
         kind: 'column-nullability-mismatch',
         name: `${expectedTable.name}.${expectedColumn.name}`,
@@ -823,7 +889,7 @@ async function auditTable({
       indexes: expectedTable.indexes ?? [],
     },
     constraintRows: constraints,
-    indexRows: indexes,
+    indexRows: indexes.filter((row) => row.tablename === expectedTable.name),
   });
 
   for (const name of missingSentinels.constraints) {
@@ -835,9 +901,7 @@ async function auditTable({
   }
 
   for (const replacement of constraintReplacements) {
-    const constraint = constraints.find(
-      (row) => row.conname === pgIdentifier(replacement.name)
-    );
+    const constraint = constraints.find((row) => row.conname === pgIdentifier(replacement.name));
     if (
       constraint &&
       !constraintDefinitionMatches(constraint.definition, replacement.expectedDefinition)
@@ -852,7 +916,25 @@ async function auditTable({
     }
   }
 
+  for (const indexDefinition of expectedTable.indexDefinitions ?? []) {
+    const index = indexes.find(
+      (row) =>
+        row.indexname === pgIdentifier(indexDefinition.name) && row.tablename === expectedTable.name
+    );
+    if (index && !indexDefinitionMatches(index.indexdef, indexDefinition.expectedDefinition)) {
+      deltas.push({
+        kind: 'index-definition-mismatch',
+        name: indexDefinition.name,
+        expected: indexDefinition.expectedDefinition,
+        actual: index.indexdef,
+        additiveSafe: false,
+      });
+    }
+  }
+
+  const requiresHumanReview = deltas.some((delta) => delta.humanReviewRequired === true);
   const populated =
+    !requiresHumanReview &&
     deltas.some((delta) => delta.additiveSafe === false) &&
     (await hasRows(client, expectedTable.name));
   const action = decideObjectAction({ tablePresent, deltas, populated, missingTablePolicy });
@@ -945,10 +1027,59 @@ function constraintDefinitionMatches(actualDefinition, expectedDefinition) {
   );
 }
 
-function extractSqlStringLiterals(definition) {
-  return [...definition.matchAll(/'((?:''|[^'])*)'/g)].map((match) =>
-    match[1].replace(/''/g, "'")
+function indexDefinitionMatches(actualDefinition, expectedDefinition) {
+  if (typeof actualDefinition !== 'string') return false;
+
+  const normalizedDefinition = normalizeSqlDefinition(actualDefinition);
+  if (normalizedDefinition !== normalizeSqlDefinition(expectedDefinition.exactDefinition)) {
+    return false;
+  }
+
+  let searchFrom = 0;
+  for (const fragment of expectedDefinition.orderedFragments) {
+    const normalizedFragment = normalizeSqlDefinition(fragment);
+    const position = normalizedDefinition.indexOf(normalizedFragment, searchFrom);
+    if (position === -1) return false;
+    searchFrom = position + normalizedFragment.length;
+  }
+
+  const actualLiterals = extractSqlStringLiterals(actualDefinition).sort();
+  const expectedLiterals = [...expectedDefinition.stringLiterals].sort();
+  return (
+    actualLiterals.length === expectedLiterals.length &&
+    actualLiterals.every((literal, index) => literal === expectedLiterals[index])
   );
+}
+
+function findIndexTableMismatches(expectedTable, indexes) {
+  const expectedNames = new Set((expectedTable.indexes ?? []).map(pgIdentifier));
+  return indexes
+    .filter(
+      (index) =>
+        expectedNames.has(pgIdentifier(index.indexname)) && index.tablename !== expectedTable.name
+    )
+    .map((index) => ({
+      kind: 'index-table-mismatch',
+      name: index.indexname,
+      expectedTable: expectedTable.name,
+      actualTable: index.tablename,
+      additiveSafe: false,
+      humanReviewRequired: true,
+    }));
+}
+
+function normalizeSqlDefinition(definition) {
+  return definition
+    .toLowerCase()
+    .replace(/"/g, '')
+    .replace(/\s+/g, ' ')
+    .replace(/\s*(::|<>|<=|>=|=)\s*/g, '$1')
+    .replace(/\s*([(),.;])\s*/g, '$1')
+    .trim();
+}
+
+function extractSqlStringLiterals(definition) {
+  return [...definition.matchAll(/'((?:''|[^'])*)'/g)].map((match) => match[1].replace(/''/g, "'"));
 }
 
 async function loadIndexes(client, expectedTables) {
@@ -958,7 +1089,7 @@ async function loadIndexes(client, expectedTables) {
 
   const result = await client.query(
     `
-      SELECT indexname
+      SELECT tablename, indexname, indexdef
       FROM pg_indexes
       WHERE schemaname = 'public'
         AND indexname = ANY($1::text[])
@@ -970,7 +1101,9 @@ async function loadIndexes(client, expectedTables) {
 
 async function hasRows(client, tableName) {
   assertSafeIdentifier(tableName);
-  const result = await client.query(`SELECT EXISTS (SELECT 1 FROM "${tableName}" LIMIT 1) AS populated`);
+  const result = await client.query(
+    `SELECT EXISTS (SELECT 1 FROM "${tableName}" LIMIT 1) AS populated`
+  );
   return result.rows[0]?.populated === true;
 }
 
@@ -1040,7 +1173,10 @@ async function hasCommittedLedger(client, manifestName, checksum) {
 }
 
 async function applyPreparedManifest({ client, prepared, identity, stdout }) {
-  const fileChecksums = prepared.sqlFiles.map((file) => ({ path: file.path, checksum: file.checksum }));
+  const fileChecksums = prepared.sqlFiles.map((file) => ({
+    path: file.path,
+    checksum: file.checksum,
+  }));
   const appliedBy = process.env.USER || process.env.USERNAME || 'unknown';
   let ledgerId;
 

--- a/scripts/reconcile-prod-schema.mjs
+++ b/scripts/reconcile-prod-schema.mjs
@@ -257,7 +257,11 @@ function validateApplyPolicy(manifest) {
     return;
   }
 
-  const knownPolicyKeys = new Set(['allowDropNotNull', 'allowConstraintReplacements']);
+  const knownPolicyKeys = new Set([
+    'allowDropNotNull',
+    'allowConstraintReplacements',
+    'allowNonNullColumnAdds',
+  ]);
   for (const key of Object.keys(applyPolicy ?? {})) {
     if (!knownPolicyKeys.has(key)) {
       throw new ReconcileError(
@@ -272,6 +276,37 @@ function validateApplyPolicy(manifest) {
   }
 
   const tables = new Map((manifest.expectedTables ?? []).map((table) => [table.name, table]));
+  const seenNonNullColumnAdds = new Set();
+  for (const target of applyPolicy.allowNonNullColumnAdds ?? []) {
+    assertSafeIdentifier(String(target.table ?? ''));
+    assertSafeIdentifier(String(target.column ?? ''));
+    const key = `${target.table}.${target.column}`;
+    if (seenNonNullColumnAdds.has(key)) {
+      throw new ReconcileError(
+        `Manifest ${manifestLabel(manifest)} has duplicate applyPolicy target ${key}`,
+        {
+          kind: 'invalid-apply-policy',
+          manifest: manifestLabel(manifest),
+          target: key,
+        }
+      );
+    }
+    seenNonNullColumnAdds.add(key);
+    const expectedColumn = tables
+      .get(target.table)
+      ?.columns?.find((column) => column.name === target.column);
+    if (expectedColumn?.nullable !== false) {
+      throw new ReconcileError(
+        `Manifest ${manifestLabel(manifest)} allowNonNullColumnAdds target ${key} is not an expected non-null column`,
+        {
+          kind: 'invalid-apply-policy',
+          manifest: manifestLabel(manifest),
+          target: key,
+        }
+      );
+    }
+  }
+
   const seenDropNotNull = new Set();
   for (const target of applyPolicy.allowDropNotNull ?? []) {
     assertSafeIdentifier(String(target.table ?? ''));
@@ -476,6 +511,159 @@ export function validateManifestSql(manifest, sqlFiles) {
       }
     }
   }
+
+  const nonNullColumnAddViolations = validateNonNullColumnAddPolicy(manifest, sqlFiles);
+  if (nonNullColumnAddViolations.length > 0) {
+    throw new ReconcileError(
+      `Manifest ${manifest.name} has SQL outside allowNonNullColumnAdds policy`,
+      {
+        kind: 'invalid-non-null-column-add-policy',
+        manifest: manifest.name,
+        violations: nonNullColumnAddViolations,
+      }
+    );
+  }
+}
+
+export function validateNonNullColumnAddPolicy(manifest, sqlFiles) {
+  const allowedTargets = manifest.applyPolicy?.allowNonNullColumnAdds ?? [];
+  if (allowedTargets.length === 0) {
+    return [];
+  }
+
+  const allowedKeys = new Set(allowedTargets.map((target) => `${target.table}.${target.column}`));
+  const additions = [];
+  const violations = [];
+
+  for (const file of sqlFiles) {
+    const statements = splitSqlStatements(file.sql)
+      .map((statement) => stripSqlComments(statement).trim())
+      .filter(Boolean);
+
+    for (const statement of statements) {
+      if (!/\bALTER\s+TABLE\b/i.test(statement) || !/\bADD\s+COLUMN\b/i.test(statement)) {
+        continue;
+      }
+
+      const parsed = parseAlterTableAddColumn(statement);
+      if (!parsed) {
+        violations.push({
+          manifest: manifest.name,
+          file: file.path,
+          kind: 'malformed-non-null-column-add',
+          statement,
+          reason: 'ALTER TABLE ADD COLUMN must be one direct, parseable statement',
+        });
+        continue;
+      }
+
+      additions.push({ ...parsed, file: file.path, statement });
+      if (!allowedKeys.has(parsed.key)) {
+        violations.push({
+          manifest: manifest.name,
+          file: file.path,
+          kind: 'undeclared-non-null-column-add',
+          statement,
+          reason: `${parsed.key} is not declared in allowNonNullColumnAdds`,
+        });
+        continue;
+      }
+
+      if (!isSafeNonNullColumnAdd(parsed)) {
+        violations.push({
+          manifest: manifest.name,
+          file: file.path,
+          kind: 'invalid-non-null-column-add',
+          statement,
+          reason: `${parsed.key} must use IF NOT EXISTS and exactly one NOT NULL DEFAULT with a proven non-null value`,
+        });
+      }
+    }
+  }
+
+  for (const target of allowedTargets) {
+    const key = `${target.table}.${target.column}`;
+    const matches = additions.filter((addition) => addition.key === key);
+    if (matches.length === 0) {
+      violations.push({
+        manifest: manifest.name,
+        file: '<manifest-sql>',
+        kind: 'unproven-non-null-column-add',
+        statement: key,
+        reason: `${key} has no matching ALTER TABLE ADD COLUMN statement`,
+      });
+    } else if (matches.length > 1) {
+      violations.push({
+        manifest: manifest.name,
+        file: '<manifest-sql>',
+        kind: 'duplicate-non-null-column-add',
+        statement: key,
+        reason: `${key} must have exactly one ALTER TABLE ADD COLUMN statement`,
+      });
+    }
+  }
+
+  return violations;
+}
+
+function parseAlterTableAddColumn(statement) {
+  const withoutTerminator = statement.replace(/;\s*$/, '').trim();
+  const statementMatch = withoutTerminator.match(
+    /^ALTER\s+TABLE\s+(?:"([a-z_][a-z0-9_]*)"|([a-z_][a-z0-9_]*))\s+ADD\s+COLUMN\s+([\s\S]+)$/i
+  );
+  if (!statementMatch) {
+    return null;
+  }
+
+  const table = statementMatch[1] ?? statementMatch[2];
+  let remainder = statementMatch[3].trim();
+  let ifNotExists = false;
+  if (/^IF\b/i.test(remainder)) {
+    const guardMatch = remainder.match(/^IF\s+NOT\s+EXISTS\s+([\s\S]+)$/i);
+    if (!guardMatch) {
+      return null;
+    }
+    ifNotExists = true;
+    remainder = guardMatch[1].trim();
+  }
+
+  const columnMatch = remainder.match(/^(?:"([a-z_][a-z0-9_]*)"|([a-z_][a-z0-9_]*))\s+([\s\S]+)$/i);
+  if (!columnMatch) {
+    return null;
+  }
+
+  const column = columnMatch[1] ?? columnMatch[2];
+  return {
+    table,
+    column,
+    key: `${table}.${column}`,
+    ifNotExists,
+    definition: columnMatch[3].trim(),
+  };
+}
+
+function isSafeNonNullColumnAdd(addition) {
+  if (
+    !addition.ifNotExists ||
+    /\b(?:ALTER\s+TABLE|ADD\s+COLUMN)\b/i.test(addition.definition) ||
+    (addition.definition.match(/\bNOT\s+NULL\b/gi) ?? []).length !== 1 ||
+    (addition.definition.match(/\bDEFAULT\b/gi) ?? []).length !== 1
+  ) {
+    return false;
+  }
+
+  const defaultMatch = addition.definition.match(/\bNOT\s+NULL\s+DEFAULT\s+([\s\S]+)$/i);
+  return defaultMatch !== null && isProvenNonNullDefault(defaultMatch[1].trim());
+}
+
+function isProvenNonNullDefault(value) {
+  return /^(?:true|false|[-+]?(?:\d+(?:\.\d+)?|\.\d+)|'(?:''|[^'])*'(?:\s*::\s*[a-z_][a-z0-9_]*(?:\([^)]*\))?)?|now\(\)|current_timestamp)$/i.test(
+    value
+  );
+}
+
+function stripSqlComments(sql) {
+  return sql.replace(/--.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
 }
 
 export function extractCreateTableNames(sql) {
@@ -522,6 +710,9 @@ export async function auditManifest(client, manifest) {
           columns: columns.get(expectedTable.name) ?? new Map(),
           constraints: tableConstraints,
           indexes,
+          nonNullColumnAdds: (manifest.applyPolicy?.allowNonNullColumnAdds ?? []).filter(
+            (target) => target.table === expectedTable.name
+          ),
           constraintReplacements: (manifest.applyPolicy?.allowConstraintReplacements ?? []).filter(
             (replacement) => replacement.table === expectedTable.name
           ),
@@ -820,6 +1011,7 @@ async function auditTable({
   columns,
   constraints,
   indexes,
+  nonNullColumnAdds,
   constraintReplacements,
   missingTablePolicy,
 }) {
@@ -847,10 +1039,13 @@ async function auditTable({
   for (const expectedColumn of expectedTable.columns ?? []) {
     const actualColumn = columns.get(expectedColumn.name);
     if (!actualColumn) {
+      const allowNonNullAdd = nonNullColumnAdds.some(
+        (target) => target.column === expectedColumn.name
+      );
       deltas.push({
         kind: 'missing-column',
         name: `${expectedTable.name}.${expectedColumn.name}`,
-        additiveSafe: expectedColumn.nullable !== false,
+        additiveSafe: expectedColumn.nullable !== false || allowNonNullAdd,
       });
       continue;
     }

--- a/scripts/rollback-verify.sh
+++ b/scripts/rollback-verify.sh
@@ -1,19 +1,111 @@
 #!/usr/bin/env bash
 set -euo pipefail
-# scripts/rollback-verify.sh
-# Usage: scripts/rollback-verify.sh <TARGET_SHA> <MIGRATION_HASH>
-SHA=${1:-""}
-MIG=${2:-""}
-if [[ -z "$SHA" || -z "$MIG" ]]; then
-  echo "Usage: $0 <TARGET_SHA> <MIGRATION_HASH>"
+
+usage() {
+  echo "Usage: $0 <REVERT_MAIN_SHA> <RELEASE_RUN_ID>" >&2
+}
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+if [[ $# -ne 2 ]]; then
+  usage
   exit 1
 fi
-echo "Rolling back to $SHA (migration $MIG)"
-# git operations (sample)
-git fetch --all && git checkout "$SHA"
-# db rollback (placeholder)
-echo "Running migration down to $MIG (implement in your migration tool)"
-# cache flush (placeholder)
-echo "Flushing caches..."
-# verification checklist (placeholder)
-echo "Running post-rollback smoke..."
+
+EXPECTED_SHA=$1
+RELEASE_RUN_ID=$2
+
+[[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]] ||
+  fail "REVERT_MAIN_SHA must be an exact 40-character lowercase commit SHA."
+[[ "$RELEASE_RUN_ID" =~ ^[1-9][0-9]*$ ]] ||
+  fail "RELEASE_RUN_ID must be a positive integer."
+command -v gh >/dev/null 2>&1 || fail "GitHub CLI (gh) is required."
+
+if ! REPOSITORY="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"; then
+  fail "Could not resolve current GitHub repository."
+fi
+[[ "$REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] ||
+  fail "GitHub CLI returned an invalid repository name."
+
+if ! LIVE_MAIN="$(gh api "repos/${REPOSITORY}/commits/main" --jq '.sha')"; then
+  fail "Could not resolve live main SHA."
+fi
+[[ "$LIVE_MAIN" =~ ^[0-9a-f]{40}$ ]] ||
+  fail "GitHub returned an invalid live main SHA."
+[[ "$LIVE_MAIN" == "$EXPECTED_SHA" ]] ||
+  fail "Live main ${LIVE_MAIN} does not equal revert release target ${EXPECTED_SHA}."
+
+if ! RUN="$(
+  gh api "repos/${REPOSITORY}/actions/runs/${RELEASE_RUN_ID}" \
+    --jq '[.name, .path, .event, .head_branch, .head_sha, .status, .conclusion, .html_url] | @tsv'
+)"; then
+  fail "Could not load Release Production run ${RELEASE_RUN_ID}."
+fi
+
+IFS=$'\t' read -r \
+  RUN_NAME \
+  RUN_PATH \
+  RUN_EVENT \
+  RUN_BRANCH \
+  RUN_SHA \
+  RUN_STATUS \
+  RUN_CONCLUSION \
+  RUN_URL <<<"$RUN"
+
+[[ "$RUN_NAME" == "Release Production" ]] ||
+  fail "Run ${RELEASE_RUN_ID} is not Release Production."
+[[ "$RUN_PATH" == ".github/workflows/release-production.yml" ]] ||
+  fail "Run ${RELEASE_RUN_ID} used unexpected workflow path ${RUN_PATH}."
+[[ "$RUN_EVENT" == "workflow_dispatch" && "$RUN_BRANCH" == "main" ]] ||
+  fail "Release run must be a workflow_dispatch from main."
+[[ "$RUN_SHA" == "$EXPECTED_SHA" ]] ||
+  fail "Release run SHA ${RUN_SHA} does not equal ${EXPECTED_SHA}."
+[[ "$RUN_STATUS" == "completed" && "$RUN_CONCLUSION" == "success" ]] ||
+  fail "Release run is ${RUN_STATUS}/${RUN_CONCLUSION}, not completed/success."
+[[ "$RUN_URL" == https://github.com/*/actions/runs/"${RELEASE_RUN_ID}" ]] ||
+  fail "Release run returned an invalid evidence URL."
+
+if ! JOBS="$(
+  gh api "repos/${REPOSITORY}/actions/runs/${RELEASE_RUN_ID}/jobs?per_page=100" \
+    --jq '
+      if .total_count > 100 then
+        error("Release run has more than 100 jobs; refusing incomplete evidence.")
+      else
+        .jobs[] | [.name, .status, .conclusion, .html_url] | @tsv
+      end
+    '
+)"; then
+  fail "Could not load jobs for Release Production run ${RELEASE_RUN_ID}."
+fi
+
+require_successful_job() {
+  local expected_name=$1
+  local matches=0
+  local job_name job_status job_conclusion job_url
+
+  while IFS=$'\t' read -r job_name job_status job_conclusion job_url; do
+    if [[ "$job_name" == "$expected_name" ]]; then
+      matches=$((matches + 1))
+      [[ "$job_status" == "completed" && "$job_conclusion" == "success" ]] ||
+        fail "${expected_name} is ${job_status}/${job_conclusion}, not completed/success."
+      [[ "$job_url" == https://github.com/*/actions/runs/"${RELEASE_RUN_ID}"/job/* ]] ||
+        fail "${expected_name} returned an invalid evidence URL."
+    fi
+  done <<<"$JOBS"
+
+  [[ "$matches" -eq 1 ]] ||
+    fail "Expected exactly one successful ${expected_name} job; found ${matches}."
+}
+
+require_successful_job "Validate Staged Deployment Identity"
+require_successful_job "Authenticated Staged Production Smoke"
+require_successful_job "Promote Staged Vercel Deployment"
+require_successful_job "Authenticated Post-promotion Smoke"
+
+echo "PASS: live main equals revert release target ${EXPECTED_SHA}."
+echo "PASS: Release Production ${RELEASE_RUN_ID} completed successfully for exact SHA."
+echo "PASS: staged identity, authenticated staged smoke, promotion, and post-promotion smoke succeeded."
+echo "Evidence: ${RUN_URL}"

--- a/scripts/smoke-test.ps1
+++ b/scripts/smoke-test.ps1
@@ -284,7 +284,7 @@ if ($testsFailed -eq 0) {
     Write-Host "Next steps:" -ForegroundColor Yellow
     Write-Host "  1. Monitor logs: vercel logs --follow" -ForegroundColor White
     Write-Host "  2. Run full E2E tests: npm run test:e2e" -ForegroundColor White
-    Write-Host "  3. Deploy to production: .\scripts\deploy-production.ps1" -ForegroundColor White
+    Write-Host "  3. Dispatch governed production release: .\scripts\deploy-production.ps1" -ForegroundColor White
     exit 0
 } else {
     Write-Host "❌ Some smoke tests failed!" -ForegroundColor Red

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -112,8 +112,8 @@ echo "━━━━━━━━━━━━━━━━━━━━━━━━�
 if [ $FAILED -eq 0 ]; then
     echo -e "${GREEN}✅ All smoke tests passed!${NC}"
     echo ""
-    echo "Ready for production deployment:"
-    echo "  npx vercel --prod"
+    echo "Dispatch governed production release:"
+    echo "  pwsh ./scripts/deploy-production.ps1"
     exit 0
 else
     echo -e "${RED}❌ $FAILED smoke test(s) failed${NC}"

--- a/tests/integration/prod-schema-clone.test.ts
+++ b/tests/integration/prod-schema-clone.test.ts
@@ -138,6 +138,41 @@ const INTERNAL_ANALYSIS_MANIFEST_TABLES = [
   'internal_narrative_claims',
   'internal_analysis_notes',
 ] as const;
+const USER_IDENTITY_GRANTS_REVOCATION_MANIFEST_TABLES = [
+  'users',
+  'user_fund_grants',
+  'revoked_tokens',
+] as const;
+const COMPANY_SCENARIO_CREATE_REQUEST_MANIFEST_TABLES = [
+  'company_scenario_create_requests',
+] as const;
+const BUSINESS_TIME_COMPARISON_LINEAGE_MANIFEST_TABLES = [
+  'calc_runs',
+  'fund_scenario_calculation_runs',
+] as const;
+const EXPECTED_PRODUCTION_MANIFEST_NAMES = [
+  'M1-cohort',
+  'M2-fund-moic',
+  'M3-operating-tasks',
+  'M4-lp-reporting',
+  'M5-operator-seam',
+  'M6-h9-actionability',
+  'M7-allocation-scenarios',
+  'scenario-case-seed-provenance',
+  'substrate-shadow-reconciliations',
+  'financial-facts-snapshots',
+  'current-plan-versions',
+  'current-forecast-references',
+  'financial-observations',
+  'investment-ledger',
+  'vehicle-financing-participations',
+  'positions-ownership-compat',
+  'position-source-basis-reliefs',
+  'internal-analysis',
+  'user-identity-grants-revocation',
+  'company-scenario-create-requests',
+  'business-time-comparison-lineage',
+] as const;
 const SHAPE_ONLY_NOT_JOURNALED = [
   'flag_changes',
   'flags_state',
@@ -741,6 +776,9 @@ describe.skipIf(skipIfNoDocker)('prod schema synthetic clone', () => {
   it('applies the PR-1 manifest tables and FK sentinels to an empty clone', async () => {
     expect(pool).toBeDefined();
     const manifests = await loadManifests();
+    expect(manifests.map((manifest) => manifest.name)).toEqual([
+      ...EXPECTED_PRODUCTION_MANIFEST_NAMES,
+    ]);
     const expectedTables = manifests.flatMap((manifest) =>
       (manifest.expectedTables ?? []).map((table: { name: string }) => table.name)
     );
@@ -770,6 +808,9 @@ describe.skipIf(skipIfNoDocker)('prod schema synthetic clone', () => {
         ...POSITIONS_OWNERSHIP_COMPAT_MANIFEST_TABLES,
         ...POSITION_SOURCE_BASIS_RELIEF_MANIFEST_TABLES,
         ...INTERNAL_ANALYSIS_MANIFEST_TABLES,
+        ...USER_IDENTITY_GRANTS_REVOCATION_MANIFEST_TABLES,
+        ...COMPANY_SCENARIO_CREATE_REQUEST_MANIFEST_TABLES,
+        ...BUSINESS_TIME_COMPARISON_LINEAGE_MANIFEST_TABLES,
       ])
     );
 

--- a/tests/integration/prod-schema-reconcile-partial-drift.test.ts
+++ b/tests/integration/prod-schema-reconcile-partial-drift.test.ts
@@ -14,6 +14,7 @@ import {
   runReconciliation,
   splitSqlStatements,
 } from '../../scripts/reconcile-prod-schema.mjs';
+import { assertApplyPolicyForManifests } from '../../scripts/prod-schema-apply-policy.mjs';
 import { runMigrationsWithConnectionString } from '../helpers/testcontainers-migration';
 
 const STARTUP_TIMEOUT_MS = 90_000;
@@ -39,6 +40,9 @@ let allocationManifest: Manifest | undefined;
 let substrateShadowManifest: Manifest | undefined;
 let currentForecastManifest: Manifest | undefined;
 let positionsOwnershipManifest: Manifest | undefined;
+let identityManifest: Manifest | undefined;
+let companyScenarioCreateManifest: Manifest | undefined;
+let businessTimeComparisonManifest: Manifest | undefined;
 let baseConnectionString = '';
 
 function requirePool(): Pool {
@@ -100,12 +104,295 @@ describe.skipIf(skipIfNoDocker)('prod schema partial-drift reconciliation', () =
     positionsOwnershipManifest = manifests.find(
       (manifest) => manifest.name === 'positions-ownership-compat'
     );
+    identityManifest = manifests.find(
+      (manifest) => manifest.name === 'user-identity-grants-revocation'
+    );
+    companyScenarioCreateManifest = manifests.find(
+      (manifest) => manifest.name === 'company-scenario-create-requests'
+    );
+    businessTimeComparisonManifest = manifests.find(
+      (manifest) => manifest.name === 'business-time-comparison-lineage'
+    );
   }, STARTUP_TIMEOUT_MS * 2);
 
   afterAll(async () => {
     await pool?.end();
     await postgres?.stop();
   });
+
+  it(
+    'manifest 19 additively converges identity grants and revocation from pre-0031',
+    async () => {
+      const activePool = requirePool();
+      const manifest = requireManifest(identityManifest, 'user_fund_grants');
+      const databaseName = 'prod_like_pre_0031_identity';
+      const databaseConnectionString = connectionStringForDatabase(
+        baseConnectionString,
+        databaseName
+      );
+      let isolatedPool: Pool | undefined;
+
+      await activePool.query(`DROP DATABASE IF EXISTS ${databaseName} WITH (FORCE)`);
+      await activePool.query(`CREATE DATABASE ${databaseName}`);
+
+      try {
+        await runMigrationsWithConnectionString(
+          databaseConnectionString,
+          '0030_allocation_scenarios_reconcile_drift'
+        );
+        isolatedPool = new Pool({ connectionString: databaseConnectionString, max: 1 });
+
+        const result = await runReconciliation({
+          client: isolatedPool,
+          manifests: [manifest],
+          apply: true,
+          stdout: { write: () => undefined },
+        });
+        expect(result.applied).toContain('user-identity-grants-revocation');
+
+        const tableResult = await isolatedPool.query<{ name: string | null }>(`
+          SELECT to_regclass('public.user_fund_grants')::text AS name
+          UNION ALL
+          SELECT to_regclass('public.revoked_tokens')::text
+        `);
+        expect(tableResult.rows.map((row) => row.name)).toEqual([
+          'user_fund_grants',
+          'revoked_tokens',
+        ]);
+
+        const columnResult = await isolatedPool.query<{
+          column_name: string;
+          data_type: string;
+          is_nullable: string;
+        }>(`
+          SELECT column_name, data_type, is_nullable
+          FROM information_schema.columns
+          WHERE table_schema = 'public'
+            AND table_name = 'users'
+            AND column_name = ANY(
+              ARRAY['role', 'is_active', 'password_updated_at']::text[]
+            )
+          ORDER BY column_name
+        `);
+        expect(columnResult.rows).toEqual([
+          { column_name: 'is_active', data_type: 'boolean', is_nullable: 'NO' },
+          {
+            column_name: 'password_updated_at',
+            data_type: 'timestamp with time zone',
+            is_nullable: 'NO',
+          },
+          { column_name: 'role', data_type: 'character varying', is_nullable: 'NO' },
+        ]);
+
+        const constraintResult = await isolatedPool.query<{ conname: string }>(`
+          SELECT conname
+          FROM pg_constraint
+          WHERE conname = ANY(
+            ARRAY[
+              'users_role_check',
+              'user_fund_grants_pkey',
+              'user_fund_grants_user_id_users_id_fk',
+              'user_fund_grants_fund_id_funds_id_fk',
+              'revoked_tokens_pkey',
+              'revoked_tokens_user_id_users_id_fk'
+            ]::text[]
+          )
+          ORDER BY conname
+        `);
+        expect(constraintResult.rows.map((row) => row.conname)).toEqual([
+          'revoked_tokens_pkey',
+          'revoked_tokens_user_id_users_id_fk',
+          'user_fund_grants_fund_id_funds_id_fk',
+          'user_fund_grants_pkey',
+          'user_fund_grants_user_id_users_id_fk',
+          'users_role_check',
+        ]);
+
+        const indexResult = await isolatedPool.query<{ name: string | null }>(
+          "SELECT to_regclass('public.revoked_tokens_expires_at_idx')::text AS name"
+        );
+        expect(indexResult.rows).toEqual([{ name: 'revoked_tokens_expires_at_idx' }]);
+        expect((await auditManifest(isolatedPool, manifest)).action).toBe(ACTION_SKIP);
+
+        const replay = await runReconciliation({
+          client: isolatedPool,
+          manifests: [manifest],
+          apply: true,
+          stdout: { write: () => undefined },
+        });
+        expect(replay.applied).toEqual([]);
+      } finally {
+        await isolatedPool?.end();
+        await activePool.query(`DROP DATABASE IF EXISTS ${databaseName} WITH (FORCE)`);
+      }
+    },
+    TEST_TIMEOUT_MS * 2
+  );
+
+  it(
+    'manifest 20 additively converges company scenario create requests from pre-0033',
+    async () => {
+      const activePool = requirePool();
+      const manifest = requireManifest(
+        companyScenarioCreateManifest,
+        'company_scenario_create_requests'
+      );
+      const databaseName = 'prod_like_pre_0033_company_requests';
+      const databaseConnectionString = connectionStringForDatabase(
+        baseConnectionString,
+        databaseName
+      );
+      let isolatedPool: Pool | undefined;
+
+      await activePool.query(`DROP DATABASE IF EXISTS ${databaseName} WITH (FORCE)`);
+      await activePool.query(`CREATE DATABASE ${databaseName}`);
+
+      try {
+        await runMigrationsWithConnectionString(
+          databaseConnectionString,
+          '0032_scenario_case_seed_provenance'
+        );
+        isolatedPool = new Pool({ connectionString: databaseConnectionString, max: 1 });
+
+        const result = await runReconciliation({
+          client: isolatedPool,
+          manifests: [manifest],
+          apply: true,
+          stdout: { write: () => undefined },
+        });
+        expect(result.applied).toContain('company-scenario-create-requests');
+
+        const tableResult = await isolatedPool.query<{ name: string | null }>(
+          "SELECT to_regclass('public.company_scenario_create_requests')::text AS name"
+        );
+        expect(tableResult.rows).toEqual([{ name: 'company_scenario_create_requests' }]);
+        expect((await auditManifest(isolatedPool, manifest)).action).toBe(ACTION_SKIP);
+
+        const replay = await runReconciliation({
+          client: isolatedPool,
+          manifests: [manifest],
+          apply: true,
+          stdout: { write: () => undefined },
+        });
+        expect(replay.applied).toEqual([]);
+      } finally {
+        await isolatedPool?.end();
+        await activePool.query(`DROP DATABASE IF EXISTS ${databaseName} WITH (FORCE)`);
+      }
+    },
+    TEST_TIMEOUT_MS * 2
+  );
+
+  it(
+    'manifest 21 exposes legacy index drift and refuses non-additive apply from pre-0034',
+    async () => {
+      const activePool = requirePool();
+      const manifest = requireManifest(businessTimeComparisonManifest, 'calc_runs');
+      const databaseName = 'prod_like_pre_0034_business_time';
+      const databaseConnectionString = connectionStringForDatabase(
+        baseConnectionString,
+        databaseName
+      );
+      let isolatedPool: Pool | undefined;
+
+      await activePool.query(`DROP DATABASE IF EXISTS ${databaseName} WITH (FORCE)`);
+      await activePool.query(`CREATE DATABASE ${databaseName}`);
+
+      try {
+        await runMigrationsWithConnectionString(
+          databaseConnectionString,
+          '0033_company_scenario_create_requests'
+        );
+        isolatedPool = new Pool({ connectionString: databaseConnectionString, max: 1 });
+
+        const legacyIndex = await isolatedPool.query<{ definition: string }>(`
+          SELECT pg_get_indexdef('public.fund_scenario_calc_runs_active_dedup_idx'::regclass)
+            AS definition
+        `);
+        expect(legacyIndex.rows[0]?.definition).toContain(
+          '(scenario_set_id, source_config_id, source_config_version, input_hash)'
+        );
+        expect(legacyIndex.rows[0]?.definition).not.toContain('COALESCE(hash_kind');
+
+        const audit = await auditManifest(isolatedPool, manifest);
+        expect(audit.action).toBe(ACTION_APPLY_MISSING_DDL);
+        expect(
+          audit.objects
+            .flatMap((object) => object.deltas)
+            .map((delta) => ({ kind: delta.kind, name: delta.name }))
+        ).toEqual(
+          expect.arrayContaining([
+            { kind: 'missing-column', name: 'calc_runs.model_inputs_as_of_date' },
+            { kind: 'missing-column', name: 'calc_runs.comparison_lineage_version' },
+            {
+              kind: 'missing-column',
+              name: 'fund_scenario_calculation_runs.hash_kind',
+            },
+            {
+              kind: 'index-definition-mismatch',
+              name: 'fund_scenario_calc_runs_active_dedup_idx',
+            },
+          ])
+        );
+
+        expect(() =>
+          assertApplyPolicyForManifests({
+            manifests: [manifest],
+            applyingManifestNames: new Set([manifest.name]),
+          })
+        ).toThrowError(
+          expect.objectContaining({
+            details: {
+              kind: 'apply-policy-violation',
+              violations: expect.arrayContaining([expect.objectContaining({ kind: 'drop-index' })]),
+            },
+          })
+        );
+
+        const unchangedColumns = await isolatedPool.query<{
+          table_name: string;
+          column_name: string;
+        }>(`
+          SELECT table_name, column_name
+          FROM information_schema.columns
+          WHERE table_schema = 'public'
+            AND (
+              (
+                table_name = 'calc_runs'
+                AND column_name = ANY(
+                  ARRAY[
+                    'model_inputs_as_of_date',
+                    'comparison_lineage_version'
+                  ]::text[]
+                )
+              )
+              OR (
+                table_name = 'fund_scenario_calculation_runs'
+                AND column_name = ANY(
+                  ARRAY[
+                    'model_inputs_as_of_date',
+                    'comparison_lineage_version',
+                    'hash_kind'
+                  ]::text[]
+                )
+              )
+            )
+          ORDER BY table_name, column_name
+        `);
+        expect(unchangedColumns.rows).toEqual([]);
+
+        const unchangedIndex = await isolatedPool.query<{ definition: string }>(`
+          SELECT pg_get_indexdef('public.fund_scenario_calc_runs_active_dedup_idx'::regclass)
+            AS definition
+        `);
+        expect(unchangedIndex.rows[0]?.definition).not.toContain('COALESCE(hash_kind');
+      } finally {
+        await isolatedPool?.end();
+        await activePool.query(`DROP DATABASE IF EXISTS ${databaseName} WITH (FORCE)`);
+      }
+    },
+    TEST_TIMEOUT_MS * 2
+  );
 
   it(
     'production-like 0035 database converges M9 through M17 in apply order',

--- a/tests/regressions/ci-fail-closed.test.ts
+++ b/tests/regressions/ci-fail-closed.test.ts
@@ -1,6 +1,9 @@
-import { access, readFile } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { access, open, readFile } from 'node:fs/promises';
 import path from 'node:path';
+import { promisify } from 'node:util';
 
+import * as ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 import YAML from 'yaml';
 
@@ -9,21 +12,87 @@ type WorkflowStep = {
   env?: Record<string, unknown>;
   name?: string;
   run?: string;
+  shell?: string;
   uses?: string;
   with?: Record<string, unknown>;
 };
 
 type WorkflowJob = {
+  defaults?: {
+    run?: {
+      shell?: string;
+    };
+  };
+  environment?: string;
   needs?: string | string[];
+  outputs?: Record<string, unknown>;
+  ['runs-on']?: string | string[];
   steps?: WorkflowStep[];
   uses?: string;
 };
 
 type Workflow = {
+  defaults?: {
+    run?: {
+      shell?: string;
+    };
+  };
   jobs?: Record<string, WorkflowJob>;
+  on?: Record<string, unknown>;
+};
+
+type AutomationSurface = {
+  content: string;
+  dialect?: ShellDialect;
+  id: string;
+  language: 'action' | 'javascript' | 'python' | 'shell';
+};
+
+type ShellDialect = 'cmd' | 'portable' | 'posix' | 'powershell';
+
+const DYNAMIC_ATOMIC_ARGUMENT = '__DYNAMIC_ATOMIC_ARGUMENT__';
+const DYNAMIC_SHELL_ARGUMENT = '__DYNAMIC_SHELL_ARGUMENT__';
+
+type CompositeAction = {
+  runs?: {
+    steps?: WorkflowStep[];
+  };
 };
 
 const workflowsDir = path.join(process.cwd(), '.github', 'workflows');
+const execFileAsync = promisify(execFile);
+
+const AUTOMATION_SCAN_EXCLUDED_DIRECTORIES = new Set([
+  '.git',
+  '.cache',
+  '.npm-cache',
+  '.omx',
+  '.superpowers',
+  '.vercel',
+  'build',
+  'coverage',
+  'dist',
+  'docs',
+  'node_modules',
+  'snapshots',
+  'tests',
+]);
+const AUTOMATION_SOURCE_EXTENSIONS = new Set([
+  '.bat',
+  '.bash',
+  '.cjs',
+  '.cmd',
+  '.cts',
+  '.js',
+  '.mjs',
+  '.mts',
+  '.ps1',
+  '.py',
+  '.sh',
+  '.ts',
+  '.tsx',
+  '.zsh',
+]);
 
 async function readWorkflow(name: string): Promise<Workflow> {
   const contents = await readFile(path.join(workflowsDir, name), 'utf8');
@@ -73,6 +142,2042 @@ function reportingPublishers(job: WorkflowJob | undefined): WorkflowStep[] {
   return (job?.steps ?? []).filter(isReportingPublisher);
 }
 
+function normalizeShellContinuations(script: string, dialect: ShellDialect): string {
+  const continuation =
+    dialect === 'posix'
+      ? /\\\r?\n/g
+      : dialect === 'powershell'
+        ? /`\r?\n/g
+        : dialect === 'cmd'
+          ? /\^\r?\n/g
+          : /[\\`^]\r?\n/g;
+  return script.replace(continuation, ' ');
+}
+
+function stripShellComments(script: string, dialect: ShellDialect = 'portable'): string {
+  return script
+    .split(/\r?\n/)
+    .map((line) => {
+      if (dialect === 'cmd' && /^\s*(?:::|rem(?:\s|$))/i.test(line)) return '';
+      let quote: '"' | "'" | undefined;
+      let escaped = false;
+
+      for (let index = 0; index < line.length; index += 1) {
+        const character = line[index];
+        if (escaped) {
+          escaped = false;
+          continue;
+        }
+        const escapeCharacter =
+          (dialect === 'posix' && character === '\\') ||
+          (dialect === 'powershell' && character === '`') ||
+          (dialect === 'cmd' && character === '^') ||
+          (dialect === 'portable' && ['\\', '`', '^'].includes(character));
+        const literalEscape =
+          ((dialect === 'posix' || dialect === 'powershell') && quote === "'") ||
+          (dialect === 'cmd' && quote === '"');
+        if (escapeCharacter && !literalEscape) {
+          escaped = true;
+          continue;
+        }
+        if (quote) {
+          if (character === quote) quote = undefined;
+          continue;
+        }
+        if (character === '"' || (character === "'" && dialect !== 'cmd')) {
+          quote = character;
+          continue;
+        }
+        if (
+          dialect !== 'cmd' &&
+          character === '#' &&
+          (index === 0 || /\s/.test(line[index - 1] ?? ''))
+        ) {
+          return line.slice(0, index);
+        }
+      }
+
+      return line;
+    })
+    .join('\n');
+}
+
+function unquoteShellToken(token: string, dialect: ShellDialect = 'portable'): string {
+  const first = token.at(0);
+  const last = token.at(-1);
+  if (first === last && (first === '"' || (first === "'" && dialect !== 'cmd'))) {
+    return token.slice(1, -1);
+  }
+  return dialect === 'cmd' ? token.replace(/^'+|'+$/g, '') : token;
+}
+
+function shellCommandTokens(script: string, dialect: ShellDialect = 'portable'): string[][] {
+  return shellCommandStrings(script, dialect).map((command) =>
+    tokenizeShellCommand(command, dialect)
+  );
+}
+
+function shellCommandStrings(script: string, dialect: ShellDialect = 'portable'): string[] {
+  const commands = splitShellCommands(
+    stripShellComments(normalizeShellContinuations(script, dialect), dialect),
+    dialect
+  );
+  const assignments = new Map<string, string>();
+  return commands.map((command) => {
+    const assignment = staticShellAssignment(command, dialect);
+    if (assignment) {
+      const key = dialect === 'posix' ? assignment.name : assignment.name.toLowerCase();
+      if (assignment.value === undefined) assignments.delete(key);
+      else assignments.set(key, assignment.value);
+      return command;
+    }
+    return resolveShellVariables(command, dialect, assignments);
+  });
+}
+
+function tokenizeShellCommand(command: string, dialect: ShellDialect): string[] {
+  const tokenPattern = dialect === 'cmd' ? /"[^"]*"|[^\s]+/g : /"[^"]*"|'[^']*'|[^\s]+/g;
+  return command.match(tokenPattern)?.map((token) => unquoteShellToken(token, dialect)) ?? [];
+}
+
+type StaticShellAssignment = {
+  name: string;
+  value?: string;
+};
+
+function staticShellAssignment(
+  command: string,
+  dialect: ShellDialect
+): StaticShellAssignment | undefined {
+  const trimmed = command.trim();
+  if (dialect === 'posix') {
+    const name = trimmed.match(/^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=/)?.[1];
+    if (!name) return undefined;
+    const literal = trimmed.match(
+      /^(?:export\s+)?[A-Za-z_][A-Za-z0-9_]*\s*=\s*(?:"([^"]*)"|'([^']*)'|([A-Za-z0-9_./:@%+-]+))\s*$/
+    );
+    return { name, value: literal?.[1] ?? literal?.[2] ?? literal?.[3] };
+  }
+  if (dialect === 'powershell') {
+    const name = trimmed.match(/^\$([A-Za-z_][A-Za-z0-9_]*)\s*=/)?.[1];
+    if (!name) return undefined;
+    const literal = trimmed.match(/^\$[A-Za-z_][A-Za-z0-9_]*\s*=\s*(?:"([^"$`]*)"|'([^']*)')\s*$/);
+    return { name, value: literal?.[1] ?? literal?.[2] };
+  }
+  if (dialect === 'cmd') {
+    const match = trimmed.match(
+      /^set\s+(?:"([A-Za-z_][A-Za-z0-9_]*)=([^"]*)"|([A-Za-z_][A-Za-z0-9_]*)=(.*))$/i
+    );
+    if (!match) return undefined;
+    return { name: match[1] ?? match[3] ?? '', value: (match[2] ?? match[4] ?? '').trim() };
+  }
+  return undefined;
+}
+
+function resolveShellVariables(
+  command: string,
+  dialect: ShellDialect,
+  assignments: Map<string, string>
+): string {
+  if (dialect === 'cmd') {
+    return command.replace(
+      /%([A-Za-z_][A-Za-z0-9_]*)%/g,
+      (reference, name: string, offset: number) => {
+        const value = assignments.get(name.toLowerCase());
+        if (value === undefined) return reference;
+        const quoted = command[offset - 1] === '"' && command[offset + reference.length] === '"';
+        return !quoted && /\s/.test(value) ? `"${value}"` : value;
+      }
+    );
+  }
+
+  let resolved = '';
+  let quote: '"' | "'" | undefined;
+  for (let index = 0; index < command.length; index += 1) {
+    const character = command[index] ?? '';
+    if (character === '"' || character === "'") {
+      if (!quote) quote = character;
+      else if (quote === character) quote = undefined;
+      resolved += character;
+      continue;
+    }
+    if (character !== '$' || quote === "'") {
+      resolved += character;
+      continue;
+    }
+
+    const remainder = command.slice(index);
+    const variableMatch =
+      remainder.match(/^\$\{([A-Za-z_][A-Za-z0-9_]*)\}/) ??
+      remainder.match(/^\$([A-Za-z_][A-Za-z0-9_]*)/);
+    const variable = variableMatch?.[1];
+    if (!variable) {
+      resolved += character;
+      continue;
+    }
+    const key = dialect === 'posix' ? variable : variable.toLowerCase();
+    const value = assignments.get(key);
+    if (value === undefined) {
+      resolved += variableMatch[0];
+    } else {
+      resolved += !quote && dialect === 'powershell' && /\s/.test(value) ? `"${value}"` : value;
+    }
+    index += variableMatch[0].length - 1;
+  }
+  return resolved;
+}
+
+function splitShellCommands(script: string, dialect: ShellDialect): string[] {
+  const commands: string[] = [];
+  let command = '';
+  let quote: '"' | "'" | undefined;
+  let escaped = false;
+
+  const finishCommand = (): void => {
+    commands.push(command);
+    command = '';
+  };
+
+  for (let index = 0; index < script.length; index += 1) {
+    const character = script[index] ?? '';
+    if (escaped) {
+      command += character;
+      escaped = false;
+      continue;
+    }
+    const escapeCharacter =
+      (dialect === 'posix' && character === '\\') ||
+      (dialect === 'powershell' && character === '`') ||
+      (dialect === 'cmd' && character === '^') ||
+      (dialect === 'portable' && ['\\', '`', '^'].includes(character));
+    const literalEscape =
+      ((dialect === 'posix' || dialect === 'powershell') && quote === "'") ||
+      (dialect === 'cmd' && quote === '"');
+    if (escapeCharacter && !literalEscape) {
+      command += character;
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      command += character;
+      if (character === quote) quote = undefined;
+      continue;
+    }
+    if (character === '"' || (character === "'" && dialect !== 'cmd')) {
+      command += character;
+      quote = character;
+      continue;
+    }
+
+    if (
+      character === '\n' ||
+      character === '\r' ||
+      (character === ';' && dialect !== 'cmd') ||
+      character === '|'
+    ) {
+      finishCommand();
+      if (character === '|' && script[index + 1] === '|') index += 1;
+      continue;
+    }
+    if (character === '&') {
+      const callOperator =
+        command.trim().length === 0 && (dialect === 'powershell' || dialect === 'portable');
+      if (callOperator) {
+        command += character;
+      } else {
+        finishCommand();
+      }
+      if (script[index + 1] === '&') index += 1;
+      continue;
+    }
+    command += character;
+  }
+
+  finishCommand();
+  return commands;
+}
+
+function isCommandPrefix(tokens: string[]): boolean {
+  return tokens.every(
+    (token) =>
+      ['if', '!', 'command', 'sudo', 'env', '&', 'call', 'cmd', '/c', 'corepack'].includes(
+        token.toLowerCase()
+      ) || /^[A-Za-z_][A-Za-z0-9_]*=/.test(token)
+  );
+}
+
+function isVercelToken(token: string): boolean {
+  return /(?:^|\/)(?:vercel|vc)(?:\.cmd)?(?:@[^\s/]+)?$/.test(token.replace(/^@/, ''));
+}
+
+function vercelCommandTokens(script: string, dialect: ShellDialect = 'portable'): string[][] {
+  return shellCommandTokens(script, dialect).filter((tokens) => {
+    const vercelIndex = tokens.findIndex(isVercelToken);
+    if (vercelIndex === -1) return false;
+
+    const first = tokens[0]?.toLowerCase();
+    if (first === 'echo' || first === 'printf' || first === 'write-host') return false;
+    if (tokens[vercelIndex - 1] === '&' || tokens[vercelIndex - 1] === '=') return true;
+
+    const prefix = tokens.slice(0, vercelIndex);
+    if (isCommandPrefix(prefix)) return true;
+
+    return prefix.some((token, launcherIndex) => {
+      const launcher = token
+        .replace(/^@/, '')
+        .replace(/\.cmd$/i, '')
+        .toLowerCase();
+      if (!isCommandPrefix(prefix.slice(0, launcherIndex))) return false;
+      if (launcher === 'npx' || launcher === 'bunx' || launcher === 'pnpx') return true;
+
+      const launcherArguments = prefix
+        .slice(launcherIndex + 1)
+        .map((argument) => argument.toLowerCase());
+      if (launcher === 'npm') {
+        return launcherArguments.includes('exec') || launcherArguments.includes('x');
+      }
+      if (launcher === 'pnpm' || launcher === 'yarn') {
+        return launcherArguments.includes('dlx') || launcherArguments.includes('exec');
+      }
+      if (launcher === 'bun') return launcherArguments.includes('x');
+      return false;
+    });
+  });
+}
+
+function possibleVercelCommandTokens(
+  script: string,
+  dialect: ShellDialect = 'portable'
+): string[][] {
+  return vercelCommandTokens(script.replaceAll(DYNAMIC_SHELL_ARGUMENT, 'env'), dialect);
+}
+
+const VERCEL_OPTIONS_WITH_VALUES = new Set([
+  '--archive',
+  '--build-env',
+  '--cwd',
+  '--env',
+  '--global-config',
+  '--local-config',
+  '--meta',
+  '--name',
+  '--regions',
+  '--scope',
+  '--target',
+  '--timeout',
+  '--token',
+  '-a',
+  '-q',
+  '-s',
+  '-t',
+]);
+
+type PositionalVercelArgument = {
+  index: number;
+  token: string;
+};
+
+function positionalVercelArguments(argumentsAfterVercel: string[]): PositionalVercelArgument[] {
+  const positional: PositionalVercelArgument[] = [];
+  for (let index = 0; index < argumentsAfterVercel.length; index += 1) {
+    const token = normalizeCliArgument(argumentsAfterVercel[index] ?? '');
+    if (token === '--') continue;
+    if (token.startsWith('-')) {
+      if (!token.includes('=') && VERCEL_OPTIONS_WITH_VALUES.has(token)) index += 1;
+      continue;
+    }
+    positional.push({ index, token });
+  }
+  return positional;
+}
+
+function normalizeCliArgument(token: string): string {
+  return token.toLowerCase().replace(/=(['"])(.*?)\1$/, '=$2');
+}
+
+function productionTargetIndex(argumentsAfterVercel: string[]): number {
+  return argumentsAfterVercel.findIndex((rawToken, index) => {
+    const token = normalizeCliArgument(rawToken);
+    const nextToken = normalizeCliArgument(argumentsAfterVercel[index + 1] ?? '');
+    return (
+      token === '--prod' ||
+      token.startsWith('--prod=') ||
+      token === '--target=production' ||
+      (token === '--target' && nextToken === 'production')
+    );
+  });
+}
+
+function containsDirectProductionVercelCommand(
+  script: string,
+  dialect: ShellDialect = 'portable'
+): boolean {
+  return vercelCommandTokens(script, dialect).some((tokens) => {
+    const vercelIndex = tokens.findIndex(isVercelToken);
+    const argumentsAfterVercel = tokens
+      .slice(vercelIndex + 1)
+      .filter((token) => token !== DYNAMIC_ATOMIC_ARGUMENT);
+    const normalizedArguments = argumentsAfterVercel.map((token) => token.toLowerCase());
+    const positionalArguments = positionalVercelArguments(normalizedArguments);
+    const subcommand = positionalArguments[0]?.token;
+    const subcommandIndex = positionalArguments[0]?.index ?? Number.POSITIVE_INFINITY;
+
+    if (subcommand === 'promote') return true;
+    if (subcommand === 'alias') {
+      return !['list', 'ls'].includes(positionalArguments[1]?.token ?? '');
+    }
+    if (subcommand === 'rollback') {
+      return positionalArguments[1]?.token !== 'status';
+    }
+
+    if (subcommand === 'rolling-release' || subcommand === 'rr') {
+      const rollingReleaseAction = positionalArguments[1]?.token;
+      if (rollingReleaseAction === 'fetch' && positionalArguments.length === 2) {
+        return false;
+      }
+      return true;
+    }
+
+    const targetIndex = productionTargetIndex(normalizedArguments);
+    if (targetIndex === -1) return false;
+
+    if (subcommand === 'ls' || subcommand === 'list') {
+      return targetIndex < subcommandIndex;
+    }
+    return true;
+  });
+}
+
+function containsDynamicAtomicProductionCommand(script: string, dialect: ShellDialect): boolean {
+  return shellCommandTokens(script, dialect).some((tokens) => {
+    if (!tokens.includes(DYNAMIC_ATOMIC_ARGUMENT)) return false;
+    const possibleCommand = tokens
+      .map((token) => (token === DYNAMIC_ATOMIC_ARGUMENT ? 'env' : token))
+      .join(' ');
+    if (vercelCommandTokens(possibleCommand, dialect).length === 0) return false;
+
+    const vercelIndex = tokens.findIndex(isVercelToken);
+    const dynamicIndex = tokens.indexOf(DYNAMIC_ATOMIC_ARGUMENT);
+    if (dynamicIndex < vercelIndex) return true;
+
+    const positional = positionalVercelArguments(tokens.slice(vercelIndex + 1));
+    const subcommand = positional[0]?.token;
+    if (!subcommand || subcommand === DYNAMIC_ATOMIC_ARGUMENT.toLowerCase()) return true;
+    if (subcommand === 'ls' || subcommand === 'list') return false;
+    if (subcommand === 'alias') {
+      return !['list', 'ls'].includes(positional[1]?.token ?? '');
+    }
+    if (subcommand === 'rollback') return positional[1]?.token !== 'status';
+    if (subcommand === 'rolling-release' || subcommand === 'rr') {
+      return positional[1]?.token !== 'fetch';
+    }
+    return true;
+  });
+}
+
+type NestedShellCommand = {
+  dialect: ShellDialect;
+  text: string;
+};
+
+function nestedShellCommandStrings(script: string, dialect: ShellDialect): NestedShellCommand[] {
+  const nested: NestedShellCommand[] = [];
+
+  for (const command of shellCommandStrings(script, dialect)) {
+    const tokens = tokenizeShellCommand(command, dialect);
+    const first = tokens[0]?.replace(/^@/, '').toLowerCase();
+    if (first === 'echo' || first === 'printf' || first === 'write-host') continue;
+
+    const shellIndex = tokens.findIndex((token) => /(?:^|\/)(?:ba|z)?sh(?:\.exe)?$/i.test(token));
+    if (shellIndex !== -1 && isCommandPrefix(tokens.slice(0, shellIndex))) {
+      const flagIndex = tokens.findIndex(
+        (token, index) => index > shellIndex && /^-[a-z]*c[a-z]*$/i.test(token)
+      );
+      if (flagIndex !== -1 && tokens[flagIndex + 1]) {
+        nested.push({
+          dialect: 'posix',
+          text: tokens[flagIndex + 1],
+        });
+      }
+    }
+
+    const cmdIndex = tokens.findIndex((token) => /(?:^|\/)cmd(?:\.exe)?$/i.test(token));
+    if (cmdIndex !== -1 && isCommandPrefix(tokens.slice(0, cmdIndex))) {
+      const flagIndex = tokens.findIndex(
+        (token, index) => index > cmdIndex && token.toLowerCase() === '/c'
+      );
+      if (flagIndex !== -1 && tokens[flagIndex + 1]) {
+        nested.push({
+          dialect: 'cmd',
+          text: tokens[flagIndex + 1],
+        });
+      }
+    }
+
+    const powerShellIndex = tokens.findIndex((token) =>
+      /(?:^|\/)(?:pwsh|powershell)(?:\.exe)?$/i.test(token)
+    );
+    if (powerShellIndex !== -1 && isCommandPrefix(tokens.slice(0, powerShellIndex))) {
+      const flagIndex = tokens.findIndex(
+        (token, index) =>
+          index > powerShellIndex && ['-command', '-c'].includes(token.toLowerCase())
+      );
+      if (flagIndex !== -1 && tokens[flagIndex + 1]) {
+        nested.push({
+          dialect: 'powershell',
+          text: tokens[flagIndex + 1],
+        });
+      }
+    }
+
+    const expressionIndex = tokens.findIndex((token) => /^(?:invoke-expression|iex)$/i.test(token));
+    if (
+      expressionIndex !== -1 &&
+      isCommandPrefix(tokens.slice(0, expressionIndex)) &&
+      tokens[expressionIndex + 1]
+    ) {
+      nested.push({
+        dialect: 'powershell',
+        text: tokens[expressionIndex + 1],
+      });
+    }
+
+    const processIndex = tokens.findIndex((token) => /^start-process$/i.test(token));
+    if (processIndex !== -1 && isCommandPrefix(tokens.slice(0, processIndex))) {
+      const filePathIndex = tokens.findIndex(
+        (token, index) => index > processIndex && token.toLowerCase() === '-filepath'
+      );
+      const executable =
+        filePathIndex === -1 ? tokens[processIndex + 1] : tokens[filePathIndex + 1];
+      const argumentListIndex = tokens.findIndex(
+        (token, index) => index > processIndex && token.toLowerCase() === '-argumentlist'
+      );
+      if (executable && argumentListIndex !== -1) {
+        const argumentListMatch = /\s-ArgumentList\s+/i.exec(command);
+        const rawArguments = argumentListMatch
+          ? command.slice((argumentListMatch.index ?? 0) + argumentListMatch[0].length).trim()
+          : '';
+        const arrayOpenIndex = rawArguments.match(/^@?\s*\(/)?.[0].lastIndexOf('(') ?? -1;
+        const arrayContent =
+          arrayOpenIndex === -1
+            ? undefined
+            : balancedContent(rawArguments, arrayOpenIndex, '(', ')');
+        const scalarArgument = rawArguments.match(/^"([^"]*)"|'([^']*)'|([^\s]+)/);
+        const argumentsList =
+          arrayContent !== undefined
+            ? splitTopLevelArguments(arrayContent).map((argument) => {
+                const literal = argument.trim().match(/^(['"])(.*?)\1$/);
+                return literal?.[2] ?? DYNAMIC_ATOMIC_ARGUMENT;
+              })
+            : [scalarArgument?.[1] ?? scalarArgument?.[2] ?? scalarArgument?.[3] ?? ''].filter(
+                Boolean
+              );
+        nested.push({ dialect: 'powershell', text: [executable, ...argumentsList].join(' ') });
+      }
+    }
+  }
+
+  return nested;
+}
+
+function containsProductionVercelCommand(
+  script: string,
+  dialect: ShellDialect = 'portable',
+  depth = 0
+): boolean {
+  if (dialect === 'portable') {
+    return (['posix', 'powershell', 'cmd'] as const).some((candidate) =>
+      containsProductionVercelCommand(script, candidate, depth)
+    );
+  }
+  if (containsDirectProductionVercelCommand(script, dialect)) return true;
+  if (
+    script.includes(DYNAMIC_SHELL_ARGUMENT) &&
+    possibleVercelCommandTokens(script, dialect).length > 0
+  ) {
+    return true;
+  }
+  if (containsDynamicAtomicProductionCommand(script, dialect)) return true;
+  if (depth >= 4) return false;
+  return nestedShellCommandStrings(script, dialect).some((nested) =>
+    containsProductionVercelCommand(nested.text, nested.dialect, depth + 1)
+  );
+}
+
+type JavaScriptAnalysisContext = {
+  checker: ts.TypeChecker;
+  sourceFile: ts.SourceFile;
+};
+
+function createJavaScriptAnalysisContext(source: string): JavaScriptAnalysisContext {
+  const fileName = 'automation.ts';
+  const compilerOptions: ts.CompilerOptions = {
+    noLib: true,
+    noResolve: true,
+    target: ts.ScriptTarget.Latest,
+  };
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX
+  );
+  const baseHost = ts.createCompilerHost(compilerOptions, true);
+  const host: ts.CompilerHost = {
+    ...baseHost,
+    fileExists: (name) => name === fileName,
+    readFile: (name) => (name === fileName ? source : undefined),
+    getSourceFile: (name) => (name === fileName ? sourceFile : undefined),
+    writeFile: () => undefined,
+    getDefaultLibFileName: () => '',
+    getCurrentDirectory: () => '',
+    getDirectories: () => [],
+    getCanonicalFileName: (name) => name,
+    useCaseSensitiveFileNames: () => true,
+    getNewLine: () => '\n',
+  };
+  const program = ts.createProgram([fileName], compilerOptions, host);
+  return { checker: program.getTypeChecker(), sourceFile };
+}
+
+function symbolDeclaration(
+  identifier: ts.Identifier,
+  context: JavaScriptAnalysisContext
+): ts.Declaration | undefined {
+  const declarations = context.checker.getSymbolAtLocation(identifier)?.declarations ?? [];
+  return declarations.length === 1 ? declarations[0] : undefined;
+}
+
+function isConstDeclaration(declaration: ts.VariableDeclaration): boolean {
+  return (ts.getCombinedNodeFlags(declaration.parent) & ts.NodeFlags.Const) !== 0;
+}
+
+function staticCommandText(
+  node: ts.Expression | undefined,
+  context: JavaScriptAnalysisContext,
+  resolving = new Set<ts.Declaration>()
+): string | undefined {
+  if (!node) return undefined;
+  if (
+    ts.isParenthesizedExpression(node) ||
+    ts.isAsExpression(node) ||
+    ts.isSatisfiesExpression(node) ||
+    ts.isTypeAssertionExpression(node)
+  ) {
+    return staticCommandText(node.expression, context, resolving);
+  }
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+    return node.text;
+  }
+  if (ts.isIdentifier(node)) {
+    const binding = symbolDeclaration(node, context);
+    if (
+      !binding ||
+      !ts.isVariableDeclaration(binding) ||
+      !isConstDeclaration(binding) ||
+      !binding.initializer ||
+      resolving.has(binding)
+    ) {
+      return undefined;
+    }
+    const nextResolving = new Set(resolving);
+    nextResolving.add(binding);
+    return staticCommandText(binding.initializer, context, nextResolving);
+  }
+  if (ts.isTemplateExpression(node)) {
+    return [
+      node.head.text,
+      ...node.templateSpans.flatMap((span) => [
+        staticCommandText(span.expression, context, resolving) ?? ` ${DYNAMIC_SHELL_ARGUMENT} `,
+        span.literal.text,
+      ]),
+    ].join('');
+  }
+  if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.PlusToken) {
+    return `${staticCommandText(node.left, context, resolving) ?? ` ${DYNAMIC_SHELL_ARGUMENT} `}${
+      staticCommandText(node.right, context, resolving) ?? ` ${DYNAMIC_SHELL_ARGUMENT} `
+    }`;
+  }
+  return undefined;
+}
+
+type StaticArray = {
+  argumentsList: string[];
+  unresolved: boolean;
+};
+
+function staticCommandArray(
+  node: ts.Expression | undefined,
+  context: JavaScriptAnalysisContext,
+  resolving = new Set<ts.Declaration>()
+): StaticArray | undefined {
+  if (!node) return undefined;
+  if (
+    ts.isParenthesizedExpression(node) ||
+    ts.isAsExpression(node) ||
+    ts.isSatisfiesExpression(node) ||
+    ts.isTypeAssertionExpression(node)
+  ) {
+    return staticCommandArray(node.expression, context, resolving);
+  }
+  if (ts.isIdentifier(node)) {
+    const binding = symbolDeclaration(node, context);
+    if (
+      !binding ||
+      !ts.isVariableDeclaration(binding) ||
+      !isConstDeclaration(binding) ||
+      !binding.initializer ||
+      resolving.has(binding)
+    ) {
+      return undefined;
+    }
+    const nextResolving = new Set(resolving);
+    nextResolving.add(binding);
+    return staticCommandArray(binding.initializer, context, nextResolving);
+  }
+  if (!ts.isArrayLiteralExpression(node)) return undefined;
+
+  let unresolved = false;
+  const argumentsList: string[] = [];
+  for (const element of node.elements) {
+    if (ts.isSpreadElement(element)) {
+      const spreadArray = staticCommandArray(element.expression, context, resolving);
+      if (spreadArray) {
+        argumentsList.push(...spreadArray.argumentsList);
+        unresolved ||= spreadArray.unresolved;
+        continue;
+      }
+      unresolved = true;
+      argumentsList.push(DYNAMIC_ATOMIC_ARGUMENT);
+      continue;
+    }
+    const value = staticCommandText(element, context, resolving);
+    if (value === undefined || value.includes(DYNAMIC_SHELL_ARGUMENT)) {
+      unresolved = true;
+      argumentsList.push(DYNAMIC_ATOMIC_ARGUMENT);
+      continue;
+    }
+    argumentsList.push(value);
+  }
+  return { argumentsList, unresolved };
+}
+
+type ProcessModule = 'child_process' | 'execa';
+type ProcessProvenance = {
+  importedName?: string;
+  module: ProcessModule;
+  namespace: boolean;
+};
+
+function processModuleName(moduleName: string): ProcessModule | undefined {
+  if (moduleName === 'child_process' || moduleName === 'node:child_process') {
+    return 'child_process';
+  }
+  return moduleName === 'execa' ? 'execa' : undefined;
+}
+
+function importModuleName(
+  binding: ts.ImportClause | ts.ImportSpecifier | ts.NamespaceImport
+): string | undefined {
+  let ancestor: ts.Node | undefined = binding.parent;
+  while (ancestor && !ts.isImportDeclaration(ancestor)) ancestor = ancestor.parent;
+  return ancestor && ts.isStringLiteral(ancestor.moduleSpecifier)
+    ? ancestor.moduleSpecifier.text
+    : undefined;
+}
+
+function requireModuleName(node: ts.Expression | undefined): string | undefined {
+  if (
+    !node ||
+    !ts.isCallExpression(node) ||
+    !ts.isIdentifier(node.expression) ||
+    node.expression.text !== 'require'
+  ) {
+    return undefined;
+  }
+  const moduleArgument = node.arguments[0];
+  return moduleArgument && ts.isStringLiteral(moduleArgument) ? moduleArgument.text : undefined;
+}
+
+function containingVariableDeclaration(
+  binding: ts.BindingElement
+): ts.VariableDeclaration | undefined {
+  const bindingPattern = binding.parent;
+  return ts.isObjectBindingPattern(bindingPattern) &&
+    ts.isVariableDeclaration(bindingPattern.parent)
+    ? bindingPattern.parent
+    : undefined;
+}
+
+function staticPropertyName(
+  expression: ts.PropertyAccessExpression | ts.ElementAccessExpression,
+  context: JavaScriptAnalysisContext
+): string | undefined {
+  if (ts.isPropertyAccessExpression(expression)) return expression.name.text;
+  const argument = expression.argumentExpression;
+  return staticCommandText(argument, context);
+}
+
+function processNamespace(
+  expression: ts.Expression,
+  context: JavaScriptAnalysisContext,
+  resolving = new Set<ts.Declaration>()
+): ProcessProvenance | undefined {
+  if (ts.isIdentifier(expression)) {
+    const binding = symbolDeclaration(expression, context);
+    const provenance = binding ? processProvenance(binding, context, resolving) : undefined;
+    return provenance?.namespace ? provenance : undefined;
+  }
+  const module = processModuleName(requireModuleName(expression) ?? '');
+  return module ? { module, namespace: true } : undefined;
+}
+
+function processProvenance(
+  binding: ts.Declaration,
+  context: JavaScriptAnalysisContext,
+  resolving = new Set<ts.Declaration>()
+): ProcessProvenance | undefined {
+  if (resolving.has(binding)) return undefined;
+  const nextResolving = new Set(resolving);
+  nextResolving.add(binding);
+
+  if (ts.isImportSpecifier(binding)) {
+    const module = processModuleName(importModuleName(binding) ?? '');
+    if (!module) return undefined;
+    return {
+      importedName: binding.propertyName?.text ?? binding.name.text,
+      module,
+      namespace: false,
+    };
+  }
+  if (ts.isNamespaceImport(binding)) {
+    const module = processModuleName(importModuleName(binding) ?? '');
+    return module ? { module, namespace: true } : undefined;
+  }
+  if (ts.isImportClause(binding)) {
+    const module = processModuleName(importModuleName(binding) ?? '');
+    return module === 'execa' ? { importedName: 'execa', module, namespace: false } : undefined;
+  }
+  if (ts.isBindingElement(binding)) {
+    const declaration = containingVariableDeclaration(binding);
+    const directModule = processModuleName(requireModuleName(declaration?.initializer) ?? '');
+    const namespace =
+      declaration?.initializer && !directModule
+        ? processNamespace(declaration.initializer, context, nextResolving)
+        : undefined;
+    const module = directModule ?? namespace?.module;
+    if (!module) return undefined;
+    const importedName =
+      binding.propertyName && ts.isIdentifier(binding.propertyName)
+        ? binding.propertyName.text
+        : ts.isIdentifier(binding.name)
+          ? binding.name.text
+          : undefined;
+    if (!importedName) return undefined;
+    return { importedName, module, namespace: false };
+  }
+  if (!ts.isVariableDeclaration(binding) || !binding.initializer) return undefined;
+
+  const requiredModule = processModuleName(requireModuleName(binding.initializer) ?? '');
+  if (requiredModule) {
+    return {
+      importedName: requiredModule === 'execa' ? 'execa' : undefined,
+      module: requiredModule,
+      namespace: true,
+    };
+  }
+  if (ts.isIdentifier(binding.initializer)) {
+    const sourceBinding = symbolDeclaration(binding.initializer, context);
+    return sourceBinding ? processProvenance(sourceBinding, context, nextResolving) : undefined;
+  }
+  if (
+    ts.isPropertyAccessExpression(binding.initializer) ||
+    ts.isElementAccessExpression(binding.initializer)
+  ) {
+    const namespace = processNamespace(binding.initializer.expression, context, nextResolving);
+    const importedName = staticPropertyName(binding.initializer, context);
+    if (namespace && importedName) {
+      return { importedName, module: namespace.module, namespace: false };
+    }
+  }
+  return undefined;
+}
+
+type ProcessCallKind = 'argv' | 'command';
+
+function processCallKind(
+  expression: ts.LeftHandSideExpression,
+  context: JavaScriptAnalysisContext
+): ProcessCallKind | undefined {
+  let provenance: ProcessProvenance | undefined;
+  let importedName: string | undefined;
+
+  if (ts.isIdentifier(expression)) {
+    const binding = symbolDeclaration(expression, context);
+    provenance = binding ? processProvenance(binding, context) : undefined;
+    importedName = provenance?.importedName;
+  } else if (
+    ts.isPropertyAccessExpression(expression) ||
+    ts.isElementAccessExpression(expression)
+  ) {
+    provenance = processNamespace(expression.expression, context);
+    if (provenance?.namespace) importedName = staticPropertyName(expression, context);
+  }
+  if (!provenance || !importedName) return undefined;
+
+  if (provenance.module === 'child_process') {
+    if (['exec', 'execSync'].includes(importedName)) return 'command';
+    if (['spawn', 'spawnSync', 'execFile', 'execFileSync'].includes(importedName)) return 'argv';
+  }
+  if (provenance.module === 'execa') {
+    if (['execaCommand', 'execaCommandSync'].includes(importedName)) return 'command';
+    if (['execa', 'execaSync'].includes(importedName)) return 'argv';
+  }
+  return undefined;
+}
+
+type ChildProcessInspection = {
+  commands: string[];
+  unresolvedVercelCommand: boolean;
+  unresolvedVercelArguments: boolean;
+};
+
+function childProcessInspection(source: string): ChildProcessInspection {
+  const context = createJavaScriptAnalysisContext(source);
+  const { sourceFile } = context;
+  const commands: string[] = [];
+  let unresolvedVercelCommand = false;
+  let unresolvedVercelArguments = false;
+
+  function visit(node: ts.Node): void {
+    if (ts.isCallExpression(node)) {
+      const callKind = processCallKind(node.expression, context);
+      if (callKind === 'command') {
+        const commandNode = node.arguments[0];
+        const command = staticCommandText(commandNode, context);
+        if (command !== undefined) {
+          commands.push(command);
+          if (
+            command.includes(DYNAMIC_SHELL_ARGUMENT) &&
+            possibleVercelCommandTokens(command).length > 0
+          ) {
+            unresolvedVercelCommand = true;
+          }
+        }
+      }
+
+      if (callKind === 'argv') {
+        const executable = staticCommandText(node.arguments[0], context);
+        const argumentNode = node.arguments[1];
+        const staticArguments = staticCommandArray(argumentNode, context);
+        if (executable && staticArguments) {
+          const command = [executable, ...staticArguments.argumentsList].join(' ');
+          commands.push(command);
+          if (
+            staticArguments.unresolved &&
+            containsDynamicAtomicProductionCommand(command, 'portable')
+          ) {
+            unresolvedVercelArguments = true;
+          }
+        } else if (executable && argumentNode && vercelCommandTokens(executable).length > 0) {
+          unresolvedVercelArguments = true;
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return { commands, unresolvedVercelArguments, unresolvedVercelCommand };
+}
+
+function automationSurfaceHasProductionMutation(surface: AutomationSurface): boolean {
+  if (surface.language === 'action') return /vercel/i.test(surface.content);
+  if (surface.language === 'shell') {
+    return containsProductionVercelCommand(surface.content, surface.dialect ?? 'portable');
+  }
+  if (surface.language === 'javascript') {
+    const inspection = childProcessInspection(surface.content);
+    return (
+      inspection.unresolvedVercelCommand ||
+      inspection.unresolvedVercelArguments ||
+      inspection.commands.some(containsProductionVercelCommand)
+    );
+  }
+  if (surface.language === 'python') {
+    return pythonChildProcessCommandStrings(surface.content).some(
+      (command) =>
+        containsProductionVercelCommand(command) ||
+        (command.includes(DYNAMIC_ATOMIC_ARGUMENT) &&
+          containsDynamicAtomicProductionCommand(command, 'portable'))
+    );
+  }
+  return false;
+}
+
+function automationSurfaceHasVercelRestMutation(surface: AutomationSurface): boolean {
+  if (surface.language === 'shell') {
+    const dialect = surface.dialect ?? 'portable';
+    if (dialect === 'portable') {
+      return (['posix', 'powershell', 'cmd'] as const).some((candidate) =>
+        shellHasVercelRestMutation(surface.content, candidate)
+      );
+    }
+    return shellHasVercelRestMutation(surface.content, dialect);
+  }
+  if (surface.language === 'javascript') {
+    return javaScriptHasVercelRestMutation(surface.content);
+  }
+  if (surface.language === 'python') {
+    return pythonHasVercelRestMutation(surface.content);
+  }
+  return false;
+}
+
+function isVercelApiUrl(value: string): boolean {
+  return /https:\/\/api\.vercel\.com(?:\/|\b)/i.test(value);
+}
+
+function shellHasVercelRestMutation(script: string, dialect: ShellDialect): boolean {
+  if (dialect === 'portable') {
+    return (['posix', 'powershell', 'cmd'] as const).some((candidate) =>
+      shellHasVercelRestMutation(script, candidate)
+    );
+  }
+  return shellCommandStrings(script, dialect).some((command) => {
+    const tokens = tokenizeShellCommand(command, dialect);
+    const first = tokens[0]?.replace(/^@/, '').toLowerCase();
+    if (first === 'echo' || first === 'printf' || first === 'write-host') return false;
+    if (!tokens.some(isVercelApiUrl)) return false;
+
+    const nested = nestedShellCommandStrings(command, dialect);
+    if (nested.length > 0) {
+      return nested.some((payload) => shellHasVercelRestMutation(payload.text, payload.dialect));
+    }
+
+    const curlIndex = tokens.findIndex((token) => /(?:^|[/\\])curl(?:\.exe)?$/i.test(token));
+    if (curlIndex !== -1) {
+      const curlArguments = tokens.slice(curlIndex + 1);
+      let method: string | undefined;
+      let requestFlagSeen = false;
+      for (let index = 0; index < curlArguments.length; index += 1) {
+        const argument = curlArguments[index] ?? '';
+        if (argument === '-X' || argument === '--request') {
+          requestFlagSeen = true;
+          method = curlArguments[index + 1];
+          index += 1;
+          continue;
+        }
+        if (argument.startsWith('--request=')) {
+          requestFlagSeen = true;
+          method = argument.slice('--request='.length);
+          continue;
+        }
+        if (/^-X.+/.test(argument)) {
+          requestFlagSeen = true;
+          method = argument.slice(2).replace(/^=/, '');
+        }
+      }
+      if (requestFlagSeen && !method) return true;
+      if (method) return !['GET', 'HEAD'].includes(method.toUpperCase());
+      if (
+        curlArguments.includes('-G') ||
+        curlArguments.includes('--get') ||
+        curlArguments.includes('-I') ||
+        curlArguments.includes('--head')
+      ) {
+        return false;
+      }
+      return curlArguments.some((token) =>
+        /^(?:--data(?:-raw|-binary|-urlencode)?|-d|--form|-F|--json|-T|--upload-file)(?:=|$)/.test(
+          token
+        )
+      );
+    }
+
+    const powerShellRequestIndex = tokens.findIndex((token) =>
+      /^(?:invoke-restmethod|irm|invoke-webrequest|iwr)$/i.test(token)
+    );
+    if (powerShellRequestIndex !== -1) {
+      const requestArguments = tokens.slice(powerShellRequestIndex + 1);
+      const methodIndex = requestArguments.findIndex((token) => /^-method$/i.test(token));
+      if (methodIndex === -1) return false;
+      const method = requestArguments[methodIndex + 1];
+      return !method || !['GET', 'HEAD'].includes(method.toUpperCase());
+    }
+
+    const wgetIndex = tokens.findIndex((token) => /(?:^|[/\\])wget(?:\.exe)?$/i.test(token));
+    if (wgetIndex !== -1) {
+      const wgetArguments = tokens.slice(wgetIndex + 1);
+      const assignedMethod = wgetArguments.find((token) => /^--method=/.test(token));
+      const methodIndex = wgetArguments.findIndex((token) => token === '--method');
+      const method =
+        methodIndex === -1
+          ? assignedMethod?.slice('--method='.length)
+          : wgetArguments[methodIndex + 1];
+      if (methodIndex !== -1 && !method) return true;
+      if (method) return !['GET', 'HEAD'].includes(method.toUpperCase());
+      return wgetArguments.some((token) =>
+        /^(?:--post-data|--post-file|--body-data|--body-file)(?:=|$)/.test(token)
+      );
+    }
+
+    return true;
+  });
+}
+
+function javaScriptHasVercelRestMutation(source: string): boolean {
+  if (
+    childProcessInspection(source).commands.some((command) =>
+      shellHasVercelRestMutation(command, 'portable')
+    )
+  ) {
+    return true;
+  }
+  const context = createJavaScriptAnalysisContext(source);
+  let mutation = false;
+
+  function visit(node: ts.Node): void {
+    if (mutation) return;
+    if (ts.isCallExpression(node)) {
+      if (javaScriptTransportCallMutatesVercel(node, context)) mutation = true;
+      if (!mutation && isVercelSdkMutationCall(node, context)) mutation = true;
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(context.sourceFile);
+  return mutation;
+}
+
+type JavaScriptTransportCall = {
+  defaultMethod: 'GET' | 'UNKNOWN';
+  methodName?: string;
+  optionsIndex?: number;
+  optionsOnlyAtZero?: boolean;
+};
+
+function javaScriptTransportCall(
+  call: ts.CallExpression,
+  context: JavaScriptAnalysisContext
+): JavaScriptTransportCall | undefined {
+  const expression = call.expression;
+  if (
+    (ts.isIdentifier(expression) &&
+      expression.text === 'fetch' &&
+      symbolDeclaration(expression, context) === undefined) ||
+    (ts.isPropertyAccessExpression(expression) &&
+      ts.isIdentifier(expression.expression) &&
+      expression.expression.text === 'globalThis' &&
+      expression.name.text === 'fetch')
+  ) {
+    return { defaultMethod: 'GET', optionsIndex: 1 };
+  }
+
+  if (ts.isIdentifier(expression)) {
+    const module = javaScriptBindingModule(expression, context);
+    if (module === 'node-fetch') return { defaultMethod: 'GET', optionsIndex: 1 };
+    if (
+      ['node:http', 'node:https', 'http', 'https', 'undici'].includes(module ?? '') &&
+      ['request', 'get'].includes(importedJavaScriptName(expression, context) ?? '')
+    ) {
+      const methodName = importedJavaScriptName(expression, context);
+      return {
+        defaultMethod: methodName === 'get' ? 'GET' : 'GET',
+        methodName,
+        optionsIndex: 1,
+        optionsOnlyAtZero: module !== 'undici',
+      };
+    }
+    if (module === 'axios') return { defaultMethod: 'GET', optionsIndex: 0 };
+    return undefined;
+  }
+
+  if (!ts.isPropertyAccessExpression(expression) && !ts.isElementAccessExpression(expression)) {
+    return undefined;
+  }
+  const methodName = staticPropertyName(expression, context)?.toLowerCase();
+  if (!methodName) return undefined;
+  const receiver = expression.expression;
+  if (ts.isIdentifier(receiver) && isAxiosReceiver(receiver, context)) {
+    if (methodName === 'create') return undefined;
+    if (methodName === 'request') return { defaultMethod: 'GET', methodName, optionsIndex: 0 };
+    return { defaultMethod: 'UNKNOWN', methodName, optionsIndex: 1 };
+  }
+  if (
+    ts.isIdentifier(receiver) &&
+    javaScriptClientBase(receiver, context)?.module === 'undici' &&
+    methodName === 'request'
+  ) {
+    return { defaultMethod: 'GET', methodName, optionsIndex: 0 };
+  }
+  const root = expressionRootIdentifier(receiver);
+  const module = root ? javaScriptBindingModule(root, context) : undefined;
+  if (['node:http', 'node:https', 'http', 'https', 'undici'].includes(module ?? '')) {
+    if (methodName === 'request' || methodName === 'get') {
+      return {
+        defaultMethod: 'GET',
+        methodName,
+        optionsIndex: 1,
+        optionsOnlyAtZero: module !== 'undici',
+      };
+    }
+  }
+  return undefined;
+}
+
+function importedJavaScriptName(
+  identifier: ts.Identifier,
+  context: JavaScriptAnalysisContext
+): string | undefined {
+  const binding = symbolDeclaration(identifier, context);
+  if (binding && ts.isImportSpecifier(binding)) {
+    return binding.propertyName?.text ?? binding.name.text;
+  }
+  return identifier.text;
+}
+
+function resolvedJavaScriptExpression(
+  expression: ts.Expression | undefined,
+  context: JavaScriptAnalysisContext,
+  resolving = new Set<ts.Declaration>()
+): ts.Expression | undefined {
+  if (!expression || !ts.isIdentifier(expression)) return expression;
+  const binding = symbolDeclaration(expression, context);
+  if (
+    !binding ||
+    !ts.isVariableDeclaration(binding) ||
+    !isConstDeclaration(binding) ||
+    !binding.initializer ||
+    resolving.has(binding)
+  ) {
+    return expression;
+  }
+  const nextResolving = new Set(resolving);
+  nextResolving.add(binding);
+  return resolvedJavaScriptExpression(binding.initializer, context, nextResolving);
+}
+
+function javaScriptExpressionHasVercelApi(
+  expression: ts.Expression | undefined,
+  context: JavaScriptAnalysisContext
+): boolean {
+  const resolved = resolvedJavaScriptExpression(expression, context);
+  const staticText = staticCommandText(resolved, context);
+  if (staticText && isVercelApiUrl(staticText)) return true;
+  if (resolved && ts.isObjectLiteralExpression(resolved)) {
+    const hostname = javaScriptObjectProperty(resolved, 'hostname', context).expression;
+    const host = hostname ?? javaScriptObjectProperty(resolved, 'host', context).expression;
+    const staticHost = staticCommandText(host, context);
+    if (staticHost?.toLowerCase() === 'api.vercel.com') return true;
+    return resolved.properties.some((property) => {
+      if (ts.isPropertyAssignment(property)) {
+        return javaScriptExpressionHasVercelApi(property.initializer, context);
+      }
+      if (ts.isShorthandPropertyAssignment(property)) {
+        return javaScriptExpressionHasVercelApi(property.name, context);
+      }
+      return ts.isSpreadAssignment(property)
+        ? javaScriptExpressionHasVercelApi(property.expression, context)
+        : false;
+    });
+  }
+  if (resolved && ts.isArrayLiteralExpression(resolved)) {
+    return resolved.elements.some(
+      (element) =>
+        !ts.isSpreadElement(element) && javaScriptExpressionHasVercelApi(element, context)
+    );
+  }
+  return false;
+}
+
+function javaScriptObjectProperty(
+  expression: ts.Expression | undefined,
+  propertyName: string,
+  context: JavaScriptAnalysisContext
+): { dynamic: boolean; expression?: ts.Expression } {
+  const resolved = resolvedJavaScriptExpression(expression, context);
+  if (!resolved) return { dynamic: false };
+  if (!ts.isObjectLiteralExpression(resolved)) return { dynamic: true };
+  let dynamic = false;
+  let propertyExpression: ts.Expression | undefined;
+  for (const property of resolved.properties) {
+    if (ts.isSpreadAssignment(property)) {
+      dynamic = true;
+      continue;
+    }
+    if (!ts.isPropertyAssignment(property)) continue;
+    const name =
+      ts.isIdentifier(property.name) || ts.isStringLiteral(property.name)
+        ? property.name.text
+        : undefined;
+    if (name === propertyName) {
+      propertyExpression = property.initializer;
+      dynamic = false;
+    }
+  }
+  return { dynamic, expression: propertyExpression };
+}
+
+function javaScriptTransportCallMutatesVercel(
+  call: ts.CallExpression,
+  context: JavaScriptAnalysisContext
+): boolean {
+  const transport = javaScriptTransportCall(call, context);
+  if (!transport) return false;
+  const receiver =
+    ts.isPropertyAccessExpression(call.expression) || ts.isElementAccessExpression(call.expression)
+      ? call.expression.expression
+      : undefined;
+  const clientBase =
+    receiver && ts.isIdentifier(receiver)
+      ? javaScriptClientBase(receiver, context)?.baseUrl
+      : undefined;
+  if (
+    !call.arguments.some((argument) => javaScriptExpressionHasVercelApi(argument, context)) &&
+    !(clientBase && isVercelApiUrl(clientBase))
+  ) {
+    return false;
+  }
+  if (transport.methodName && ['get', 'head'].includes(transport.methodName)) return false;
+  if (transport.methodName && ['post', 'put', 'patch', 'delete'].includes(transport.methodName)) {
+    return true;
+  }
+
+  const firstArgument = resolvedJavaScriptExpression(call.arguments[0], context);
+  const options =
+    transport.optionsOnlyAtZero && firstArgument && ts.isObjectLiteralExpression(firstArgument)
+      ? call.arguments[0]
+      : call.arguments[transport.optionsIndex ?? -1];
+  const methodProperty = javaScriptObjectProperty(options, 'method', context);
+  if (methodProperty.expression) {
+    const method = staticCommandText(methodProperty.expression, context);
+    return methodProperty.dynamic || !method || !['GET', 'HEAD'].includes(method.toUpperCase());
+  }
+  if (methodProperty.dynamic) return true;
+  return transport.defaultMethod !== 'GET';
+}
+
+function javaScriptClientBase(
+  identifier: ts.Identifier,
+  context: JavaScriptAnalysisContext,
+  resolving = new Set<ts.Declaration>()
+): { baseUrl?: string; module: 'axios' | 'undici' } | undefined {
+  const binding = symbolDeclaration(identifier, context);
+  if (
+    !binding ||
+    resolving.has(binding) ||
+    !ts.isVariableDeclaration(binding) ||
+    !binding.initializer
+  ) {
+    return undefined;
+  }
+  const nextResolving = new Set(resolving);
+  nextResolving.add(binding);
+  if (ts.isIdentifier(binding.initializer)) {
+    return javaScriptClientBase(binding.initializer, context, nextResolving);
+  }
+  if (
+    ts.isCallExpression(binding.initializer) &&
+    (ts.isPropertyAccessExpression(binding.initializer.expression) ||
+      ts.isElementAccessExpression(binding.initializer.expression)) &&
+    staticPropertyName(binding.initializer.expression, context) === 'create'
+  ) {
+    const receiver = binding.initializer.expression.expression;
+    if (ts.isIdentifier(receiver) && isAxiosReceiver(receiver, context)) {
+      const baseUrlProperty = javaScriptObjectProperty(
+        binding.initializer.arguments[0],
+        'baseURL',
+        context
+      );
+      return {
+        baseUrl: staticCommandText(baseUrlProperty.expression, context),
+        module: 'axios',
+      };
+    }
+  }
+  if (
+    ts.isNewExpression(binding.initializer) &&
+    ts.isIdentifier(binding.initializer.expression) &&
+    javaScriptBindingModule(binding.initializer.expression, context) === 'undici' &&
+    importedJavaScriptName(binding.initializer.expression, context) === 'Client'
+  ) {
+    return {
+      baseUrl: staticCommandText(binding.initializer.arguments?.[0], context),
+      module: 'undici',
+    };
+  }
+  return undefined;
+}
+
+function javaScriptBindingModule(
+  identifier: ts.Identifier,
+  context: JavaScriptAnalysisContext
+): string | undefined {
+  const binding = symbolDeclaration(identifier, context);
+  if (!binding) return undefined;
+  if (
+    ts.isImportClause(binding) ||
+    ts.isImportSpecifier(binding) ||
+    ts.isNamespaceImport(binding)
+  ) {
+    return importModuleName(binding);
+  }
+  if (ts.isVariableDeclaration(binding)) return requireModuleName(binding.initializer);
+  return undefined;
+}
+
+function isAxiosReceiver(
+  identifier: ts.Identifier,
+  context: JavaScriptAnalysisContext,
+  resolving = new Set<ts.Declaration>()
+): boolean {
+  const binding = symbolDeclaration(identifier, context);
+  if (!binding || resolving.has(binding)) return false;
+  if (javaScriptBindingModule(identifier, context) === 'axios') return true;
+  if (!ts.isVariableDeclaration(binding) || !binding.initializer) return false;
+
+  const nextResolving = new Set(resolving);
+  nextResolving.add(binding);
+  if (ts.isIdentifier(binding.initializer)) {
+    return isAxiosReceiver(binding.initializer, context, nextResolving);
+  }
+  if (
+    ts.isCallExpression(binding.initializer) &&
+    ts.isPropertyAccessExpression(binding.initializer.expression) &&
+    binding.initializer.expression.name.text === 'create' &&
+    ts.isIdentifier(binding.initializer.expression.expression)
+  ) {
+    return isAxiosReceiver(binding.initializer.expression.expression, context, nextResolving);
+  }
+  return false;
+}
+
+function expressionRootIdentifier(expression: ts.Expression): ts.Identifier | undefined {
+  if (ts.isIdentifier(expression)) return expression;
+  if (ts.isPropertyAccessExpression(expression) || ts.isElementAccessExpression(expression)) {
+    return expressionRootIdentifier(expression.expression);
+  }
+  return undefined;
+}
+
+function isVercelSdkExpression(
+  expression: ts.Expression,
+  context: JavaScriptAnalysisContext,
+  resolving = new Set<ts.Declaration>()
+): boolean {
+  if (ts.isPropertyAccessExpression(expression) || ts.isElementAccessExpression(expression)) {
+    return isVercelSdkExpression(expression.expression, context, resolving);
+  }
+  if (ts.isNewExpression(expression) || ts.isCallExpression(expression)) {
+    return isVercelSdkExpression(expression.expression, context, resolving);
+  }
+  if (!ts.isIdentifier(expression)) return false;
+
+  const binding = symbolDeclaration(expression, context);
+  if (!binding || resolving.has(binding)) return false;
+  const module = javaScriptBindingModule(expression, context);
+  if (module === '@vercel/sdk' || module === '@vercel/client') return true;
+
+  const nextResolving = new Set(resolving);
+  nextResolving.add(binding);
+  if (ts.isBindingElement(binding)) {
+    const declaration = containingVariableDeclaration(binding);
+    return Boolean(
+      declaration?.initializer &&
+      isVercelSdkExpression(declaration.initializer, context, nextResolving)
+    );
+  }
+  if (ts.isVariableDeclaration(binding) && binding.initializer) {
+    return isVercelSdkExpression(binding.initializer, context, nextResolving);
+  }
+  return false;
+}
+
+function isVercelSdkMutatorExpression(
+  expression: ts.Expression,
+  context: JavaScriptAnalysisContext,
+  resolving = new Set<ts.Declaration>()
+): boolean {
+  const mutator =
+    /^(?:create|delete|update|promote|rollback|assign|set|start|approve|abort|complete|configure)/i;
+  if (ts.isPropertyAccessExpression(expression) || ts.isElementAccessExpression(expression)) {
+    const method = staticPropertyName(expression, context);
+    return Boolean(
+      method && mutator.test(method) && isVercelSdkExpression(expression.expression, context)
+    );
+  }
+  if (!ts.isIdentifier(expression)) return false;
+  const binding = symbolDeclaration(expression, context);
+  if (!binding || resolving.has(binding)) return false;
+  const nextResolving = new Set(resolving);
+  nextResolving.add(binding);
+  if (ts.isBindingElement(binding)) {
+    const declaration = containingVariableDeclaration(binding);
+    const importedName =
+      binding.propertyName && ts.isIdentifier(binding.propertyName)
+        ? binding.propertyName.text
+        : binding.name.getText();
+    return Boolean(
+      mutator.test(importedName) &&
+      declaration?.initializer &&
+      isVercelSdkExpression(declaration.initializer, context)
+    );
+  }
+  return Boolean(
+    ts.isVariableDeclaration(binding) &&
+    binding.initializer &&
+    isVercelSdkMutatorExpression(binding.initializer, context, nextResolving)
+  );
+}
+
+function isVercelSdkMutationCall(
+  call: ts.CallExpression,
+  context: JavaScriptAnalysisContext
+): boolean {
+  return isVercelSdkMutatorExpression(call.expression, context);
+}
+
+function pythonHasVercelRestMutation(source: string): boolean {
+  if (
+    pythonChildProcessCommandStrings(source).some((command) =>
+      shellHasVercelRestMutation(command, 'portable')
+    )
+  ) {
+    return true;
+  }
+  const withoutComments = stripShellComments(source, 'posix');
+  type PythonHttpModule = 'httpx' | 'requests' | 'urllib';
+  const namespaces = new Map<string, PythonHttpModule>();
+  const directCalls = new Map<string, { api: string; module: PythonHttpModule }>();
+  for (const match of withoutComments.matchAll(
+    /^\s*import\s+(httpx|requests)(?:\s+as\s+([A-Za-z_]\w*))?\s*$/gm
+  )) {
+    const module = match[1] as PythonHttpModule;
+    namespaces.set(match[2] ?? module, module);
+  }
+  for (const match of withoutComments.matchAll(
+    /^\s*import\s+urllib\.request(?:\s+as\s+([A-Za-z_]\w*))?\s*$/gm
+  )) {
+    namespaces.set(match[1] ?? 'urllib', 'urllib');
+  }
+  for (const match of withoutComments.matchAll(
+    /^\s*from\s+(httpx|requests|urllib\.request)\s+import\s+(.+?)\s*$/gm
+  )) {
+    const module = match[1] === 'urllib.request' ? 'urllib' : (match[1] as PythonHttpModule);
+    for (const imported of (match[2] ?? '').split(',')) {
+      const [api = '', alias] = imported.trim().split(/\s+as\s+/);
+      if (api) directCalls.set(alias ?? api, { api, module });
+    }
+  }
+
+  const callSearchSource = maskQuotedContent(withoutComments);
+  const callPattern = /\b([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\s*\(/g;
+  for (const match of callSearchSource.matchAll(callPattern)) {
+    const callee = match[1] ?? '';
+    const parts = callee.split('.');
+    const directCall = parts.length === 1 ? directCalls.get(callee) : undefined;
+    const module = directCall?.module ?? namespaces.get(parts[0] ?? '');
+    const api = directCall?.api ?? parts.at(-1) ?? '';
+    if (!module) continue;
+    if (
+      (module === 'requests' || module === 'httpx') &&
+      !['get', 'head', 'post', 'put', 'patch', 'delete', 'request'].includes(api.toLowerCase())
+    ) {
+      continue;
+    }
+    if (module === 'urllib' && !['Request', 'urlopen'].includes(api)) continue;
+
+    const openParenthesis = (match.index ?? 0) + match[0].lastIndexOf('(');
+    const callArguments = balancedContent(withoutComments, openParenthesis, '(', ')');
+    if (callArguments === undefined) continue;
+    const argumentsList = splitTopLevelArguments(callArguments);
+    const assignments = pythonAssignmentsBefore(withoutComments, match.index ?? 0);
+    const resolvedArguments = argumentsList.map((argument) => {
+      const expression = pythonKeywordArgument(argument).expression;
+      return pythonStaticCommand(expression, assignments) ?? expression;
+    });
+    if (!resolvedArguments.some((argument) => isVercelApiUrl(argument))) continue;
+    const normalizedApi = api.toLowerCase();
+    if (normalizedApi === 'get' || normalizedApi === 'head') continue;
+    if (['post', 'put', 'patch', 'delete'].includes(normalizedApi)) return true;
+    const keywordArguments = new Map(
+      argumentsList
+        .map(pythonKeywordArgument)
+        .filter(
+          (argument): argument is { expression: string; name: string } =>
+            argument.name !== undefined
+        )
+        .map((argument) => [argument.name.toLowerCase(), argument.expression])
+    );
+    if (normalizedApi === 'request' && module !== 'urllib') {
+      const methodExpression = keywordArguments.get('method') ?? argumentsList[0] ?? '';
+      const method = pythonStaticCommand(methodExpression, assignments);
+      if (!method || !['GET', 'HEAD'].includes(method.toUpperCase())) return true;
+      continue;
+    }
+    const methodExpression = keywordArguments.get('method');
+    if (methodExpression) {
+      const method = pythonStaticCommand(methodExpression, assignments);
+      if (!method || !['GET', 'HEAD'].includes(method.toUpperCase())) return true;
+      continue;
+    }
+    if (
+      argumentsList.some((argument) => argument.trim().startsWith('**')) ||
+      keywordArguments.has('data') ||
+      (normalizedApi === 'urlopen' &&
+        argumentsList.filter((argument) => !argument.includes('=')).length > 1)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function pythonAssignmentsBefore(source: string, beforeIndex: number): Map<string, string> {
+  const assignments = new Map<string, string>();
+  const prefix = source.slice(0, beforeIndex);
+  for (const match of prefix.matchAll(/^\s*([A-Za-z_]\w*)\s*=\s*(.+?)\s*$/gm)) {
+    const name = match[1];
+    const expression = match[2];
+    if (name && expression) assignments.set(name, expression);
+  }
+  return assignments;
+}
+
+function pythonKeywordArgument(argument: string): { expression: string; name?: string } {
+  const match = argument.trim().match(/^([A-Za-z_]\w*)\s*=\s*([\s\S]+)$/);
+  return match ? { expression: match[2] ?? '', name: match[1] } : { expression: argument.trim() };
+}
+
+function pythonChildProcessCommandStrings(source: string): string[] {
+  const withoutComments = stripShellComments(source, 'posix');
+  const commands: string[] = [];
+  const namespaces = new Map<string, 'os' | 'subprocess'>();
+  const directCalls = new Map<string, { api: string; module: 'os' | 'subprocess' }>();
+  const assignments = new Map<string, string>();
+  const ambiguousAssignments = new Set<string>();
+
+  for (const match of withoutComments.matchAll(
+    /^\s*import\s+(os|subprocess)(?:\s+as\s+([A-Za-z_]\w*))?\s*$/gm
+  )) {
+    const module = match[1] as 'os' | 'subprocess';
+    namespaces.set(match[2] ?? module, module);
+  }
+  for (const match of withoutComments.matchAll(
+    /^\s*from\s+(os|subprocess)\s+import\s+(.+?)\s*$/gm
+  )) {
+    const module = match[1] as 'os' | 'subprocess';
+    for (const imported of (match[2] ?? '').split(',')) {
+      const parts = imported.trim().split(/\s+as\s+/);
+      const api = parts[0] ?? '';
+      const localName = parts[1] ?? api;
+      if (api && localName) directCalls.set(localName, { api, module });
+    }
+  }
+  for (const match of withoutComments.matchAll(/^\s*([A-Za-z_]\w*)\s*=\s*(.+?)\s*$/gm)) {
+    const name = match[1] ?? '';
+    const expression = match[2] ?? '';
+    if (!name || !expression) continue;
+    if (assignments.has(name)) ambiguousAssignments.add(name);
+    assignments.set(name, expression);
+    namespaces.delete(name);
+    directCalls.delete(name);
+  }
+  for (const name of ambiguousAssignments) assignments.delete(name);
+
+  const allowedApis = {
+    os: new Set(['system']),
+    subprocess: new Set(['call', 'check_call', 'check_output', 'Popen', 'run']),
+  };
+  const callPattern = /\b([A-Za-z_]\w*)(?:\.([A-Za-z_]\w*))?\s*\(/g;
+  const callSearchSource = maskQuotedContent(withoutComments);
+  for (const match of callSearchSource.matchAll(callPattern)) {
+    const namespaceOrCall = match[1] ?? '';
+    const property = match[2];
+    const directCall = property ? undefined : directCalls.get(namespaceOrCall);
+    const module = property ? namespaces.get(namespaceOrCall) : directCall?.module;
+    const api = property ?? directCall?.api;
+    if (!module || !api || !allowedApis[module].has(api)) continue;
+
+    const openParenthesis = (match.index ?? 0) + match[0].lastIndexOf('(');
+    const callArguments = balancedContent(withoutComments, openParenthesis, '(', ')');
+    if (callArguments === undefined) continue;
+    const firstArgument = firstTopLevelArgument(callArguments);
+    const command = pythonStaticCommand(firstArgument, assignments);
+    if (command) commands.push(command);
+  }
+  return commands;
+}
+
+function maskQuotedContent(source: string): string {
+  const characters = [...source];
+  let quote: '"' | "'" | undefined;
+  let escaped = false;
+  for (let index = 0; index < characters.length; index += 1) {
+    const character = characters[index];
+    if (escaped) {
+      if (character !== '\n' && character !== '\r') characters[index] = ' ';
+      escaped = false;
+      continue;
+    }
+    if (quote) {
+      if (character === '\\') {
+        characters[index] = ' ';
+        escaped = true;
+      } else if (character === quote) {
+        quote = undefined;
+      } else if (character !== '\n' && character !== '\r') {
+        characters[index] = ' ';
+      }
+      continue;
+    }
+    if (character === '"' || character === "'") quote = character;
+  }
+  return characters.join('');
+}
+
+function balancedContent(
+  source: string,
+  openIndex: number,
+  opening: '(' | '[',
+  closing: ')' | ']'
+): string | undefined {
+  let depth = 0;
+  let quote: '"' | "'" | undefined;
+  let escaped = false;
+  for (let index = openIndex; index < source.length; index += 1) {
+    const character = source[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (character === quote) quote = undefined;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+      continue;
+    }
+    if (character === opening) depth += 1;
+    if (character === closing) {
+      depth -= 1;
+      if (depth === 0) return source.slice(openIndex + 1, index);
+    }
+  }
+  return undefined;
+}
+
+function firstTopLevelArgument(argumentsText: string): string {
+  return splitTopLevelArguments(argumentsText)[0]?.trim() ?? '';
+}
+
+function splitTopLevelArguments(argumentsText: string): string[] {
+  const argumentsList: string[] = [];
+  let argumentStart = 0;
+  let roundDepth = 0;
+  let squareDepth = 0;
+  let curlyDepth = 0;
+  let quote: '"' | "'" | undefined;
+  let escaped = false;
+  for (let index = 0; index < argumentsText.length; index += 1) {
+    const character = argumentsText[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (character === quote) quote = undefined;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+      continue;
+    }
+    if (character === '(') roundDepth += 1;
+    if (character === ')') roundDepth -= 1;
+    if (character === '[') squareDepth += 1;
+    if (character === ']') squareDepth -= 1;
+    if (character === '{') curlyDepth += 1;
+    if (character === '}') curlyDepth -= 1;
+    if (character === ',' && roundDepth === 0 && squareDepth === 0 && curlyDepth === 0) {
+      argumentsList.push(argumentsText.slice(argumentStart, index).trim());
+      argumentStart = index + 1;
+    }
+  }
+  argumentsList.push(argumentsText.slice(argumentStart).trim());
+  return argumentsList.filter(Boolean);
+}
+
+function pythonStaticCommand(
+  expression: string,
+  assignments: Map<string, string>,
+  resolving = new Set<string>()
+): string | undefined {
+  const trimmed = expression.trim();
+  if (/^[A-Za-z_]\w*$/.test(trimmed)) {
+    if (resolving.has(trimmed)) return undefined;
+    const initializer = assignments.get(trimmed);
+    if (!initializer) return undefined;
+    const nextResolving = new Set(resolving);
+    nextResolving.add(trimmed);
+    return pythonStaticCommand(initializer, assignments, nextResolving);
+  }
+
+  const stringMatch = trimmed.match(/^(['"])([\s\S]*)\1$/);
+  if (stringMatch) return stringMatch[2];
+  const sequence =
+    (trimmed.startsWith('[') && trimmed.endsWith(']')) ||
+    (trimmed.startsWith('(') && trimmed.endsWith(')'));
+  if (!sequence) return undefined;
+
+  const argumentsList = splitTopLevelArguments(trimmed.slice(1, -1)).map((argument) => {
+    const literal = argument.match(/^(['"])(.*?)\1$/);
+    return literal?.[2] ?? DYNAMIC_ATOMIC_ARGUMENT;
+  });
+  return argumentsList.some((argument) => argument !== DYNAMIC_ATOMIC_ARGUMENT)
+    ? argumentsList.join(' ')
+    : undefined;
+}
+
+function shouldExcludeAutomationPath(relativePath: string): boolean {
+  const normalizedPath = relativePath.replaceAll('\\', '/');
+  const segments = normalizedPath.split('/');
+  return (
+    segments.some(
+      (segment) =>
+        AUTOMATION_SCAN_EXCLUDED_DIRECTORIES.has(segment) ||
+        segment === 'generated' ||
+        segment === '_generated'
+    ) || normalizedPath === 'api/_app.generated.mjs'
+  );
+}
+
+async function listRepositoryFiles(): Promise<string[]> {
+  const { stdout } = await execFileAsync('git', ['ls-files', '-z'], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  return stdout
+    .split('\0')
+    .filter(Boolean)
+    .filter((relativePath) => !shouldExcludeAutomationPath(relativePath));
+}
+
+function automationLanguage(filePath: string, content: string): AutomationSurface['language'] {
+  if (/\.(?:cjs|cts|js|mjs|mts|ts|tsx)$/.test(filePath) || /^#!.*\bnode\b/.test(content)) {
+    return 'javascript';
+  }
+  if (/\.py$/.test(filePath) || /^#!.*\bpython(?:3)?\b/.test(content)) {
+    return 'python';
+  }
+  return 'shell';
+}
+
+function dialectFromShellName(shell: string | undefined): ShellDialect | undefined {
+  if (!shell || shell.includes('${{')) return undefined;
+  const executable = shell.trim().split(/\s+/)[0]?.toLowerCase() ?? '';
+  if (/(?:^|[/\\])(?:pwsh|powershell)(?:\.exe)?$/.test(executable)) return 'powershell';
+  if (/(?:^|[/\\])cmd(?:\.exe)?$/.test(executable)) return 'cmd';
+  if (/(?:^|[/\\])(?:ba|z)?sh(?:\.exe)?$/.test(executable)) return 'posix';
+  return undefined;
+}
+
+function workflowStepDialect(
+  step: WorkflowStep,
+  job: WorkflowJob,
+  workflow: Workflow
+): ShellDialect {
+  const configuredShell = step.shell ?? job.defaults?.run?.shell ?? workflow.defaults?.run?.shell;
+  const explicit = dialectFromShellName(configuredShell);
+  if (explicit) return explicit;
+  if (configuredShell) return 'portable';
+  const runners = typeof job['runs-on'] === 'string' ? [job['runs-on']] : (job['runs-on'] ?? []);
+  if (runners.some((runner) => /windows/i.test(runner))) return 'powershell';
+  if (runners.length > 0 && runners.every((runner) => /ubuntu|macos|linux/i.test(runner))) {
+    return 'posix';
+  }
+  return 'portable';
+}
+
+function operatorDialect(filePath: string, content: string): ShellDialect {
+  if (/\.(?:ps1)$/i.test(filePath) || /^#!.*\b(?:pwsh|powershell)\b/i.test(content)) {
+    return 'powershell';
+  }
+  if (/\.(?:bat|cmd)$/i.test(filePath) || /^#!.*\bcmd(?:\.exe)?\b/i.test(content)) {
+    return 'cmd';
+  }
+  if (/\.(?:bash|sh|zsh)$/i.test(filePath) || /^#!.*(?:\/|\b)(?:ba|z)?sh(?:\s|$)/i.test(content)) {
+    return 'posix';
+  }
+  return 'portable';
+}
+
+async function readAutomationSource(
+  absolutePath: string,
+  extension: string
+): Promise<string | undefined> {
+  if (AUTOMATION_SOURCE_EXTENSIONS.has(extension)) {
+    return readFile(absolutePath, 'utf8');
+  }
+
+  const handle = await open(absolutePath, 'r');
+  try {
+    const probe = Buffer.alloc(512);
+    const { bytesRead } = await handle.read(probe, 0, probe.length, 0);
+    if (!probe.subarray(0, bytesRead).toString('utf8').startsWith('#!')) return undefined;
+  } finally {
+    await handle.close();
+  }
+  return readFile(absolutePath, 'utf8');
+}
+
+async function collectAutomationSurfaces(): Promise<AutomationSurface[]> {
+  const surfaces: AutomationSurface[] = [];
+  const repositoryFiles = await listRepositoryFiles();
+  const workflowPaths = repositoryFiles.filter((filePath) =>
+    /^\.github\/workflows\/[^/]+\.ya?ml$/.test(filePath)
+  );
+
+  for (const workflowPath of workflowPaths) {
+    const workflowName = path.basename(workflowPath);
+    const workflow = await readWorkflow(workflowName);
+    for (const [jobName, job] of Object.entries(workflow.jobs ?? {})) {
+      if (typeof job.uses === 'string') {
+        surfaces.push({
+          id: `workflow-use:${workflowName}#${jobName}`,
+          content: job.uses,
+          language: 'action',
+        });
+      }
+      for (const [stepIndex, step] of (job.steps ?? []).entries()) {
+        if (typeof step.uses === 'string') {
+          surfaces.push({
+            id: `workflow-use:${workflowName}#${jobName}:${stepIndex}`,
+            content: step.uses,
+            language: 'action',
+          });
+        }
+        if (typeof step.run === 'string') {
+          surfaces.push({
+            id: `workflow:${workflowName}#${jobName}:${stepIndex}`,
+            content: step.run,
+            dialect: workflowStepDialect(step, job, workflow),
+            language: 'shell',
+          });
+        }
+      }
+    }
+  }
+
+  for (const actionPath of repositoryFiles.filter((filePath) =>
+    /^\.github\/actions\/.+\/action\.ya?ml$/.test(filePath)
+  )) {
+    const contents = await readFile(path.join(process.cwd(), actionPath), 'utf8');
+    const action = YAML.parse(contents) as CompositeAction;
+    for (const [stepIndex, step] of (action.runs?.steps ?? []).entries()) {
+      if (typeof step.uses === 'string') {
+        surfaces.push({
+          id: `action-use:${actionPath.slice('.github/actions/'.length)}#${stepIndex}`,
+          content: step.uses,
+          language: 'action',
+        });
+      }
+      if (typeof step.run === 'string') {
+        surfaces.push({
+          id: `action:${actionPath.slice('.github/actions/'.length)}#${stepIndex}`,
+          content: step.run,
+          dialect: dialectFromShellName(step.shell) ?? 'portable',
+          language: 'shell',
+        });
+      }
+    }
+  }
+
+  for (const packagePath of repositoryFiles.filter(
+    (filePath) => path.basename(filePath) === 'package.json'
+  )) {
+    const packageDocument = JSON.parse(
+      await readFile(path.join(process.cwd(), packagePath), 'utf8')
+    ) as { scripts?: Record<string, unknown> };
+    for (const [scriptName, script] of Object.entries(packageDocument.scripts ?? {})) {
+      if (typeof script === 'string') {
+        surfaces.push({
+          id: `package:${packagePath}#${scriptName}`,
+          content: script,
+          dialect: 'portable',
+          language: 'shell',
+        });
+      }
+    }
+  }
+
+  for (const filePath of repositoryFiles) {
+    const extension = path.extname(filePath);
+    const absolutePath = path.join(process.cwd(), filePath);
+    const content = await readAutomationSource(absolutePath, extension);
+    if (content === undefined) continue;
+
+    surfaces.push({
+      id: `operator:${filePath}`,
+      content,
+      dialect: operatorDialect(filePath, content),
+      language: automationLanguage(filePath, content),
+    });
+  }
+
+  return surfaces;
+}
+
+function callsReleaseWorkflow(workflow: Workflow): boolean {
+  const jobs = Object.values(workflow.jobs ?? {});
+  if (jobs.some((job) => job.uses === './.github/workflows/release-production.yml')) {
+    return true;
+  }
+
+  return allRunScripts(workflow).some((script) =>
+    shellCommandTokens(script).some((tokens) => {
+      if (tokens[0] !== 'gh') return false;
+
+      const delegatesWithCli =
+        tokens[1] === 'workflow' &&
+        tokens[2] === 'run' &&
+        tokens[3]?.replace(/^\.\//, '') === 'release-production.yml';
+      if (delegatesWithCli) return true;
+
+      if (tokens[1] !== 'api') return false;
+
+      const apiArguments = tokens.slice(2);
+      const hasDispatchEndpoint = apiArguments.some((token) =>
+        /\/actions\/workflows\/release-production\.yml\/dispatches(?:\?|$)/.test(token)
+      );
+      const hasExplicitPost = apiArguments.some((token, index) => {
+        if (/^(?:--method|-X)=POST$/i.test(token) || /^-XPOST$/i.test(token)) return true;
+        return (
+          (token === '--method' || token === '-X') &&
+          apiArguments[index + 1]?.toUpperCase() === 'POST'
+        );
+      });
+      return hasDispatchEndpoint && hasExplicitPost;
+    })
+  );
+}
+
+function directProductionCommandScripts(workflow: Workflow): string[] {
+  return allRunScripts(workflow).filter(containsProductionVercelCommand);
+}
+
 // The exact set of jobs the required aggregator (CI Gate Status) consumes.
 // Pinned so that adding a new gate input forces a conscious review of its
 // authority-vs-reporting classification below.
@@ -93,6 +2198,1247 @@ const GATE_FEEDING_JOBS = [
 ];
 
 describe('required CI fails closed', () => {
+  it.each([
+    ['POSIX backslash continuation', 'npx vercel \\\n --prod', 'posix'],
+    ['PowerShell backtick continuation', 'npx vercel `\n --prod', 'powershell'],
+    ['CMD caret continuation', 'npx vercel ^\n --prod', 'cmd'],
+    ['POSIX ampersand separator', 'printf safe & vercel --prod', 'posix'],
+    ['PowerShell ampersand separator', 'Write-Host safe & vercel --prod', 'powershell'],
+    ['CMD ampersand separator', 'echo safe & vercel --prod', 'cmd'],
+    ['PowerShell leading call operator', '& vercel --prod', 'powershell'],
+  ] as const)('uses dialect-specific shell semantics with %s', (_caseName, script, dialect) => {
+    expect(containsProductionVercelCommand(script, dialect)).toBe(true);
+  });
+
+  it.each([
+    ['POSIX does not consume backtick', 'npx vercel `\n --prod', 'posix'],
+    ['POSIX does not consume caret', 'npx vercel ^\n --prod', 'posix'],
+    ['PowerShell does not consume backslash', 'npx vercel \\\n --prod', 'powershell'],
+    ['PowerShell does not consume caret', 'npx vercel ^\n --prod', 'powershell'],
+    ['CMD does not consume backslash', 'npx vercel \\\n --prod', 'cmd'],
+    ['CMD does not consume backtick', 'npx vercel `\n --prod', 'cmd'],
+    ['POSIX escaped ampersand', 'printf safe \\& vercel --prod', 'posix'],
+    ['PowerShell escaped ampersand', 'Write-Host safe `& vercel --prod', 'powershell'],
+    ['CMD escaped ampersand', 'echo safe ^& vercel --prod', 'cmd'],
+    ['quoted ampersand', 'Write-Host "safe & vercel --prod"', 'powershell'],
+    ['CMD REM comment', 'REM safe & vercel --prod', 'cmd'],
+    ['CMD semicolon is ordinary', 'echo safe; vercel --prod', 'cmd'],
+  ] as const)('keeps dialect-inert command text inert with %s', (_caseName, script, dialect) => {
+    expect(containsProductionVercelCommand(script, dialect)).toBe(false);
+  });
+
+  it.each([
+    ['POSIX variable payload', 'PAYLOAD=\'npx vercel --prod\'; bash -c "$PAYLOAD"', 'posix'],
+    ['CMD variable payload', 'set "PAYLOAD=npx vercel --prod"\ncmd /c %PAYLOAD%', 'cmd'],
+    [
+      'PowerShell variable payload',
+      "$Payload = 'npx vercel --prod'; Invoke-Expression $Payload",
+      'powershell',
+    ],
+  ] as const)('resolves static interpreter payload with %s', (_caseName, script, dialect) => {
+    expect(containsProductionVercelCommand(script, dialect)).toBe(true);
+  });
+
+  it('does not invent production movement from unrelated static payloads', () => {
+    expect(
+      containsProductionVercelCommand(
+        "PAYLOAD='echo safe'; OTHER='npx vercel --prod'; bash -c \"$PAYLOAD\"",
+        'posix'
+      )
+    ).toBe(false);
+  });
+
+  it.each([
+    ['POSIX direct executable', 'CLI=vercel; "$CLI" --prod', 'posix'],
+    ['POSIX assigned interpreter', "SHELL=bash; $SHELL -c 'npx vercel --prod'", 'posix'],
+    ['PowerShell direct executable', "$Cli = 'vercel'; & $Cli --prod", 'powershell'],
+    [
+      'PowerShell Start-Process executable',
+      "$Exe = 'vercel'; Start-Process $Exe -ArgumentList '--prod'",
+      'powershell',
+    ],
+    ['CMD direct executable', 'set "CLI=vercel"\n%CLI% --prod', 'cmd'],
+  ] as const)('resolves static executable wrapper with %s', (_caseName, script, dialect) => {
+    expect(containsProductionVercelCommand(script, dialect)).toBe(true);
+  });
+
+  it.each([
+    ['later assignment', 'bash -c "$PAYLOAD"; PAYLOAD=\'npx vercel --prod\''],
+    [
+      'dynamic reassignment invalidates binding',
+      'PAYLOAD=\'npx vercel --prod\'; PAYLOAD=$RUNTIME; bash -c "$PAYLOAD"',
+    ],
+  ])('does not resolve stale POSIX assignment with %s', (_caseName, script) => {
+    expect(containsProductionVercelCommand(script, 'posix')).toBe(false);
+  });
+
+  it('uses dialect-specific comment and quote rules', () => {
+    expect(containsProductionVercelCommand('REM safe & vercel --prod', 'posix')).toBe(true);
+    expect(containsProductionVercelCommand('REM safe & vercel --prod', 'powershell')).toBe(true);
+    expect(containsProductionVercelCommand('# safe & vercel --prod', 'cmd')).toBe(true);
+    expect(containsProductionVercelCommand("echo 'safe & vercel --prod'", 'cmd')).toBe(true);
+    expect(
+      containsProductionVercelCommand("Write-Host 'safe `& vercel --prod'", 'powershell')
+    ).toBe(false);
+    expect(
+      containsProductionVercelCommand("Write-Host 'safe `' & vercel --prod", 'powershell')
+    ).toBe(true);
+    expect(containsProductionVercelCommand('echo "safe ^" & vercel --prod', 'cmd')).toBe(true);
+  });
+
+  it('applies workflow shell precedence and runner defaults', () => {
+    expect(
+      workflowStepDialect(
+        { run: 'echo safe', shell: 'cmd' },
+        { defaults: { run: { shell: 'pwsh' } }, 'runs-on': 'ubuntu-latest' },
+        { defaults: { run: { shell: 'bash' } } }
+      )
+    ).toBe('cmd');
+    expect(
+      workflowStepDialect(
+        { run: 'echo safe' },
+        { defaults: { run: { shell: 'pwsh' } }, 'runs-on': 'ubuntu-latest' },
+        { defaults: { run: { shell: 'bash' } } }
+      )
+    ).toBe('powershell');
+    expect(
+      workflowStepDialect(
+        { run: 'echo safe' },
+        { 'runs-on': 'ubuntu-latest' },
+        { defaults: { run: { shell: 'bash' } } }
+      )
+    ).toBe('posix');
+    expect(workflowStepDialect({ run: 'echo safe' }, { 'runs-on': 'windows-latest' }, {})).toBe(
+      'powershell'
+    );
+  });
+
+  it.each([
+    ['line continuation before production flag', 'npx vercel \\\n  --prod'],
+    ['global option before production flag', 'npx vercel --yes --prod'],
+    ['deploy subcommand before production flag', 'npx vercel deploy --prod'],
+    ['global option before promote', 'npx vercel --yes promote "$DEPLOYMENT_URL"'],
+    ['global option before alias', 'npx vercel --scope team alias source target'],
+    ['production target assignment', 'npx vercel deploy --target=production'],
+    ['production target pair', 'npx vercel deploy --target production'],
+    ['rollback', 'vercel rollback "$DEPLOYMENT_URL" --yes'],
+    ['rolling release mutation', 'npx vercel rolling-release approve'],
+    ['conditional promotion', 'if npx vercel promote "$DEPLOYMENT_URL"; then exit 0; fi'],
+    ['PowerShell call operator', '& vercel rollback "$DEPLOYMENT_URL" --yes'],
+    ['sudo wrapper', 'sudo npx vercel deploy --prod'],
+    ['npm exec wrapper', 'npm exec vercel -- --prod'],
+    ['pnpm dlx wrapper', 'pnpm dlx vercel --prod'],
+    ['deploy path named ls', 'npx vercel deploy ls --prod'],
+    ['default deploy path named ls', 'npx vercel --prod ls'],
+    ['batch echo-suppressed command', '@vercel deploy --prod'],
+    ['batch call wrapper', 'call npx vercel deploy --prod'],
+    ['cmd wrapper', 'cmd /c npx vercel deploy --prod'],
+    ['official vc alias', 'vc deploy --prod'],
+    ['Windows vc shim', 'vc.cmd deploy --prod'],
+    ['Windows Vercel shim', 'vercel.cmd deploy --prod'],
+    ['Windows npx shim', 'npx.cmd vercel deploy --prod'],
+    ['npx package with vc alias', 'npx --package=vercel@55 vc --prod'],
+    ['Corepack pnpm wrapper', 'corepack pnpm dlx vercel --prod'],
+    ['Bun x wrapper', 'bun x vercel --prod'],
+    ['quoted production target', "npx vercel deploy --target='production'"],
+    ['nested bash shell', "bash -lc 'npx vercel --prod'"],
+    ['nested sh shell', "sh -c 'npx vercel deploy --prod'"],
+    ['nested zsh shell', "zsh -c 'vc --prod'"],
+    ['nested cmd shell', 'cmd /c "vercel --prod"'],
+    ['nested PowerShell shell', "pwsh -Command 'vercel promote https://example.vercel.app'"],
+    ['PowerShell expression', "Invoke-Expression 'vercel rollback deployment-url'"],
+    ['PowerShell expression alias', "IEX 'vercel --prod'"],
+    ['PowerShell process', "Start-Process vercel -ArgumentList '--prod'"],
+    [
+      'PowerShell process with file path',
+      "Start-Process -FilePath vercel -ArgumentList '--target=production'",
+    ],
+    ['single ampersand sequence', 'Write-Host safe & npx vercel --prod'],
+    ['single ampersand direct sequence', 'Write-Host safe & vercel --prod'],
+    ['PowerShell backtick continuation', 'npx vercel `\n  --prod'],
+    ['batch caret continuation', 'npx vercel ^\n  --prod'],
+    [
+      'PowerShell process argument array',
+      'Start-Process -FilePath npx.cmd -ArgumentList @("vercel","--prod")',
+    ],
+    [
+      'PowerShell process dynamic Vercel arguments',
+      "Start-Process -FilePath npx.cmd -ArgumentList @('vercel', $runtimeArgs)",
+    ],
+    [
+      'PowerShell process dynamic direct arguments',
+      "Start-Process vercel -ArgumentList @('deploy', $runtimeFlag)",
+    ],
+  ])('detects Vercel production movement with %s', (_caseName, script) => {
+    expect(containsProductionVercelCommand(script)).toBe(true);
+  });
+
+  it.each(
+    ['start', 'approve', 'abort', 'complete', 'configure'].flatMap((action) => [
+      [`long rolling-release ${action}`, `npx vercel rolling-release ${action}`],
+      [`short rolling-release ${action}`, `npx vercel rr ${action}`],
+    ])
+  )('detects Vercel rolling-release mutation with %s', (_caseName, script) => {
+    expect(containsProductionVercelCommand(script)).toBe(true);
+  });
+
+  it.each([
+    ['commented command', '# npx vercel deploy --prod'],
+    ['echoed command', 'echo "npx vercel deploy --prod"'],
+    ['PowerShell display string', 'Write-Host "vercel rollback old-url --yes"'],
+    ['production-filtered listing', 'vercel ls --prod'],
+    ['production-filtered listing through npx', 'npx vercel ls --prod'],
+    ['production-filtered list alias', 'npx vercel list --prod'],
+    ['global option before listing', 'npx vercel --scope team ls --prod'],
+    ['global assignment before list alias', 'npx vercel --scope=team list --prod'],
+    ['long rolling-release fetch', 'npx vercel rolling-release fetch'],
+    ['short rolling-release fetch', 'npx vercel rr fetch'],
+    ['optioned long rolling-release fetch', 'npx vercel --scope team rolling-release fetch --yes'],
+    ['optioned short rolling-release fetch', 'npx vercel rr --scope team fetch --yes'],
+    ['read-only alias list', 'npx vercel alias list'],
+    ['read-only alias ls', 'npx vercel --scope team alias ls'],
+    ['read-only rollback status', 'npx vercel rollback status project-name'],
+    ['read-only vc listing', 'vc list --prod'],
+    ['nested read-only listing', "bash -lc 'vercel ls --prod'"],
+    ['nested read-only alias list', "pwsh -Command 'vercel alias list'"],
+    ['PowerShell call operator read-only', '& vercel ls --prod'],
+    ['quoted ampersand example', 'Write-Host "safe & npx vercel --prod"'],
+    [
+      'PowerShell process read-only argument array',
+      'Start-Process -FilePath npx.cmd -ArgumentList @("vercel","ls","--prod")',
+    ],
+    [
+      'PowerShell process bounded argument list',
+      "Start-Process vercel -ArgumentList @('ls','--prod') -WorkingDirectory 'x --prod'",
+    ],
+  ])('ignores inert or read-only Vercel production text with %s', (_caseName, script) => {
+    expect(containsProductionVercelCommand(script)).toBe(false);
+  });
+
+  it('detects JavaScript child-process mutations but ignores inert examples', () => {
+    expect(
+      automationSurfaceHasProductionMutation({
+        id: 'synthetic:exec',
+        content: [
+          "import { execSync } from 'node:child_process';",
+          "execSync('npx vercel --prod');",
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasProductionMutation({
+        id: 'synthetic:spawn',
+        content: [
+          "import { spawnSync } from 'node:child_process';",
+          "spawnSync('pnpm', ['dlx', 'vercel', 'rr', 'approve']);",
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasProductionMutation({
+        id: 'synthetic:template',
+        content: [
+          "const { execSync } = require('node:child_process');",
+          'execSync(`npx vercel --prod --meta sha=${expectedSha}`);',
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasProductionMutation({
+        id: 'synthetic:concatenation',
+        content: [
+          "const childProcess = require('child_process');",
+          "childProcess.execSync('npx vercel deploy ' + '--target=production');",
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasProductionMutation({
+        id: 'synthetic:dynamic-spawn',
+        content: [
+          "import * as childProcess from 'node:child_process';",
+          "childProcess.execFileSync('vercel', ['deploy', dynamicFlag, '--prod']);",
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasProductionMutation({
+        id: 'synthetic:const-command',
+        content: [
+          "import { execSync } from 'node:child_process';",
+          "const target = '--prod';",
+          "const command = 'npx vercel deploy ' + target;",
+          'execSync(command);',
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasProductionMutation({
+        id: 'synthetic:const-args',
+        content: [
+          "import { execaSync } from 'execa';",
+          "const cli = 'vercel';",
+          "const args = ['deploy', '--target=production'];",
+          'execaSync(cli, args);',
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasProductionMutation({
+        id: 'synthetic:unresolved-vercel-args',
+        content: [
+          "import { spawnSync } from 'node:child_process';",
+          "spawnSync('vercel', runtimeArgs);",
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasProductionMutation({
+        id: 'synthetic:unresolved-exec-template',
+        content: [
+          "import { execSync } from 'node:child_process';",
+          "const cli = 'vercel';",
+          'execSync(`${cli} ${runtimeArgs}`);',
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasProductionMutation({
+        id: 'synthetic:unresolved-exec-wrapper',
+        content: [
+          "import { execSync } from 'node:child_process';",
+          'execSync(`${runtimeRunner} vercel ${runtimeArgs}`);',
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasProductionMutation({
+        id: 'synthetic:unresolved-exec-wrapper-with-prod',
+        content: [
+          "import { execSync } from 'node:child_process';",
+          'execSync(`${runtimeRunner} vercel --prod`);',
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasProductionMutation({
+        id: 'synthetic:duplicate-const-scopes',
+        content: [
+          "import { execSync } from 'node:child_process';",
+          "function deploy() { const cmd = 'npx vercel --prod'; execSync(cmd); }",
+          "function safe() { const cmd = 'echo safe'; execSync(cmd); }",
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasProductionMutation({
+        id: 'synthetic:duplicate-safe-const-scopes',
+        content: [
+          "import { execSync } from 'node:child_process';",
+          "function inspect() { const cmd = 'vercel ls --prod'; execSync(cmd); }",
+          "function safe() { const cmd = 'echo safe'; execSync(cmd); }",
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(false);
+    expect(
+      automationSurfaceHasProductionMutation({
+        id: 'synthetic:dormant-cross-scope-command',
+        content: [
+          "import { execSync } from 'node:child_process';",
+          "function dormant() { const cmd = 'npx vercel --prod'; return cmd; }",
+          "function safe() { const cmd = 'echo safe'; execSync(cmd); }",
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(false);
+    expect(
+      automationSurfaceHasProductionMutation({
+        id: 'synthetic:unrelated-method-name',
+        content: "runner.execSync('npx vercel --prod');",
+        language: 'javascript',
+      })
+    ).toBe(false);
+    expect(
+      automationSurfaceHasProductionMutation({
+        id: 'synthetic:echoed-unresolved-exec',
+        content: [
+          "import { execSync } from 'node:child_process';",
+          'execSync(`echo ${runtimeText} vercel --prod`);',
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(false);
+    expect(
+      automationSurfaceHasProductionMutation({
+        id: 'synthetic:inert',
+        content: [
+          "// execSync('npx vercel --prod');",
+          'const example = "execSync(\'npx vercel --prod\')";',
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(false);
+    expect(
+      automationSurfaceHasProductionMutation({
+        id: 'synthetic:python',
+        content: 'import subprocess\nsubprocess.run(["npx", "vercel", "deploy", "--prod"])',
+        language: 'python',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasProductionMutation({
+        id: 'synthetic:python-comment',
+        content: '# subprocess.run(["npx", "vercel", "deploy", "--prod"])',
+        language: 'python',
+      })
+    ).toBe(false);
+    expect(
+      automationSurfaceHasProductionMutation({
+        id: 'synthetic:python-keyword-string',
+        content:
+          'import subprocess\nsubprocess.run(["vercel", "deploy"], env={"TARGET": "--prod"})',
+        language: 'python',
+      })
+    ).toBe(false);
+    expect(
+      automationSurfaceHasProductionMutation({
+        id: 'synthetic:batch',
+        content: 'vercel deploy --target production',
+        language: 'shell',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasProductionMutation({
+        id: 'synthetic:batch-comment',
+        content: 'REM vercel deploy --target production',
+        language: 'shell',
+      })
+    ).toBe(false);
+  });
+
+  it.each([
+    [
+      'spawnSync wrapper spread',
+      "import { spawnSync } from 'node:child_process';\nspawnSync('npx', ['vercel', ...runtimeArgs]);",
+    ],
+    [
+      'spawn wrapper spread',
+      "import { spawn } from 'node:child_process';\nspawn('pnpm', ['dlx', 'vercel', ...runtimeArgs]);",
+    ],
+    [
+      'execFileSync wrapper spread',
+      "import { execFileSync } from 'node:child_process';\nexecFileSync('npm', ['exec', 'vercel', ...runtimeArgs]);",
+    ],
+    [
+      'execFile wrapper spread',
+      "import { execFile } from 'node:child_process';\nexecFile('bun', ['x', 'vercel', ...runtimeArgs]);",
+    ],
+    [
+      'execaSync wrapper spread',
+      "import { execaSync } from 'execa';\nexecaSync('npx', ['vercel', ...runtimeArgs]);",
+    ],
+    [
+      'execa wrapper spread',
+      "import { execa } from 'execa';\nexeca('yarn', ['dlx', 'vercel', ...runtimeArgs]);",
+    ],
+    [
+      'const argv wrapper spread',
+      [
+        "import { spawnSync } from 'node:child_process';",
+        "const argv = ['vercel', ...runtimeArgs];",
+        "spawnSync('npx', argv);",
+      ].join('\n'),
+    ],
+  ])('fails closed for unresolved wrapped argv with %s', (_caseName, content) => {
+    expect(
+      automationSurfaceHasProductionMutation({
+        id: 'synthetic:wrapped-unresolved',
+        content,
+        language: 'javascript',
+      })
+    ).toBe(true);
+  });
+
+  it.each([
+    [
+      'aliased ESM child-process import',
+      "import { spawnSync as run } from 'node:child_process';\nrun('npx', ['vercel', '--prod']);",
+    ],
+    [
+      'ESM child-process namespace',
+      "import * as cp from 'child_process';\ncp.execFileSync('npx', ['vercel', '--prod']);",
+    ],
+    [
+      'destructured CJS child-process require',
+      "const { spawnSync: run } = require('node:child_process');\nrun('npx', ['vercel', '--prod']);",
+    ],
+    [
+      'CJS child-process namespace',
+      "const cp = require('child_process');\ncp.execSync('npx vercel --prod');",
+    ],
+    ['default execa import', "import execa from 'execa';\nexeca('npx', ['vercel', '--prod']);"],
+    [
+      'resolved static array spread',
+      [
+        "import { spawnSync } from 'node:child_process';",
+        "const prefix = ['vercel'];",
+        'const argv = [...prefix, ...runtimeArgs];',
+        "spawnSync('npx', argv);",
+      ].join('\n'),
+    ],
+    [
+      'inline child-process require',
+      "require('node:child_process').execSync('npx vercel --prod');",
+    ],
+    [
+      'CJS namespace element access',
+      "const cp = require('child_process');\ncp['execSync']('npx vercel --prod');",
+    ],
+    [
+      'namespace member alias',
+      "const cp = require('child_process');\nconst run = cp.execSync;\nrun('npx vercel --prod');",
+    ],
+    [
+      'named import alias variable',
+      "import { execSync } from 'node:child_process';\nconst run = execSync;\nrun('npx vercel --prod');",
+    ],
+    ['inline execa require', "require('execa').execaSync('npx', ['vercel', '--prod']);"],
+    [
+      'two-step CJS namespace destructure',
+      [
+        "const cp = require('child_process');",
+        'const { execSync } = cp;',
+        "execSync('npx vercel --prod');",
+      ].join('\n'),
+    ],
+    [
+      'computed const process method',
+      [
+        "import * as cp from 'node:child_process';",
+        "const method = 'execSync';",
+        "cp[method]('npx vercel --prod');",
+      ].join('\n'),
+    ],
+  ])('accepts proven process provenance with %s', (_caseName, content) => {
+    expect(
+      automationSurfaceHasProductionMutation({
+        id: 'synthetic:provenance-positive',
+        content,
+        language: 'javascript',
+      })
+    ).toBe(true);
+  });
+
+  it.each([
+    [
+      'fully dynamic wrapper argv',
+      "import { spawnSync } from 'node:child_process';\nspawnSync('npx', runtimeArgs);",
+    ],
+    ['unproven bare call', "execSync('npx vercel --prod');"],
+    ['unrelated object method', "runner.execSync('npx vercel --prod');"],
+    [
+      'function shadow',
+      [
+        "import { execSync } from 'node:child_process';",
+        'function safe() {',
+        '  function execSync(_command) {}',
+        "  execSync('npx vercel --prod');",
+        '}',
+      ].join('\n'),
+    ],
+    [
+      'parameter shadow',
+      [
+        "import { execSync } from 'node:child_process';",
+        "function safe(execSync) { execSync('npx vercel --prod'); }",
+      ].join('\n'),
+    ],
+    [
+      'catch binding shadow',
+      [
+        "import { execSync } from 'node:child_process';",
+        "try { throw new Error('safe'); }",
+        "catch (execSync) { execSync('npx vercel --prod'); }",
+      ].join('\n'),
+    ],
+    [
+      'local const shadow',
+      [
+        "import { execSync } from 'node:child_process';",
+        "function safe() { const execSync = () => undefined; execSync('npx vercel --prod'); }",
+      ].join('\n'),
+    ],
+  ])('ignores unproven or shadowed process call with %s', (_caseName, content) => {
+    expect(
+      automationSurfaceHasProductionMutation({
+        id: 'synthetic:provenance-negative',
+        content,
+        language: 'javascript',
+      })
+    ).toBe(false);
+  });
+
+  it.each([
+    ['list', "spawnSync('vercel', ['ls', ...runtimeArgs]);"],
+    ['list alias', "spawnSync('vercel', ['list', ...runtimeArgs]);"],
+    ['alias list', "spawnSync('vercel', ['alias', 'list', ...runtimeArgs]);"],
+    ['alias ls', "spawnSync('vercel', ['alias', 'ls', ...runtimeArgs]);"],
+    ['rollback status', "spawnSync('vercel', ['rollback', 'status', ...runtimeArgs]);"],
+    ['rolling release fetch', "spawnSync('vercel', ['rr', 'fetch', ...runtimeArgs]);"],
+  ])('keeps fixed read-only atomic argv read-only with %s', (_caseName, invocation) => {
+    expect(
+      automationSurfaceHasProductionMutation({
+        id: 'synthetic:read-only-atomic-tail',
+        content: ["import { spawnSync } from 'node:child_process';", invocation].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(false);
+  });
+
+  it('fails closed when dynamic atomic argv precedes the Vercel action', () => {
+    expect(
+      automationSurfaceHasProductionMutation({
+        id: 'synthetic:dynamic-atomic-action',
+        content: [
+          "import { spawnSync } from 'node:child_process';",
+          "spawnSync('vercel', [runtimeAction, 'ls']);",
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(true);
+  });
+
+  it('keeps atomic template interpolation after a fixed read-only action read-only', () => {
+    expect(
+      automationSurfaceHasProductionMutation({
+        id: 'synthetic:atomic-template-tail',
+        content: [
+          "import { spawnSync } from 'node:child_process';",
+          "spawnSync('vercel', ['ls', `${runtimeTail}`]);",
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(false);
+  });
+
+  it('distinguishes Start-Process read-only tails from dynamic actions', () => {
+    expect(
+      containsProductionVercelCommand(
+        "Start-Process vercel -ArgumentList @('ls', $runtimeArgs)",
+        'powershell'
+      )
+    ).toBe(false);
+    expect(
+      containsProductionVercelCommand(
+        "Start-Process vercel -ArgumentList @($runtimeAction, 'ls')",
+        'powershell'
+      )
+    ).toBe(true);
+  });
+
+  it.each([
+    ['inline list', 'import subprocess\nsubprocess.run(["npx", "vercel", "--prod"])'],
+    ['inline tuple', 'import subprocess\nsubprocess.run(("npx", "vercel", "--prod"))'],
+    ['inline string', 'import subprocess\nsubprocess.run("npx vercel --prod", shell=True)'],
+    [
+      'const-bound list',
+      'import subprocess\nargv = ["npx", "vercel", "--prod"]\nsubprocess.run(argv)',
+    ],
+    [
+      'const-bound tuple',
+      'import subprocess\nargv = ("npx", "vercel", "--prod")\nsubprocess.Popen(argv)',
+    ],
+    [
+      'unresolved inline tail',
+      'import subprocess\nsubprocess.run(["npx", "vercel", *runtime_args])',
+    ],
+    [
+      'unresolved const tail',
+      'import subprocess\nargv = ["npx", "vercel", *runtime_args]\nsubprocess.run(argv)',
+    ],
+    ['aliased subprocess import', 'import subprocess as sp\nsp.run(("npx", "vercel", "--prod"))'],
+    [
+      'aliased direct import',
+      'from subprocess import run as execute\nexecute(["npx", "vercel", "--prod"])',
+    ],
+    ['os system import', 'import os\nos.system("npx vercel --prod")'],
+    [
+      'dynamic action before read-only token',
+      'import subprocess\nsubprocess.run(["vercel", runtime_action, "ls"])',
+    ],
+  ])('detects Python production invocation with %s', (_caseName, content) => {
+    expect(
+      automationSurfaceHasProductionMutation({
+        id: 'synthetic:python-command',
+        content,
+        language: 'python',
+      })
+    ).toBe(true);
+  });
+
+  it.each([
+    ['read-only tuple', 'import subprocess\nsubprocess.run(("vercel", "ls", "--prod"))'],
+    ['dormant const', 'argv = ["npx", "vercel", "--prod"]\nprint("safe")'],
+    ['unrelated dynamic argv', 'import subprocess\nsubprocess.run(["echo", *runtime_args])'],
+    [
+      'fake subprocess object',
+      [
+        'import subprocess',
+        'class Fake:',
+        '    def run(self, argv): pass',
+        'subprocess = Fake()',
+        'subprocess.run(["npx", "vercel", "--prod"])',
+      ].join('\n'),
+    ],
+    [
+      'proven import with inert string',
+      ['import subprocess', 'example = \'subprocess.run(["npx", "vercel", "--prod"])\''].join('\n'),
+    ],
+    [
+      'fully dynamic wrapper tail without Vercel evidence',
+      'import subprocess\nsubprocess.run(["npx", *runtime_args])',
+    ],
+    [
+      'dynamic tail after fixed read-only action',
+      'import subprocess\nsubprocess.run(["vercel", "ls", runtime_tail])',
+    ],
+  ])('ignores safe Python invocation with %s', (_caseName, content) => {
+    expect(
+      automationSurfaceHasProductionMutation({
+        id: 'synthetic:python-safe',
+        content,
+        language: 'python',
+      })
+    ).toBe(false);
+  });
+
+  it('rejects Vercel deployment action uses and pins scan exclusions', () => {
+    expect(
+      automationSurfaceHasProductionMutation({
+        id: 'synthetic:action',
+        content: 'amondnet/vercel-action@v25',
+        language: 'action',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasProductionMutation({
+        id: 'synthetic:safe-action',
+        content: 'actions/checkout@pinned-sha',
+        language: 'action',
+      })
+    ).toBe(false);
+
+    expect([...AUTOMATION_SCAN_EXCLUDED_DIRECTORIES].sort()).toEqual(
+      [
+        '.cache',
+        '.git',
+        '.npm-cache',
+        '.omx',
+        '.superpowers',
+        '.vercel',
+        'build',
+        'coverage',
+        'dist',
+        'docs',
+        'node_modules',
+        'snapshots',
+        'tests',
+      ].sort()
+    );
+    expect(shouldExcludeAutomationPath(path.join('api', '_app.generated.mjs'))).toBe(true);
+    expect(shouldExcludeAutomationPath(path.join('docs', 'deploy.sh'))).toBe(true);
+    expect(shouldExcludeAutomationPath('deploy.sh')).toBe(false);
+    expect([...AUTOMATION_SOURCE_EXTENSIONS]).toEqual(
+      expect.arrayContaining(['.bat', '.cmd', '.cts', '.mts', '.py', '.tsx'])
+    );
+  });
+
+  it('distinguishes Vercel REST mutations from read-only API requests', () => {
+    for (const command of [
+      'curl -X DELETE "https://api.vercel.com/v13/deployments/dpl_123"',
+      'curl -XPOST "https://api.vercel.com/v13/deployments"',
+      'curl -X "$METHOD" "https://api.vercel.com/v13/deployments"',
+      'curl -X "https://api.vercel.com/v13/deployments"',
+      'curl --json \'{"name":"release"}\' "https://api.vercel.com/v13/deployments"',
+      'curl -T payload.json "https://api.vercel.com/v13/deployments/dpl_123"',
+      'wget --method=POST "https://api.vercel.com/v13/deployments"',
+      "bash -c 'curl -X POST https://api.vercel.com/v13/deployments'",
+      'curl -X GET --request POST "https://api.vercel.com/v13/deployments"',
+      'curl -XGET --request=POST "https://api.vercel.com/v13/deployments"',
+    ]) {
+      expect(
+        automationSurfaceHasVercelRestMutation({
+          id: 'synthetic:vercel-rest-curl-mutation',
+          content: command,
+          dialect: 'posix',
+          language: 'shell',
+        })
+      ).toBe(true);
+    }
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:vercel-rest-post',
+        content:
+          "fetch('https://api.vercel.com/v13/deployments', { method: 'POST', body: payload });",
+        language: 'javascript',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:vercel-rest-get',
+        content: 'curl "https://api.vercel.com/v13/deployments/dpl_123"',
+        dialect: 'posix',
+        language: 'shell',
+      })
+    ).toBe(false);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:vercel-rest-curl-forced-get',
+        content: 'curl -G --data "teamId=team_123" "https://api.vercel.com/v13/deployments"',
+        dialect: 'posix',
+        language: 'shell',
+      })
+    ).toBe(false);
+    for (const command of [
+      'curl --request POST -X GET "https://api.vercel.com/v13/deployments"',
+      'curl --request=POST -XGET "https://api.vercel.com/v13/deployments"',
+    ]) {
+      expect(
+        automationSurfaceHasVercelRestMutation({
+          id: 'synthetic:vercel-rest-curl-last-request-wins',
+          content: command,
+          dialect: 'posix',
+          language: 'shell',
+        })
+      ).toBe(false);
+    }
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:vercel-rest-powershell',
+        content: "Invoke-RestMethod -Uri 'https://api.vercel.com/v13/deployments' -Method POST",
+        dialect: 'powershell',
+        language: 'shell',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:vercel-rest-axios',
+        content: [
+          "import axios from 'axios';",
+          "axios.patch('https://api.vercel.com/v13/deployments/dpl_123', payload);",
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:vercel-rest-child-process',
+        content: [
+          "import { execSync } from 'node:child_process';",
+          "execSync('curl -X POST https://api.vercel.com/v13/deployments');",
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:vercel-rest-global-fetch',
+        content: "globalThis.fetch('https://api.vercel.com/v13/deployments', { method: 'POST' });",
+        language: 'javascript',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:fake-axios',
+        content: [
+          'const axios = { patch: () => undefined };',
+          "axios.patch('https://api.vercel.com/v13/deployments/dpl_123', payload);",
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(false);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:vercel-rest-echo',
+        content: 'echo \'curl -X POST "https://api.vercel.com/v13/deployments"\'',
+        dialect: 'posix',
+        language: 'shell',
+      })
+    ).toBe(false);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:vercel-rest-python-dynamic-method',
+        content: [
+          'import requests',
+          'requests.request(runtime_method, "https://api.vercel.com/v13/deployments")',
+        ].join('\n'),
+        language: 'python',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:configured-axios',
+        content: [
+          "import axios from 'axios';",
+          'const client = axios.create();',
+          "client.post('https://api.vercel.com/v13/deployments', payload);",
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:axios-request',
+        content: [
+          "import axios from 'axios';",
+          "axios.request({ url: 'https://api.vercel.com/v13/deployments', method: 'POST' });",
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:node-https-request',
+        content: [
+          "import https from 'node:https';",
+          "https.request('https://api.vercel.com/v13/deployments', { method: 'POST' });",
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:node-https-options-request',
+        content: [
+          "import https from 'node:https';",
+          "https.request({ url: 'https://api.vercel.com/v13/deployments', method: 'POST' });",
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:node-https-hostname-request',
+        content: [
+          "import https from 'node:https';",
+          "https.request({ hostname: 'api.vercel.com', path: '/v13/deployments', method: 'POST' });",
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:undici-request',
+        content: [
+          "import { request } from 'undici';",
+          "request('https://api.vercel.com/v13/deployments', { method: 'POST' });",
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:undici-client-request',
+        content: [
+          "import { Client } from 'undici';",
+          "const client = new Client('https://api.vercel.com');",
+          "client.request({ path: '/v13/deployments', method: 'POST' });",
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:node-fetch-post',
+        content: [
+          "import fetch from 'node-fetch';",
+          "fetch('https://api.vercel.com/v13/deployments', { method: 'POST' });",
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:configured-axios-base-url',
+        content: [
+          "import axios from 'axios';",
+          "const client = axios.create({ baseURL: 'https://api.vercel.com' });",
+          "client.post('/v13/deployments', payload);",
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:configured-axios-base-url-get',
+        content: [
+          "import axios from 'axios';",
+          "const client = axios.create({ baseURL: 'https://api.vercel.com' });",
+          "client.get('/v13/deployments');",
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(false);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:vercel-rest-js-dynamic-method',
+        content: "fetch('https://api.vercel.com/v13/deployments', { method: runtimeMethod });",
+        language: 'javascript',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:vercel-rest-js-spread-after-get',
+        content:
+          "fetch('https://api.vercel.com/v13/deployments', { method: 'GET', ...runtimeOptions });",
+        language: 'javascript',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:vercel-rest-js-duplicate-method',
+        content:
+          "fetch('https://api.vercel.com/v13/deployments', { method: 'GET', method: 'POST' });",
+        language: 'javascript',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:vercel-rest-js-overridden-spread',
+        content:
+          "fetch('https://api.vercel.com/v13/deployments', { ...runtimeOptions, method: 'GET' });",
+        language: 'javascript',
+      })
+    ).toBe(false);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:vercel-rest-python-subprocess',
+        content: [
+          'import subprocess',
+          'subprocess.run(["curl", "-X", "POST", "https://api.vercel.com/v13/deployments"])',
+        ].join('\n'),
+        language: 'python',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:vercel-rest-python-const-url',
+        content: [
+          'import requests',
+          'URL = "https://api.vercel.com/v13/deployments"',
+          'requests.post(URL, json=payload)',
+        ].join('\n'),
+        language: 'python',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:vercel-rest-js-inert',
+        content: [
+          "// fetch('https://api.vercel.com/v13/deployments', { method: 'POST' });",
+          "const example = \"fetch('https://api.vercel.com', { method: 'POST' })\";",
+          "fetch('https://api.vercel.com/v13/deployments', { method: 'GET' });",
+          "fetch('https://example.com', { method: 'POST' });",
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(false);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:vercel-rest-python-post',
+        content:
+          'import requests\nrequests.post("https://api.vercel.com/v13/deployments", json=payload)',
+        language: 'python',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:vercel-rest-python-direct-post',
+        content: [
+          'from requests import post',
+          'API = "https://api.vercel.com/v13/deployments"',
+          'post(API, json=payload)',
+        ].join('\n'),
+        language: 'python',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:vercel-rest-python-urllib',
+        content: [
+          'import urllib.request',
+          'API = "https://api.vercel.com/v13/deployments"',
+          "request = urllib.request.Request(API, data=payload, method='POST')",
+          'urllib.request.urlopen(request)',
+        ].join('\n'),
+        language: 'python',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:vercel-rest-python-later-assignment',
+        content: [
+          'import requests',
+          'requests.post(API, json=payload)',
+          'API = "https://api.vercel.com/v13/deployments"',
+        ].join('\n'),
+        language: 'python',
+      })
+    ).toBe(false);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:vercel-rest-python-before-reassignment',
+        content: [
+          'import requests',
+          'API = "https://api.vercel.com/v13/deployments"',
+          'requests.post(API, json=payload)',
+          'API = runtime_url',
+        ].join('\n'),
+        language: 'python',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:vercel-rest-python-get',
+        content: 'import httpx\nhttpx.get("https://api.vercel.com/v13/deployments")',
+        language: 'python',
+      })
+    ).toBe(false);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:vercel-sdk-mutation',
+        content: [
+          "import { Vercel } from '@vercel/sdk';",
+          'const client = new Vercel();',
+          'client.deployments.createDeployment(payload);',
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:vercel-sdk-read-only',
+        content: [
+          "import { Vercel } from '@vercel/sdk';",
+          'const client = new Vercel();',
+          'client.deployments.listDeployments();',
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(false);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:vercel-sdk-destructured-mutator',
+        content: [
+          "import { Vercel } from '@vercel/sdk';",
+          'const client = new Vercel();',
+          'const { createDeployment } = client.deployments;',
+          'createDeployment(payload);',
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:vercel-sdk-aliased-mutator',
+        content: [
+          "import { Vercel } from '@vercel/sdk';",
+          'const client = new Vercel();',
+          'const promote = client.deployments.promoteDeployment;',
+          'promote(payload);',
+        ].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(true);
+    expect(
+      automationSurfaceHasVercelRestMutation({
+        id: 'synthetic:vercel-sdk-unrelated-update',
+        content: ["import { Vercel } from '@vercel/sdk';", 'database.update(record);'].join('\n'),
+        language: 'javascript',
+      })
+    ).toBe(false);
+  });
+
+  it.each([
+    ['GitHub CLI workflow dispatch', 'gh workflow run release-production.yml \\\n  --ref main'],
+    [
+      'GitHub workflow dispatch API',
+      'gh api --method POST "repos/${REPO}/actions/workflows/release-production.yml/dispatches"',
+    ],
+    [
+      'GitHub workflow dispatch API with endpoint before method',
+      'gh api "repos/${REPO}/actions/workflows/release-production.yml/dispatches" --method POST',
+    ],
+    [
+      'GitHub workflow dispatch API with short method flag',
+      'gh api -X POST "repos/${REPO}/actions/workflows/release-production.yml/dispatches"',
+    ],
+  ])('recognizes %s as governed release delegation', (_caseName, run) => {
+    const workflow: Workflow = { jobs: { dispatch: { steps: [{ run }] } } };
+    expect(callsReleaseWorkflow(workflow)).toBe(true);
+  });
+
+  it.each([
+    ['echoed CLI command', 'echo gh workflow run release-production.yml'],
+    [
+      'echoed dispatch endpoint',
+      'echo POST repos/x/actions/workflows/release-production.yml/dispatches',
+    ],
+    ['commented CLI command', '# gh workflow run release-production.yml'],
+    ['inline commented CLI command', 'echo safe # gh workflow run release-production.yml'],
+    [
+      'unrelated POST command',
+      'POST gh api repos/x/actions/workflows/release-production.yml/dispatches',
+    ],
+  ])('rejects %s as governed release delegation', (_caseName, run) => {
+    const workflow: Workflow = { jobs: { inert: { steps: [{ run }] } } };
+    expect(callsReleaseWorkflow(workflow)).toBe(false);
+  });
+
+  it('does not treat release run lookup as governed release delegation', () => {
+    const workflow: Workflow = {
+      jobs: {
+        lookup: {
+          steps: [
+            {
+              run: 'gh api "repos/${REPO}/actions/workflows/release-production.yml/runs"',
+            },
+          ],
+        },
+      },
+    };
+    expect(callsReleaseWorkflow(workflow)).toBe(false);
+  });
+
+  it('rejects direct production movement even beside governed release delegation', () => {
+    const workflow: Workflow = {
+      jobs: {
+        mixed: {
+          steps: [
+            { run: 'gh workflow run release-production.yml --ref main' },
+            { run: 'npx vercel deploy --prod' },
+          ],
+        },
+      },
+    };
+
+    expect(callsReleaseWorkflow(workflow)).toBe(true);
+    expect(directProductionCommandScripts(workflow)).toEqual(['npx vercel deploy --prod']);
+  });
+
   it('does not fall through from a failed unit or affected suite', async () => {
     const workflow = await readWorkflow('ci-unified.yml');
     const scripts = allRunScripts(workflow);
@@ -229,13 +3575,146 @@ describe('required CI fails closed', () => {
     expect(schemaScripts).toContain('Production schema audit is clean.');
 
     const releaseWorkflow = await readWorkflow('release-production.yml');
+    expect(Object.keys(releaseWorkflow.on ?? {})).toEqual(['workflow_dispatch']);
+
+    const vercelConfig = JSON.parse(
+      await readFile(path.join(process.cwd(), 'vercel.json'), 'utf8')
+    ) as { github?: { autoAlias?: boolean } };
+    expect(vercelConfig.github?.autoAlias).toBe(false);
+
+    const automationSurfaces = await collectAutomationSurfaces();
+    expect(automationSurfaces.some((surface) => surface.id.startsWith('workflow:'))).toBe(true);
+    expect(automationSurfaces.some((surface) => surface.id.startsWith('action:'))).toBe(true);
+    expect(
+      automationSurfaces.some((surface) => surface.id === 'package:package.json#vercel-build')
+    ).toBe(true);
+    expect(automationSurfaces.some((surface) => surface.id === 'operator:pilot.sh')).toBe(true);
+    expect(automationSurfaces.some((surface) => surface.id === 'operator:server/index.ts')).toBe(
+      true
+    );
+    expect(
+      automationSurfaces.some((surface) => surface.id === 'operator:client/src/main.tsx')
+    ).toBe(true);
+    expect(
+      automationSurfaces.some((surface) => surface.id === 'operator:scripts/deploy-production.ps1')
+    ).toBe(true);
+    expect(
+      automationSurfaces.some(
+        (surface) =>
+          surface.id === 'operator:.husky/commit-msg' &&
+          surface.language === 'shell' &&
+          surface.dialect === 'posix'
+      )
+    ).toBe(true);
+    expect(automationSurfaces.some((surface) => surface.id === 'operator:.husky/post-commit')).toBe(
+      true
+    );
+    expect(automationSurfaces.some((surface) => surface.id === 'operator:.husky/pre-commit')).toBe(
+      true
+    );
+    expect(automationSurfaces.some((surface) => surface.id.includes('HANDOFF'))).toBe(false);
+
+    const ungovernedProductionCommands = automationSurfaces
+      .filter((surface) => !surface.id.startsWith('workflow:release-production.yml#'))
+      .filter(automationSurfaceHasProductionMutation)
+      .map((surface) => surface.id);
+    expect(ungovernedProductionCommands).toEqual([]);
+    const ungovernedVercelRestMutations = automationSurfaces
+      .filter((surface) => !surface.id.startsWith('workflow:release-production.yml#'))
+      .filter(automationSurfaceHasVercelRestMutation)
+      .map((surface) => surface.id);
+    expect(ungovernedVercelRestMutations).toEqual([]);
+
+    expect(Object.keys(releaseWorkflow.jobs ?? {})).toEqual([
+      'validate-target',
+      'release-proof',
+      'schema-audit',
+      'stage-production',
+      'validate-deployment',
+      'staged-smoke',
+      'promote',
+      'post-promotion-smoke',
+    ]);
+    expect(normalizeNeeds(releaseWorkflow.jobs?.['validate-target']?.needs)).toEqual([]);
+    expect(normalizeNeeds(releaseWorkflow.jobs?.['release-proof']?.needs)).toEqual([
+      'validate-target',
+    ]);
+    expect(normalizeNeeds(releaseWorkflow.jobs?.['schema-audit']?.needs)).toEqual([
+      'release-proof',
+    ]);
     expect(releaseWorkflow.jobs?.['schema-audit']?.uses).toBe(
       './.github/workflows/prod-schema-reconcile.yml'
     );
+    const dispatchInputs = (
+      releaseWorkflow.on?.workflow_dispatch as
+        { inputs?: Record<string, { required?: boolean }> } | undefined
+    )?.inputs;
+    expect(dispatchInputs?.expected_sha?.required).toBe(true);
+    expect(dispatchInputs?.deployment_url?.required).toBe(false);
+
+    const stageProduction = releaseWorkflow.jobs?.['stage-production'];
+    expect(normalizeNeeds(stageProduction?.needs)).toEqual(['schema-audit']);
+    expect(stageProduction?.environment).toBe('Production');
+    expect(stageProduction?.outputs?.deployment_url).toBe(
+      '${{ steps.deploy.outputs.deployment_url }}'
+    );
+    const stageCheckout = stageProduction?.steps?.find((step) =>
+      step.uses?.startsWith('actions/checkout@')
+    );
+    expect(stageCheckout?.uses).toBe('actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0');
+    expect(stageCheckout?.with?.ref).toBe('${{ inputs.expected_sha }}');
+    const stageNode = stageProduction?.steps?.find((step) =>
+      step.uses?.startsWith('actions/setup-node@')
+    );
+    expect(stageNode?.uses).toBe('actions/setup-node@820762786026740c76f36085b0efc47a31fe5020');
+    expect(stageNode?.with?.['node-version']).toBe('20.19.0');
+    expect(stageNode?.with?.cache).toBeUndefined();
+    const stageScripts = allRunScripts({ jobs: { stage: stageProduction ?? {} } }).join('\n');
+    expect(stageScripts).toContain('repos/${REPO}/commits/main');
+    expect(stageScripts).toContain('git rev-parse HEAD');
+    expect(stageScripts).toContain('vercel@55.0.0 deploy');
+    expect(stageScripts).toContain('--prod');
+    expect(stageScripts).toContain('--skip-domain');
+    expect(stageScripts).toContain('--yes');
+    expect(stageScripts).toContain('--meta githubDeployment=1');
+    expect(stageScripts).toContain('--meta githubCommitRef=main');
+    expect(stageScripts).toContain('--meta "githubCommitSha=${EXPECTED_SHA}"');
+    expect(stageScripts).not.toContain('--no-wait');
+    expect(stageScripts).not.toMatch(/vercel(?:\s|@(?:latest|\^|~))/);
+    expect(stageScripts).not.toContain('--token');
+    expect(stageScripts).toContain('VERCEL_TOKEN is required');
+    expect(stageScripts).toContain('VERCEL_ORG_ID is required');
+    expect(stageScripts).toContain('VERCEL_PROJECT_ID is required');
+    expect(stageScripts).toContain('GITHUB_OUTPUT');
+    expect(stageScripts).toContain('Vercel deploy must return one bare HTTPS vercel.app');
+    const deployStep = stageProduction?.steps?.find(
+      (step) => step.name === 'Create staged production deployment'
+    );
+    expect(deployStep?.env?.VERCEL_TOKEN).toBe('${{ secrets.VERCEL_TOKEN }}');
+    expect(deployStep?.env?.VERCEL_ORG_ID).toBe('${{ vars.VERCEL_ORG_ID }}');
+    expect(deployStep?.env?.VERCEL_PROJECT_ID).toBe('${{ vars.VERCEL_PROJECT_ID }}');
+
+    const validateDeployment = releaseWorkflow.jobs?.['validate-deployment'];
+    expect(normalizeNeeds(validateDeployment?.needs)).toEqual(['stage-production']);
+    const identityStep = validateDeployment?.steps?.find(
+      (step) => step.name === 'Normalize and verify exact staged deployment'
+    );
+    expect(identityStep?.env?.DEPLOYMENT_URL).toBe(
+      '${{ needs.stage-production.outputs.deployment_url }}'
+    );
+    expect(identityStep?.run).toContain("deployment.meta?.githubDeployment === '1'");
+    expect(identityStep?.run).toContain("deployment.readyState === 'READY'");
+    expect(identityStep?.run).toContain("deployment.target === 'production'");
+    expect(identityStep?.run).toContain('deployment.projectId === process.env.VERCEL_PROJECT_ID');
+    expect(identityStep?.run).toContain(
+      'deployment.meta?.githubCommitSha === process.env.EXPECTED_SHA'
+    );
+    expect(identityStep?.run).toContain("deployment.meta?.githubCommitRef === 'main'");
+    expect(identityStep?.run).toContain('deploymentHost === requestedHost');
+    expect(JSON.stringify(releaseWorkflow.jobs ?? {})).not.toContain('inputs.deployment_url');
+
     const stagedSmoke = releaseWorkflow.jobs?.['staged-smoke'];
-    const stagedNeeds =
-      typeof stagedSmoke?.needs === 'string' ? [stagedSmoke.needs] : (stagedSmoke?.needs ?? []);
-    expect(stagedNeeds).toContain('validate-deployment');
+    expect(normalizeNeeds(stagedSmoke?.needs)).toEqual(['validate-deployment']);
     const stagedSmokeStep = stagedSmoke?.steps?.find(
       (step) => step.name === 'Run authenticated staged smoke'
     );
@@ -252,7 +3731,12 @@ describe('required CI fails closed', () => {
     expect(stagedCredentialGuard?.run).toContain('VERCEL_AUTOMATION_BYPASS_SECRET is required');
     expect(stagedCredentialGuard?.run).toContain('RUM_ALLOWED_ORIGIN is required');
 
+    expect(normalizeNeeds(releaseWorkflow.jobs?.promote?.needs)).toEqual([
+      'staged-smoke',
+      'validate-deployment',
+    ]);
     const postPromotionSmoke = releaseWorkflow.jobs?.['post-promotion-smoke'];
+    expect(normalizeNeeds(postPromotionSmoke?.needs)).toEqual(['promote']);
     expect(JSON.stringify(postPromotionSmoke?.steps ?? [])).not.toContain(
       'VERCEL_AUTOMATION_BYPASS_SECRET'
     );
@@ -266,9 +3750,33 @@ describe('required CI fails closed', () => {
 
     const releaseScripts = allRunScripts(releaseWorkflow).join('\n');
     expect(releaseScripts).toContain('vercel@55.0.0 promote');
+    for (const tokens of vercelCommandTokens(releaseScripts)) {
+      expect(tokens.some((token) => token === '--token' || token.startsWith('--token='))).toBe(
+        false
+      );
+    }
     expect(releaseScripts).toContain('tests/smoke/production-boundaries.spec.ts');
     expect(releaseScripts).toContain('PROD_SMOKE_USERNAME');
     expect(releaseScripts).toContain('PROD_SMOKE_PASSWORD');
+  });
+
+  it('keeps the PowerShell production helper as an exact-live-main dispatcher', async () => {
+    const dispatcher = await readFile(
+      path.join(process.cwd(), 'scripts', 'deploy-production.ps1'),
+      'utf8'
+    );
+
+    expect(dispatcher).toContain('gh api "repos/$repository/commits/main" --jq ".sha"');
+    expect(dispatcher).toContain(
+      'gh workflow run release-production.yml --ref main --field "expected_sha=$expectedSha"'
+    );
+    expect(dispatcher).toContain('--repo $repository');
+    expect(dispatcher).not.toMatch(/\bSkipSmokeTest\b|\bForce\b/);
+    expect(dispatcher.match(/\$LASTEXITCODE/g)).toHaveLength(3);
+    expect(dispatcher).toContain('[string]::IsNullOrWhiteSpace($repository)');
+    expect(dispatcher).toContain('[string]::IsNullOrWhiteSpace($expectedSha)');
+    expect(dispatcher).toContain('$expectedSha -notmatch "^[0-9a-f]{40}$"');
+    expect(containsProductionVercelCommand(dispatcher)).toBe(false);
   });
 
   // --- Retro follow-up: authority-vs-reporting boundary enumeration ----------

--- a/tests/regressions/ci-fail-closed.test.ts
+++ b/tests/regressions/ci-fail-closed.test.ts
@@ -3569,6 +3569,9 @@ describe('required CI fails closed', () => {
     expect(releaseChecker).toContain('steps.push(...dbBackedSteps)');
   });
 
+  // This guard intentionally scans every tracked automation surface. Under the
+  // full Linux unit-fast shard, concurrent repository I/O can exceed Vitest's
+  // 30-second default even though the same scan is fast in isolation.
   it('gates production promotion on a clean schema audit and authenticated smoke', async () => {
     const schemaWorkflow = await readWorkflow('prod-schema-reconcile.yml');
     const schemaScripts = allRunScripts(schemaWorkflow).join('\n');
@@ -3758,7 +3761,7 @@ describe('required CI fails closed', () => {
     expect(releaseScripts).toContain('tests/smoke/production-boundaries.spec.ts');
     expect(releaseScripts).toContain('PROD_SMOKE_USERNAME');
     expect(releaseScripts).toContain('PROD_SMOKE_PASSWORD');
-  });
+  }, 120_000);
 
   it('keeps the PowerShell production helper as an exact-live-main dispatcher', async () => {
     const dispatcher = await readFile(

--- a/tests/unit/prod-schema-apply-policy.test.ts
+++ b/tests/unit/prod-schema-apply-policy.test.ts
@@ -15,6 +15,14 @@ const policyManifest = {
   },
 };
 
+const nonNullAddManifest = {
+  name: 'non-null-add-fixture',
+  sqlFiles: [],
+  applyPolicy: {
+    allowNonNullColumnAdds: [{ table: 'users', column: 'role' }],
+  },
+};
+
 describe('prod schema apply policy', () => {
   it('allows declared nullable widening and same-name check replacement', () => {
     const violations = validateSqlApplyPolicy({
@@ -158,6 +166,126 @@ describe('prod schema apply policy', () => {
         sql: '-- @drift-patch\nALTER TABLE "ledger_rows" ALTER COLUMN "other_hash" DROP NOT NULL;',
       }).map((violation) => violation.kind)
     ).toEqual(['drop-not-null']);
+  });
+
+  it('proves each declared NOT NULL column add has IF NOT EXISTS and a DEFAULT', () => {
+    expect(
+      validateSqlApplyPolicy({
+        manifest: nonNullAddManifest,
+        sqlFile: 'fixture.sql',
+        sql: `
+          -- @drift-patch
+          ALTER TABLE "users"
+            ADD COLUMN IF NOT EXISTS "role" varchar(32) NOT NULL DEFAULT 'viewer';
+        `,
+      })
+    ).toEqual([]);
+  });
+
+  it.each([
+    [
+      'missing DEFAULT',
+      'ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "role" varchar(32) NOT NULL;',
+      'invalid-non-null-column-add',
+    ],
+    [
+      'missing NOT NULL',
+      `ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "role" varchar(32) DEFAULT 'viewer';`,
+      'invalid-non-null-column-add',
+    ],
+    [
+      'missing IF NOT EXISTS',
+      `ALTER TABLE "users" ADD COLUMN "role" varchar(32) NOT NULL DEFAULT 'viewer';`,
+      'invalid-non-null-column-add',
+    ],
+    [
+      'wrong table',
+      `ALTER TABLE "accounts" ADD COLUMN IF NOT EXISTS "role" varchar(32) NOT NULL DEFAULT 'viewer';`,
+      'unproven-non-null-column-add',
+    ],
+    [
+      'wrong column',
+      `ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "user_role" varchar(32) NOT NULL DEFAULT 'viewer';`,
+      'unproven-non-null-column-add',
+    ],
+  ])('blocks a declared NOT NULL column add with %s', (_case, sql, expectedKind) => {
+    const violations = validateSqlApplyPolicy({
+      manifest: nonNullAddManifest,
+      sqlFile: 'fixture.sql',
+      sql: `-- @drift-patch\n${sql}`,
+    });
+
+    expect(violations.map((violation) => violation.kind)).toContain(expectedKind);
+  });
+
+  it('rejects an undeclared column addition beside the declared target', () => {
+    const violations = validateSqlApplyPolicy({
+      manifest: nonNullAddManifest,
+      sqlFile: 'fixture.sql',
+      sql: `
+        -- @drift-patch
+        ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "role" varchar(32) NOT NULL DEFAULT 'viewer';
+        --> statement-breakpoint
+        ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "is_active" boolean NOT NULL DEFAULT true;
+      `,
+    });
+
+    expect(violations.map((violation) => violation.kind)).toContain(
+      'undeclared-non-null-column-add'
+    );
+  });
+
+  it.each([
+    ['missing target', 'ALTER TABLE "users" ADD COLUMN IF NOT EXISTS;'],
+    [
+      'unmatched table quote',
+      `ALTER TABLE "users ADD COLUMN IF NOT EXISTS "role" varchar(32) NOT NULL DEFAULT 'viewer';`,
+    ],
+    [
+      'unmatched column quote',
+      `ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "role varchar(32) NOT NULL DEFAULT 'viewer';`,
+    ],
+  ])('rejects a malformed ALTER TABLE ADD COLUMN statement with %s', (_case, sql) => {
+    const violations = validateSqlApplyPolicy({
+      manifest: nonNullAddManifest,
+      sqlFile: 'fixture.sql',
+      sql: `-- @drift-patch\n${sql}`,
+    });
+
+    expect(violations.map((violation) => violation.kind)).toContain(
+      'malformed-non-null-column-add'
+    );
+  });
+
+  it('rejects DEFAULT NULL for a declared non-null column addition', () => {
+    const violations = validateSqlApplyPolicy({
+      manifest: nonNullAddManifest,
+      sqlFile: 'fixture.sql',
+      sql: `
+        -- @drift-patch
+        ALTER TABLE "users"
+          ADD COLUMN IF NOT EXISTS "role" varchar(32) NOT NULL DEFAULT NULL;
+      `,
+    });
+
+    expect(violations.map((violation) => violation.kind)).toContain('invalid-non-null-column-add');
+  });
+
+  it('rejects duplicate unsafe and safe statements for one declared target', () => {
+    const violations = validateSqlApplyPolicy({
+      manifest: nonNullAddManifest,
+      sqlFile: 'fixture.sql',
+      sql: `
+        -- @drift-patch
+        ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "role" varchar(32) NOT NULL DEFAULT NULL;
+        --> statement-breakpoint
+        ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "role" varchar(32) NOT NULL DEFAULT 'viewer';
+      `,
+    });
+
+    expect(violations.map((violation) => violation.kind)).toContain(
+      'duplicate-non-null-column-add'
+    );
   });
 
   it('rejects dropObjects during additive-safe apply', () => {

--- a/tests/unit/prod-schema-apply-policy.test.ts
+++ b/tests/unit/prod-schema-apply-policy.test.ts
@@ -180,10 +180,14 @@ describe('prod schema apply policy', () => {
     ).toThrow(ReconcileError);
   });
 
-  it('accepts the actual production-like M9 through M17 manifest SQL set', async () => {
+  it('accepts additive-safe production manifests from M9 onward', async () => {
     const manifests = await loadManifests();
     const applyingManifestNames = new Set(
-      manifests.filter((manifest) => manifest.order >= 9).map((manifest) => manifest.name)
+      manifests
+        .filter(
+          (manifest) => manifest.order >= 9 && manifest.name !== 'business-time-comparison-lineage'
+        )
+        .map((manifest) => manifest.name)
     );
 
     expect(() =>
@@ -192,5 +196,16 @@ describe('prod schema apply policy', () => {
         applyingManifestNames,
       })
     ).not.toThrow();
+  });
+
+  it('refuses automated apply for business-time comparison lineage', async () => {
+    const manifests = await loadManifests();
+
+    expect(() =>
+      assertApplyPolicyForManifests({
+        manifests,
+        applyingManifestNames: new Set(['business-time-comparison-lineage']),
+      })
+    ).toThrow(ReconcileError);
   });
 });

--- a/tests/unit/prod-schema-manifest-coverage.test.ts
+++ b/tests/unit/prod-schema-manifest-coverage.test.ts
@@ -1,0 +1,104 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = process.cwd();
+const manifestDir = path.join(repoRoot, 'scripts', 'prod-schema-manifests');
+const migrationsDir = path.join(repoRoot, 'migrations');
+
+interface ManifestSqlFiles {
+  file: string;
+  sqlFiles: string[];
+}
+
+function loadManifestSqlFiles(directory: string): ManifestSqlFiles[] {
+  return fs
+    .readdirSync(directory)
+    .filter((file) => file.endsWith('.json'))
+    .sort()
+    .map((file) => {
+      const manifest = JSON.parse(fs.readFileSync(path.join(directory, file), 'utf8')) as {
+        sqlFiles?: string[];
+      };
+
+      return { file, sqlFiles: manifest.sqlFiles ?? [] };
+    });
+}
+
+function canonicalForwardMigrationFiles(directory: string): string[] {
+  return fs
+    .readdirSync(directory)
+    .filter((file) => {
+      const match = /^(\d{4})_.*\.sql$/i.exec(file);
+      return match !== null && Number(match[1]) >= 31 && !/_ROLLBACK\.sql$/i.test(file);
+    })
+    .sort();
+}
+
+function assertForwardMigrationCoverage(
+  manifests: ManifestSqlFiles[],
+  canonicalForwardMigrations: string[]
+): void {
+  const referenceCount = new Map<string, number>();
+
+  for (const { file, sqlFiles } of manifests) {
+    for (const sqlFile of sqlFiles) {
+      expect(sqlFile, `${file} -> ${sqlFile}`).not.toContain('..');
+      expect(path.isAbsolute(sqlFile), `${file} -> ${sqlFile}`).toBe(false);
+      expect(sqlFile, `${file} -> ${sqlFile}`).not.toMatch(/rollback/i);
+
+      const normalizedSqlFile = path.normalize(sqlFile).split(path.sep).join(path.posix.sep);
+      referenceCount.set(normalizedSqlFile, (referenceCount.get(normalizedSqlFile) ?? 0) + 1);
+    }
+  }
+
+  for (const migration of canonicalForwardMigrations) {
+    expect(referenceCount.get(`migrations/${migration}`), migration).toBe(1);
+  }
+}
+
+describe('prod-schema manifest forward migration coverage', () => {
+  const manifests = loadManifestSqlFiles(manifestDir);
+  const canonicalForwardMigrations = canonicalForwardMigrationFiles(migrationsDir);
+
+  for (const migration of canonicalForwardMigrations) {
+    it(`assigns ${migration} to exactly one manifest`, () => {
+      assertForwardMigrationCoverage(manifests, [migration]);
+    });
+  }
+
+  it('negative control: reports duplicate manifest ownership', () => {
+    expect(() =>
+      assertForwardMigrationCoverage(
+        [
+          {
+            file: 'first.json',
+            sqlFiles: ['migrations/0031_user_identity_grants_revocation.sql'],
+          },
+          {
+            file: 'second.json',
+            sqlFiles: ['migrations/0031_user_identity_grants_revocation.sql'],
+          },
+        ],
+        ['0031_user_identity_grants_revocation.sql']
+      )
+    ).toThrowError(/0031_user_identity_grants_revocation\.sql/);
+  });
+
+  it('negative control: reports parent-directory manifest paths', () => {
+    expect(() =>
+      assertForwardMigrationCoverage(
+        [
+          {
+            file: 'traversal.json',
+            sqlFiles: ['../migrations/0031_user_identity_grants_revocation.sql'],
+          },
+        ],
+        ['0031_user_identity_grants_revocation.sql']
+      )
+    ).toThrowError(
+      /traversal\.json -> \.\.\/migrations\/0031_user_identity_grants_revocation\.sql/
+    );
+  });
+});

--- a/tests/unit/prod-schema-manifest-sentinels.test.ts
+++ b/tests/unit/prod-schema-manifest-sentinels.test.ts
@@ -83,6 +83,19 @@ function namesSurvivingSql(sqlFiles: string[]): Set<string> {
 
   for (const sqlFile of sqlFiles) {
     const sql = fs.readFileSync(path.join(repoRoot, sqlFile), 'utf8');
+    for (const match of sql.matchAll(
+      /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"?([a-z0-9_]+)"?\s*\(([\s\S]*?)\);/gi
+    )) {
+      const tableName = match[1];
+      const tableBody = match[2] ?? '';
+      if (
+        tableName &&
+        /^\s*(?!CONSTRAINT\b)"?[a-z0-9_]+"?\s+[^,\n]*\bPRIMARY\s+KEY\b/im.test(tableBody)
+      ) {
+        surviving.add(pgIdentifier(`${tableName}_pkey`));
+      }
+    }
+
     const pattern = new RegExp(SQL_NAME_EVENT.source, 'gi');
     let match: RegExpExecArray | null;
     while ((match = pattern.exec(sql)) !== null) {
@@ -123,6 +136,9 @@ describe('prod-schema manifest sentinels', () => {
       '16-positions-ownership-compat.json',
       '17-position-source-basis-reliefs.json',
       '18-internal-analysis.json',
+      '19-user-identity-grants-revocation.json',
+      '20-company-scenario-create-requests.json',
+      '21-business-time-comparison-lineage.json',
     ]);
   });
 
@@ -201,6 +217,15 @@ describe('prod-schema manifest sentinels', () => {
     }
 
     expect(failures).toEqual([]);
+  });
+
+  it('derives PostgreSQL names for both inline primary keys in manifests 19 and 20', () => {
+    expect(namesSurvivingSql(['migrations/0031_user_identity_grants_revocation.sql'])).toContain(
+      'revoked_tokens_pkey'
+    );
+    expect(namesSurvivingSql(['migrations/0033_company_scenario_create_requests.sql'])).toContain(
+      'company_scenario_create_requests_pkey'
+    );
   });
 
   it('negative control: a dropped-then-replaced name does not survive (0016/0017 case)', () => {

--- a/tests/unit/reconcile-prod-schema.test.ts
+++ b/tests/unit/reconcile-prod-schema.test.ts
@@ -2,6 +2,8 @@
 // readFileSync export, but its ...actual spread preserves `default` as the
 // real fs module - same pattern as the sibling ledger/sentinel tests.
 import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 import { describe, expect, it, vi } from 'vitest';
 
@@ -813,6 +815,84 @@ describe('reconcile-prod-schema shape decisions', () => {
     ]);
   });
 
+  it('allows an explicitly declared missing NOT NULL column on a populated table', async () => {
+    const client = createMockClient({
+      presentTables: ['tasks'],
+      populatedTables: ['tasks'],
+      columns: [
+        {
+          table_name: 'tasks',
+          column_name: 'id',
+          data_type: 'integer',
+          is_nullable: 'NO',
+        },
+        {
+          table_name: 'tasks',
+          column_name: 'fund_id',
+          data_type: 'integer',
+          is_nullable: 'NO',
+        },
+      ],
+    });
+    const audit = await auditManifest(client, {
+      ...manifest,
+      applyPolicy: {
+        allowNonNullColumnAdds: [{ table: 'tasks', column: 'title' }],
+      },
+      expectedTables: [
+        {
+          ...manifest.expectedTables[0],
+          constraints: [],
+          indexes: [],
+        },
+      ],
+    });
+
+    expect(audit.action).toBe(ACTION_APPLY_MISSING_DDL);
+    expect(audit.objects[0]?.populated).toBe(false);
+    expect(audit.objects[0]?.deltas).toEqual([
+      {
+        kind: 'missing-column',
+        name: 'tasks.title',
+        additiveSafe: true,
+      },
+    ]);
+  });
+
+  it('refuses an undeclared missing NOT NULL column on a populated table', async () => {
+    const client = createMockClient({
+      presentTables: ['tasks'],
+      populatedTables: ['tasks'],
+      columns: [
+        {
+          table_name: 'tasks',
+          column_name: 'id',
+          data_type: 'integer',
+          is_nullable: 'NO',
+        },
+        {
+          table_name: 'tasks',
+          column_name: 'fund_id',
+          data_type: 'integer',
+          is_nullable: 'NO',
+        },
+      ],
+    });
+    const audit = await auditManifest(client, {
+      ...manifest,
+      expectedTables: [
+        {
+          ...manifest.expectedTables[0],
+          constraints: [],
+          indexes: [],
+        },
+      ],
+    });
+
+    expect(audit.action).toBe(ACTION_REFUSE_FOR_HUMAN);
+    expect(audit.objects[0]?.populated).toBe(true);
+  });
+
   it('refuses non-additive deltas on populated tables', () => {
     expect(
       decideObjectAction({
@@ -953,6 +1033,68 @@ describe('reconcile-prod-schema shape decisions', () => {
       client.calls.some((call) => /\bBEGIN\b|INSERT INTO|CREATE TABLE|COMMIT/.test(call.text))
     ).toBe(false);
   });
+
+  it.each([
+    [
+      'missing DEFAULT',
+      'ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "role" varchar(32) NOT NULL;',
+    ],
+    [
+      'missing NOT NULL',
+      `ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "role" varchar(32) DEFAULT 'viewer';`,
+    ],
+    [
+      'DEFAULT NULL',
+      'ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "role" varchar(32) NOT NULL DEFAULT NULL;',
+    ],
+    [
+      'unmatched table quote',
+      `ALTER TABLE "users ADD COLUMN IF NOT EXISTS "role" varchar(32) NOT NULL DEFAULT 'viewer';`,
+    ],
+    [
+      'unmatched column quote',
+      `ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "role varchar(32) NOT NULL DEFAULT 'viewer';`,
+    ],
+  ])('apply rejects a declared non-null add with %s before mutation', async (_case, sql) => {
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prod-schema-policy-'));
+    const sqlFile = 'fixture.sql';
+    fs.writeFileSync(path.join(rootDir, sqlFile), `-- @drift-patch\n${sql}`);
+    const client = createMockClient();
+
+    try {
+      await expect(
+        runReconciliation({
+          client,
+          manifests: [
+            {
+              name: 'runner-policy-fixture',
+              missingTablePolicy: MISSING_TABLE_POLICY_CREATE_OR_REPAIR,
+              sqlFiles: [sqlFile],
+              applyPolicy: {
+                allowNonNullColumnAdds: [{ table: 'users', column: 'role' }],
+              },
+              expectedTables: [
+                {
+                  name: 'users',
+                  columns: [{ name: 'role', type: 'varchar', nullable: false }],
+                },
+              ],
+            },
+          ],
+          rootDir,
+          apply: true,
+          stdout: { write: () => undefined },
+        })
+      ).rejects.toMatchObject({
+        details: { kind: 'invalid-non-null-column-add-policy' },
+      });
+      expect(
+        client.calls.some((call) => /\bBEGIN\b|INSERT INTO|ALTER TABLE|COMMIT/.test(call.text))
+      ).toBe(false);
+    } finally {
+      fs.rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('missing-table policy', () => {
@@ -1039,6 +1181,35 @@ describe('missing-table policy', () => {
       {
         applyPolicy: {
           allowDropNotNull: [{ table: 'tasks', column: 'title' }],
+        },
+      },
+      {
+        applyPolicy: {
+          allowNonNullColumnAdds: [{ table: 'tasks', column: 'bad;column' }],
+        },
+      },
+      {
+        applyPolicy: {
+          allowNonNullColumnAdds: [{ table: 'tasks', column: 'missing' }],
+        },
+      },
+      {
+        applyPolicy: {
+          allowNonNullColumnAdds: [{ table: 'tasks', column: 'title' }],
+        },
+        expectedTables: [
+          {
+            ...manifest.expectedTables[0],
+            columns: [{ name: 'title', type: 'varchar', nullable: true }],
+          },
+        ],
+      },
+      {
+        applyPolicy: {
+          allowNonNullColumnAdds: [
+            { table: 'tasks', column: 'title' },
+            { table: 'tasks', column: 'title' },
+          ],
         },
       },
       {

--- a/tests/unit/reconcile-prod-schema.test.ts
+++ b/tests/unit/reconcile-prod-schema.test.ts
@@ -50,7 +50,14 @@ interface MockClientOptions {
         definition: string;
       }
   )[];
-  readonly indexes?: readonly string[];
+  readonly indexes?: readonly (
+    | string
+    | {
+        tablename: string;
+        indexname: string;
+        indexdef: string;
+      }
+  )[];
   readonly populatedTables?: readonly string[];
   /** When true, DROP statements do NOT mutate mock state - simulates a drop
    * that silently fails to take effect, so the post-apply audit must catch it. */
@@ -66,7 +73,16 @@ function createMockClient(options: MockClientOptions = {}) {
       : constraint
   );
   const constraints = new Set(constraintRows.map((constraint) => constraint.conname));
-  const indexes = new Set(options.indexes ?? []);
+  const indexRows = (options.indexes ?? []).map((index) =>
+    typeof index === 'string'
+      ? {
+          tablename: options.presentTables?.[0],
+          indexname: index,
+          indexdef: undefined,
+        }
+      : index
+  );
+  const indexes = new Set(indexRows.map((index) => index.indexname));
   const populatedTables = new Set(options.populatedTables ?? []);
 
   return {
@@ -140,9 +156,15 @@ function createMockClient(options: MockClientOptions = {}) {
       if (text.includes('FROM pg_indexes')) {
         const names = params?.[0] as string[];
         return {
-          rows: names
-            .filter((indexname) => indexes.has(indexname))
-            .map((indexname) => ({ indexname })),
+          rows: indexRows
+            .filter((index) => indexes.has(index.indexname) && names.includes(index.indexname))
+            .map((index) =>
+              text.includes('tablename')
+                ? index
+                : {
+                    indexname: index.indexname,
+                  }
+            ),
           rowCount: names.length,
         };
       }
@@ -258,6 +280,43 @@ function fullShapeClient() {
   });
 }
 
+const activeDedupeIndexName = 'fund_scenario_calc_runs_active_dedup_idx';
+const activeDedupeExactDefinition =
+  "CREATE UNIQUE INDEX fund_scenario_calc_runs_active_dedup_idx ON public.fund_scenario_calculation_runs USING btree (scenario_set_id, source_config_id, source_config_version, COALESCE(hash_kind, 'scenario-input-hash-v1'::character varying), input_hash) WHERE ((status)::text = ANY ((ARRAY['queued'::character varying, 'running'::character varying, 'completed'::character varying])::text[]))";
+const activeDedupeExpectedDefinition = {
+  exactDefinition: activeDedupeExactDefinition,
+  orderedFragments: [
+    'CREATE UNIQUE INDEX',
+    'ON public.fund_scenario_calculation_runs',
+    'scenario_set_id',
+    'source_config_id',
+    'source_config_version',
+    'COALESCE(hash_kind',
+    'input_hash',
+    'WHERE',
+    'status',
+  ],
+  stringLiterals: ['scenario-input-hash-v1', 'queued', 'running', 'completed'],
+};
+const definitionAwareIndexManifest = {
+  name: 'definition-aware-index-fixture',
+  missingTablePolicy: MISSING_TABLE_POLICY_EXISTING_REQUIRED,
+  expectedTables: [
+    {
+      name: 'fund_scenario_calculation_runs',
+      columns: [{ name: 'id', type: 'uuid', nullable: false }],
+      constraints: [],
+      indexes: [activeDedupeIndexName],
+      indexDefinitions: [
+        {
+          name: activeDedupeIndexName,
+          expectedDefinition: activeDedupeExpectedDefinition,
+        },
+      ],
+    },
+  ],
+};
+
 describe('reconcile-prod-schema runner helpers', () => {
   it('defaults to audit-only mode', () => {
     expect(parseReconcileArgs([])).toMatchObject({
@@ -320,6 +379,32 @@ describe('reconcile-prod-schema runner helpers', () => {
       ])
     ).toThrow(/missing -- @generated or -- @drift-patch marker/);
   });
+
+  it('requires index definitions to target a named expected index', () => {
+    expect(() =>
+      validateManifestSql(
+        {
+          name: 'bad-index-definition-fixture',
+          expectedTables: [
+            {
+              name: 'tasks',
+              indexes: [],
+              indexDefinitions: [
+                {
+                  name: 'idx_tasks_fund_created',
+                  expectedDefinition: {
+                    orderedFragments: ['CREATE INDEX'],
+                    stringLiterals: [],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        []
+      )
+    ).toThrow(ReconcileError);
+  });
 });
 
 describe('reconcile-prod-schema shape decisions', () => {
@@ -367,6 +452,207 @@ describe('reconcile-prod-schema shape decisions', () => {
     expect(audit.objects[0]?.deltas).toEqual([]);
     expect(client.calls.find((call) => call.text.includes('FROM pg_indexes'))?.params).toEqual([
       [storedIndexName],
+    ]);
+  });
+
+  it('skips a matching definition-aware unique index', async () => {
+    const formattingVariant = activeDedupeExactDefinition
+      .replace(activeDedupeIndexName, `"${activeDedupeIndexName}"`)
+      .replace(
+        'public.fund_scenario_calculation_runs',
+        '"public" . "fund_scenario_calculation_runs"'
+      )
+      .replace(/, /g, ' ,   ');
+    const client = createMockClient({
+      presentTables: ['fund_scenario_calculation_runs'],
+      columns: [
+        {
+          table_name: 'fund_scenario_calculation_runs',
+          column_name: 'id',
+          data_type: 'uuid',
+          udt_name: 'uuid',
+          is_nullable: 'NO',
+        },
+      ],
+      indexes: [
+        {
+          tablename: 'fund_scenario_calculation_runs',
+          indexname: activeDedupeIndexName,
+          indexdef: formattingVariant,
+        },
+      ],
+    });
+
+    const audit = await auditManifest(client, definitionAwareIndexManifest);
+
+    expect(audit.action).toBe(ACTION_SKIP);
+    expect(audit.objects[0]?.deltas).toEqual([]);
+  });
+
+  it('refuses a populated table with the legacy same-name four-key index', async () => {
+    const legacyDefinition =
+      "CREATE UNIQUE INDEX fund_scenario_calc_runs_active_dedup_idx ON public.fund_scenario_calculation_runs USING btree (scenario_set_id, source_config_id, source_config_version, input_hash) WHERE ((status)::text = ANY ((ARRAY['queued'::character varying, 'running'::character varying, 'completed'::character varying])::text[]))";
+    const client = createMockClient({
+      presentTables: ['fund_scenario_calculation_runs'],
+      populatedTables: ['fund_scenario_calculation_runs'],
+      columns: [
+        {
+          table_name: 'fund_scenario_calculation_runs',
+          column_name: 'id',
+          data_type: 'uuid',
+          udt_name: 'uuid',
+          is_nullable: 'NO',
+        },
+      ],
+      indexes: [
+        {
+          tablename: 'fund_scenario_calculation_runs',
+          indexname: activeDedupeIndexName,
+          indexdef: legacyDefinition,
+        },
+      ],
+    });
+
+    const audit = await auditManifest(client, definitionAwareIndexManifest);
+
+    expect(audit.action).toBe(ACTION_REFUSE_FOR_HUMAN);
+    expect(audit.objects[0]?.populated).toBe(true);
+    expect(audit.objects[0]?.deltas).toEqual([
+      {
+        kind: 'index-definition-mismatch',
+        name: activeDedupeIndexName,
+        expected: activeDedupeExpectedDefinition,
+        actual: legacyDefinition,
+        additiveSafe: false,
+      },
+    ]);
+  });
+
+  it('refuses a NOT IN predicate with the expected literals', async () => {
+    const notInDefinition =
+      "CREATE UNIQUE INDEX fund_scenario_calc_runs_active_dedup_idx ON public.fund_scenario_calculation_runs USING btree (scenario_set_id, source_config_id, source_config_version, COALESCE(hash_kind, 'scenario-input-hash-v1'::character varying), input_hash) WHERE status NOT IN ('queued', 'running', 'completed')";
+    const client = createMockClient({
+      presentTables: ['fund_scenario_calculation_runs'],
+      populatedTables: ['fund_scenario_calculation_runs'],
+      columns: [
+        {
+          table_name: 'fund_scenario_calculation_runs',
+          column_name: 'id',
+          data_type: 'uuid',
+          udt_name: 'uuid',
+          is_nullable: 'NO',
+        },
+      ],
+      indexes: [
+        {
+          tablename: 'fund_scenario_calculation_runs',
+          indexname: activeDedupeIndexName,
+          indexdef: notInDefinition,
+        },
+      ],
+    });
+
+    const audit = await auditManifest(client, definitionAwareIndexManifest);
+
+    expect(audit.action).toBe(ACTION_REFUSE_FOR_HUMAN);
+    expect(audit.objects[0]?.deltas.map((delta) => delta.kind)).toEqual([
+      'index-definition-mismatch',
+    ]);
+  });
+
+  it('refuses an extra OR TRUE predicate', async () => {
+    const orTrueDefinition = `${activeDedupeExactDefinition} OR true`;
+    const client = createMockClient({
+      presentTables: ['fund_scenario_calculation_runs'],
+      populatedTables: ['fund_scenario_calculation_runs'],
+      columns: [
+        {
+          table_name: 'fund_scenario_calculation_runs',
+          column_name: 'id',
+          data_type: 'uuid',
+          udt_name: 'uuid',
+          is_nullable: 'NO',
+        },
+      ],
+      indexes: [
+        {
+          tablename: 'fund_scenario_calculation_runs',
+          indexname: activeDedupeIndexName,
+          indexdef: orTrueDefinition,
+        },
+      ],
+    });
+
+    const audit = await auditManifest(client, definitionAwareIndexManifest);
+
+    expect(audit.action).toBe(ACTION_REFUSE_FOR_HUMAN);
+    expect(audit.objects[0]?.deltas.map((delta) => delta.kind)).toEqual([
+      'index-definition-mismatch',
+    ]);
+  });
+
+  it('refuses a schema-global same-name index owned by another table', async () => {
+    const client = createMockClient({
+      presentTables: ['fund_scenario_calculation_runs'],
+      columns: [
+        {
+          table_name: 'fund_scenario_calculation_runs',
+          column_name: 'id',
+          data_type: 'uuid',
+          udt_name: 'uuid',
+          is_nullable: 'NO',
+        },
+      ],
+      indexes: [
+        {
+          tablename: 'archived_calculation_runs',
+          indexname: activeDedupeIndexName,
+          indexdef: activeDedupeExactDefinition.replace(
+            'public.fund_scenario_calculation_runs',
+            'public.archived_calculation_runs'
+          ),
+        },
+      ],
+    });
+
+    const audit = await auditManifest(client, definitionAwareIndexManifest);
+
+    expect(audit.action).toBe(ACTION_REFUSE_FOR_HUMAN);
+    expect(audit.objects[0]?.populated).toBe(false);
+    expect(audit.objects[0]?.deltas).toEqual([
+      {
+        kind: 'index-table-mismatch',
+        name: activeDedupeIndexName,
+        expectedTable: 'fund_scenario_calculation_runs',
+        actualTable: 'archived_calculation_runs',
+        additiveSafe: false,
+        humanReviewRequired: true,
+      },
+      { kind: 'missing-index', name: activeDedupeIndexName, additiveSafe: true },
+    ]);
+  });
+
+  it('keeps a missing definition-aware index as additive missing DDL', async () => {
+    const client = createMockClient({
+      presentTables: ['fund_scenario_calculation_runs'],
+      populatedTables: ['fund_scenario_calculation_runs'],
+      columns: [
+        {
+          table_name: 'fund_scenario_calculation_runs',
+          column_name: 'id',
+          data_type: 'uuid',
+          udt_name: 'uuid',
+          is_nullable: 'NO',
+        },
+      ],
+    });
+
+    const audit = await auditManifest(client, definitionAwareIndexManifest);
+
+    expect(audit.action).toBe(ACTION_APPLY_MISSING_DDL);
+    expect(audit.objects[0]?.populated).toBe(false);
+    expect(audit.objects[0]?.deltas).toEqual([
+      { kind: 'missing-index', name: activeDedupeIndexName, additiveSafe: true },
     ]);
   });
 
@@ -860,6 +1146,32 @@ describe('reconcile-prod-schema dropObjects path (s8.1 slice 3.5)', () => {
         applyPolicy: {
           allowDropNotNull: [{ table: 'jobs', column: 'state' }],
         },
+      },
+      []
+    );
+
+    expect(changed).not.toBe(base);
+  });
+
+  it('manifest checksum changes when an expected index definition changes', () => {
+    const base = manifestChecksum(definitionAwareIndexManifest, []);
+    const changed = manifestChecksum(
+      {
+        ...definitionAwareIndexManifest,
+        expectedTables: [
+          {
+            ...definitionAwareIndexManifest.expectedTables[0],
+            indexDefinitions: [
+              {
+                name: activeDedupeIndexName,
+                expectedDefinition: {
+                  ...activeDedupeExpectedDefinition,
+                  orderedFragments: [...activeDedupeExpectedDefinition.orderedFragments, 'extra'],
+                },
+              },
+            ],
+          },
+        ],
       },
       []
     );

--- a/tests/unit/services/monte-carlo-actuals-inputs.test.ts
+++ b/tests/unit/services/monte-carlo-actuals-inputs.test.ts
@@ -168,6 +168,30 @@ function sha256(value: unknown): string {
   return createHash('sha256').update(JSON.stringify(value)).digest('hex');
 }
 
+function normalizeExternalGolden(value: unknown): unknown {
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new Error(`External golden contains non-finite number: ${String(value)}`);
+    }
+    return value.toPrecision(12);
+  }
+  if (Array.isArray(value)) {
+    return value.map(normalizeExternalGolden);
+  }
+  if (value !== null && typeof value === 'object') {
+    const normalized: Record<string, unknown> = {};
+    for (const [key, nestedValue] of Object.entries(value)) {
+      normalized[key] = normalizeExternalGolden(nestedValue);
+    }
+    return normalized;
+  }
+  return value;
+}
+
+function externalGoldenSha256(value: unknown): string {
+  return sha256(normalizeExternalGolden(value));
+}
+
 function withoutAssumptionsProvenance(
   forecast: Awaited<ReturnType<MonteCarloSimulationService['generateForecast']>>
 ): Record<string, unknown> {
@@ -234,6 +258,44 @@ describe('Monte Carlo assumptions profile v1', () => {
   });
 });
 
+describe('cross-platform Monte Carlo external golden projection', () => {
+  it('changes the hash for material numeric changes within retained precision', () => {
+    expect(externalGoldenSha256({ value: 1.23456789012 })).not.toBe(
+      externalGoldenSha256({ value: 1.23456789013 })
+    );
+  });
+
+  it('collapses numeric drift beyond the retained 12 significant digits', () => {
+    expect(externalGoldenSha256({ value: 1.234567890123 })).toBe(
+      externalGoldenSha256({ value: 1.234567890124 })
+    );
+  });
+
+  it('preserves nested array shape and object insertion order', () => {
+    const normalized = normalizeExternalGolden({
+      z: [3.14159, { b: true, a: null }],
+      a: ['tail', -2.5],
+    });
+
+    expect(normalized).toEqual({
+      z: ['3.14159000000', { b: true, a: null }],
+      a: ['tail', '-2.50000000000'],
+    });
+    expect(JSON.stringify(normalized)).toBe(
+      '{"z":["3.14159000000",{"b":true,"a":null}],"a":["tail","-2.50000000000"]}'
+    );
+  });
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    'rejects non-finite number %s',
+    (value) => {
+      expect(() => normalizeExternalGolden({ value })).toThrow(
+        'External golden contains non-finite number'
+      );
+    }
+  );
+});
+
 describe('MonteCarloSimulationService actuals-backed company inputs', () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -281,11 +343,8 @@ describe('MonteCarloSimulationService actuals-backed company inputs', () => {
     expect(flagOffForecast).toEqual(legacyForecast);
     expect(insertedSnapshots).toHaveLength(2);
     expect(insertedSnapshots[1]).toEqual(insertedSnapshots[0]);
-    expect(sha256(legacyForecast)).toBe(
-      '69a0799ff35b8790f91d22989c9079ab78eee22159f3976f0bc4a5ee765c2c49'
-    );
-    expect(sha256(insertedSnapshots[0])).toBe(
-      '44481fab6a0726bbabc2bdedb4d98bc499792a5725cbdab31b301d226df6b643'
+    expect(externalGoldenSha256(legacyForecast)).toBe(
+      '7436ed22741a23d3017fa23dcdd0821c950205005137aac3d5315ea3f8d6d401'
     );
     expect(flagOffForecast).not.toHaveProperty('provenance');
     expect(insertedSnapshots[1]?.metadata).not.toHaveProperty('actualsFacts');
@@ -305,11 +364,11 @@ describe('MonteCarloSimulationService actuals-backed company inputs', () => {
     const shadowForecast = await new MonteCarloSimulationService().generateForecast(PARAMS);
 
     expect
-      .soft(sha256(withoutAssumptionsProvenance(onForecast)))
-      .toBe('3ecee4b969b8e5bd423bb322a0cb078e862a4069eb24a2526d63252dc49f70ad');
+      .soft(externalGoldenSha256(withoutAssumptionsProvenance(onForecast)))
+      .toBe('d7ec452b229e69c630fe6658cba3cbd00c46fd82bff1a870071274a4a59efb4c');
     expect
-      .soft(sha256(withoutAssumptionsProvenance(shadowForecast)))
-      .toBe('35736f29571844d463574dcf59c57836e67d9712297c41d90075f108c30f8e1d');
+      .soft(externalGoldenSha256(withoutAssumptionsProvenance(shadowForecast)))
+      .toBe('1b842f12238fa9adab2ff149504bc27e5e939f7caad9d9bf6e9536e4f7faadc1');
   });
 
   it('registers the server-only actuals-input flag off in every environment', () => {

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,8 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "github": {
+    "autoAlias": false
+  },
   "version": 2,
   "buildCommand": "npm run build:web && node scripts/build-vercel-api.mjs",
   "outputDirectory": "dist/public",


### PR DESCRIPTION
## Summary

- make production release governed-only and stage with `autoAlias=false`
- add schema manifests 19, 20, and 21; keep manifest 21 audit-only with human repair
- enforce release graph: target validation → release proof → schema audit → staged production deploy → deployment validation → authenticated staged smoke → promotion → authenticated post-promotion smoke
- add repository-wide sole-mutation guard and forward-revert rollback verification
- pin normalized Monte Carlo production inputs and schema drift evidence

## Scope and safety

Tracks #1179. Do not close that issue until exact merged-SHA runtime proof and production alias evidence are posted.

This PR authorizes clean-audit releases only. REFL-041 production schema-apply authorization remains OPEN; no production schema apply is authorized here. Task 16.3 economics implementation is out of scope.

## Verification

- full Vitest suite: 859 files passed, 6 skipped; 10,428 tests passed, 90 skipped
- pre-push targeted suite: 8 files, 299 tests passed
- TypeScript check: passed
- ESLint: passed
- Phoenix truth: 298/298
- workflow YAML, shell syntax, Prettier, and diff checks: passed
- focused release/security suite: 213/213
- local Testcontainers unavailable because no container runtime; mandatory GitHub Actions Testcontainers proof must pass before merge

## Merge gate

Do not merge until all required checks are green, including `CI Gate Status`, Testcontainers integration, and Linux normalized Monte Carlo golden proof.