### PR TITLE
fix(release): archive staged Vercel upload

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -119,6 +119,7 @@ jobs:
           DEPLOYMENT_URL="$(
             npx --yes vercel@55.0.0 deploy \
               --prod \
+              --archive=tgz \
               --skip-domain \
               --yes \
               --meta githubDeployment=1 \

--- a/tests/regressions/ci-fail-closed.test.ts
+++ b/tests/regressions/ci-fail-closed.test.ts
@@ -3672,6 +3672,12 @@ describe('required CI fails closed', () => {
     expect(stageNode?.uses).toBe('actions/setup-node@820762786026740c76f36085b0efc47a31fe5020');
     expect(stageNode?.with?.['node-version']).toBe('20.19.0');
     expect(stageNode?.with?.cache).toBeUndefined();
+    const deployStep = stageProduction?.steps?.find(
+      (step) => step.name === 'Create staged production deployment'
+    );
+    const stageDeployCommands = vercelCommandTokens(deployStep?.run ?? '');
+    expect(stageDeployCommands).toHaveLength(1);
+    expect(stageDeployCommands[0]).toContain('--archive=tgz');
     const stageScripts = allRunScripts({ jobs: { stage: stageProduction ?? {} } }).join('\n');
     expect(stageScripts).toContain('repos/${REPO}/commits/main');
     expect(stageScripts).toContain('git rev-parse HEAD');
@@ -3690,9 +3696,6 @@ describe('required CI fails closed', () => {
     expect(stageScripts).toContain('VERCEL_PROJECT_ID is required');
     expect(stageScripts).toContain('GITHUB_OUTPUT');
     expect(stageScripts).toContain('Vercel deploy must return one bare HTTPS vercel.app');
-    const deployStep = stageProduction?.steps?.find(
-      (step) => step.name === 'Create staged production deployment'
-    );
     expect(deployStep?.env?.VERCEL_TOKEN).toBe('${{ secrets.VERCEL_TOKEN }}');
     expect(deployStep?.env?.VERCEL_ORG_ID).toBe('${{ vars.VERCEL_ORG_ID }}');
     expect(deployStep?.env?.VERCEL_PROJECT_ID).toBe('${{ vars.VERCEL_PROJECT_ID }}');


### PR DESCRIPTION
## Failure

Governed Release Production run [30564904448](https://github.com/nikhillinit/Updog_restore/actions/runs/30564904448) passed exact-SHA validation, full DB-backed release proof, and clean production schema audit, then failed before deployment creation with Vercel `api-upload-free` (>5000 uploaded files). Identity, smoke, promotion, and post-promotion jobs were skipped; production traffic did not move.

## Fix

- add Vercel CLI `--archive=tgz` to the staged `--prod --skip-domain` deployment
- pin the archive flag at argv level in the fail-closed release regression
- preserve SHA fences, metadata, secret handling, strict deployment URL validation, staged smoke, promotion, and post-promotion ordering

Official Vercel deploy documentation recommends `--archive=tgz` to minimize file count and avoid upload limits.

## Verification

- `TZ=UTC npx vitest run tests/regressions/ci-fail-closed.test.ts --project=server` — 189/189
- `npm run check` — 0 errors
- `npm run lint` — pass
- Prettier, YAML parse, and `git diff --check` — pass
- independent review — APPROVE, 0 findings

## Runtime plan

After merge, rerun `Release Production` for exact live `main`, approve the Production environment, and retain all identity/smoke/promotion evidence for #1179.
