### PR TITLE
feat(economics): WP-L3 internal LP economics service/persistence tier

### DIFF
--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -327,6 +327,11 @@ schema_tests:
   - 'server/routes/internal-analysis.ts'
   - 'scripts/audit-prod-operator-seam.mjs'
   - 'scripts/reconcile-prod-schema.mjs'
+  # WP-L3 (task 16.3) internal-economics policy/envelope/run substrate
+  - 'tests/integration/internal-economics/economics-schema.pg.test.ts'
+  - 'migrations/0045_internal_economics_policy_runs.sql'
+  - 'scripts/prod-schema-manifests/22-internal-economics-policy-runs.json'
+  - 'shared/schema/internal-economics.ts'
   - 'scripts/prod-schema-apply-policy.mjs'
   - 'scripts/prod-schema-patches/**'
   - 'scripts/prod-schema-manifests/**'

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -31,6 +31,18 @@ paths = [
 ]
 
 [[allowlists]]
+description = "Allow deterministic WP-L3 idempotency fixtures"
+targetRules = ["generic-api-key"]
+condition = "AND"
+regexTarget = "line"
+regexes = [
+  '''^\s*idempotencyKey:\s*'(?:tc13-ordinary|tc16-exhausted)',$'''
+]
+paths = [
+  '''^tests/unit/services/internal-economics/lp-economics-run-service\.test\.ts$'''
+]
+
+[[allowlists]]
 description = "Allow historical negative-control fixture template from blocking repo-history scans"
 targetRules = ["updog-negative-control-token"]
 condition = "AND"

--- a/client/src/components/fund-results/ReserveIntelligencePanel.tsx
+++ b/client/src/components/fund-results/ReserveIntelligencePanel.tsx
@@ -151,7 +151,8 @@ function evidenceFromReserveRun(run: ReserveRun, fact: CompanyFact): FinancialEv
 function EffectiveTermsBasis({ snapshot }: { snapshot: FactsSnapshot }) {
   if (
     snapshot.policyVersion !== 'financial-facts-policy/1.1.0' &&
-    snapshot.policyVersion !== 'financial-facts-policy/1.2.0'
+    snapshot.policyVersion !== 'financial-facts-policy/1.2.0' &&
+    snapshot.policyVersion !== 'financial-facts-policy/1.3.0'
   ) {
     return (
       <div className="space-y-1 text-xs text-presson-textMuted">
@@ -212,7 +213,8 @@ function buildSelectionDeviationItems(snapshot: FactsSnapshot): string[] {
   const items = ['working_value_selection_deviation'];
   if (
     snapshot.policyVersion !== 'financial-facts-policy/1.1.0' &&
-    snapshot.policyVersion !== 'financial-facts-policy/1.2.0'
+    snapshot.policyVersion !== 'financial-facts-policy/1.2.0' &&
+    snapshot.policyVersion !== 'financial-facts-policy/1.3.0'
   ) {
     return items;
   }

--- a/client/src/hooks/useReserveIntelligence.ts
+++ b/client/src/hooks/useReserveIntelligence.ts
@@ -73,6 +73,7 @@ const factsSnapshotSchema = z
       'financial-facts-policy/1.0.1',
       'financial-facts-policy/1.1.0',
       'financial-facts-policy/1.2.0',
+      'financial-facts-policy/1.3.0',
     ]),
     asOfDate: z.string().date(),
     snapshotInputHash: sha256Schema,

--- a/migrations/0045_internal_economics_policy_runs.sql
+++ b/migrations/0045_internal_economics_policy_runs.sql
@@ -1,0 +1,279 @@
+-- @drift-patch
+-- Reason: Task 16.3 WP-L3 Phase A (ADR-065 items 2/3/6) — internal LP economics
+-- persistence tier: immutable capital-envelope versions (Brief 3), immutable
+-- economics-policy versions (D3/P-D6), and pure-lineage run rows (P-D4/P-D5),
+-- landing dormant ahead of their services (0038/0044 posture). Adds the
+-- fund_snapshots (id, type) unique so run rows can pin snapshot TYPE with a
+-- composite FK (P-D3), and the repo's first DB-enforced immutability trigger
+-- (P-D2): BEFORE UPDATE forbid on the three new tables plus a type-scoped
+-- forbid on fund_snapshots INTERNAL_LP_ECONOMICS rows (both OLD and NEW type,
+-- so a row cannot be laundered INTO the protected type). Replay-safe by
+-- construction: CREATE TABLE/INDEX IF NOT EXISTS, guarded ADD CONSTRAINT,
+-- CREATE OR REPLACE FUNCTION, DROP TRIGGER IF EXISTS + CREATE TRIGGER.
+
+-- Snapshot TYPE becomes DB-enforced (P-D3). Trivially valid: "id" is the PK.
+-- Guarded for replay safety; scoped to fund_snapshots via conrelid.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'fund_snapshots_id_type_unique'
+      AND conrelid = 'public.fund_snapshots'::regclass
+  ) THEN
+    ALTER TABLE "fund_snapshots"
+      ADD CONSTRAINT "fund_snapshots_id_type_unique" UNIQUE ("id", "type");
+  END IF;
+END $$;
+--> statement-breakpoint
+
+-- Immutable legal capital envelope (Brief 3). Corrections insert child
+-- versions via parent_envelope_version_id; rows are never updated (trigger
+-- below). Every basis-version FK is ON DELETE restrict (D8, L3-Q2 ruling);
+-- version-lineage self-FKs stay NO ACTION (correction-chain, not a basis pin).
+CREATE TABLE IF NOT EXISTS "internal_capital_envelope_versions" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "fund_id" integer NOT NULL,
+  "version" integer NOT NULL,
+  "main_fund_vehicle_id" integer NOT NULL,
+  "lp_commitment_usd" numeric(20,6) NOT NULL,
+  "gp_commitment_usd" numeric(20,6) NOT NULL,
+  "total_commitment_usd" numeric(20,6) NOT NULL,
+  "currency" varchar(3) NOT NULL,
+  "effective_at" timestamp with time zone NOT NULL,
+  "source_artifact_id" integer NOT NULL,
+  "source_config_id" integer NOT NULL,
+  "source_config_version" integer NOT NULL,
+  "source_config_hash" varchar(64) NOT NULL,
+  "attested_by" integer NOT NULL,
+  "attested_at" timestamp with time zone NOT NULL,
+  "envelope_hash" varchar(64) NOT NULL,
+  "parent_envelope_version_id" integer,
+  "idempotency_key" varchar(128) NOT NULL,
+  "request_hash" varchar(64) NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "internal_capital_envelope_versions_fund_id_funds_id_fk"
+    FOREIGN KEY ("fund_id") REFERENCES "public"."funds"("id") ON DELETE cascade,
+  CONSTRAINT "internal_capital_envelope_versions_vehicle_fund_fk"
+    FOREIGN KEY ("main_fund_vehicle_id", "fund_id")
+    REFERENCES "public"."vehicles"("id", "fund_id") ON DELETE restrict,
+  CONSTRAINT "internal_capital_envelope_versions_source_artifact_fund_fk"
+    FOREIGN KEY ("source_artifact_id", "fund_id")
+    REFERENCES "public"."source_artifacts"("id", "fund_id") ON DELETE restrict,
+  CONSTRAINT "internal_capital_envelope_versions_attested_by_fk"
+    FOREIGN KEY ("attested_by") REFERENCES "public"."users"("id"),
+  CONSTRAINT "internal_capital_envelope_versions_parent_fund_fk"
+    FOREIGN KEY ("parent_envelope_version_id", "fund_id")
+    REFERENCES "public"."internal_capital_envelope_versions"("id", "fund_id"),
+  CONSTRAINT "internal_capital_envelope_versions_id_fund_unique"
+    UNIQUE ("id", "fund_id"),
+  CONSTRAINT "internal_capital_envelope_versions_fund_version_unique"
+    UNIQUE ("fund_id", "version"),
+  CONSTRAINT "internal_capital_envelope_versions_fund_idempotency_unique"
+    UNIQUE ("fund_id", "idempotency_key"),
+  CONSTRAINT "internal_capital_envelope_versions_currency_check"
+    CHECK ("currency" = 'USD'),
+  CONSTRAINT "internal_capital_envelope_versions_lp_nonnegative_check"
+    CHECK ("lp_commitment_usd" >= 0),
+  CONSTRAINT "internal_capital_envelope_versions_gp_nonnegative_check"
+    CHECK ("gp_commitment_usd" >= 0),
+  CONSTRAINT "internal_capital_envelope_versions_total_positive_check"
+    CHECK ("total_commitment_usd" > 0),
+  CONSTRAINT "internal_capital_envelope_versions_commitment_sum_check"
+    CHECK ("lp_commitment_usd" + "gp_commitment_usd" = "total_commitment_usd"),
+  CONSTRAINT "internal_capital_envelope_versions_no_self_parent_check"
+    CHECK ("parent_envelope_version_id" IS NULL OR "parent_envelope_version_id" <> "id")
+);
+--> statement-breakpoint
+
+-- Immutable authored economics policy (D3 minimum columns + P-D6). The
+-- terminal pair lives in dedicated columns, written exclusively via the
+-- exported terminal-policy helpers (G11; ADR-065 item 8). The envelope pin is
+-- a basis-version FK (restrict); the parent self-FK is lineage (NO ACTION).
+CREATE TABLE IF NOT EXISTS "internal_economics_policy_versions" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "fund_id" integer NOT NULL,
+  "version" integer NOT NULL,
+  "policy_schema_version" text NOT NULL,
+  "policy_body" jsonb NOT NULL,
+  "normalization_warnings" jsonb DEFAULT '[]'::jsonb NOT NULL,
+  "terminal_period_end" date NOT NULL,
+  "terminal_resolution_methodology_version" text NOT NULL,
+  "capital_envelope_version_id" integer NOT NULL,
+  "assumptions_hash" text NOT NULL,
+  "source_config_id" integer NOT NULL,
+  "source_config_version" integer NOT NULL,
+  "parent_policy_version_id" integer,
+  "created_by" integer,
+  "idempotency_key" varchar(128) NOT NULL,
+  "request_hash" varchar(64) NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "internal_economics_policy_versions_fund_id_funds_id_fk"
+    FOREIGN KEY ("fund_id") REFERENCES "public"."funds"("id") ON DELETE cascade,
+  CONSTRAINT "internal_economics_policy_versions_envelope_fund_fk"
+    FOREIGN KEY ("capital_envelope_version_id", "fund_id")
+    REFERENCES "public"."internal_capital_envelope_versions"("id", "fund_id") ON DELETE restrict,
+  CONSTRAINT "internal_economics_policy_versions_parent_fund_fk"
+    FOREIGN KEY ("parent_policy_version_id", "fund_id")
+    REFERENCES "public"."internal_economics_policy_versions"("id", "fund_id"),
+  CONSTRAINT "internal_economics_policy_versions_created_by_fk"
+    FOREIGN KEY ("created_by") REFERENCES "public"."users"("id"),
+  CONSTRAINT "internal_economics_policy_versions_id_fund_unique"
+    UNIQUE ("id", "fund_id"),
+  CONSTRAINT "internal_economics_policy_versions_fund_version_unique"
+    UNIQUE ("fund_id", "version"),
+  CONSTRAINT "internal_economics_policy_versions_fund_idempotency_unique"
+    UNIQUE ("fund_id", "idempotency_key"),
+  CONSTRAINT "internal_economics_policy_versions_no_self_parent_check"
+    CHECK ("parent_policy_version_id" IS NULL OR "parent_policy_version_id" <> "id")
+);
+--> statement-breakpoint
+
+-- Pure lineage run rows (ADR-065 item 2 + P-D3/P-D5): FKs + hashes + state,
+-- never result values. Result payloads live in fund_snapshots
+-- (type = 'INTERNAL_LP_ECONOMICS'), pinned here through the typed composite
+-- FK onto fund_snapshots (id, type). The state-coupling CHECK makes a
+-- completed run structurally inseparable from exactly one result snapshot and
+-- a failed run structurally unable to carry one. result_status admits only
+-- 'indicative' | 'unavailable' so 'available' is DB-unreachable until the
+-- certification act amends this constraint (D-11 addendum).
+CREATE TABLE IF NOT EXISTS "internal_lp_economics_runs" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "fund_id" integer NOT NULL,
+  "policy_version_id" integer NOT NULL,
+  "facts_snapshot_id" integer NOT NULL,
+  "plan_version_id" integer NOT NULL,
+  "forecast_snapshot_id" integer NOT NULL,
+  "forecast_snapshot_type" varchar(50) NOT NULL,
+  "result_snapshot_id" integer,
+  "result_snapshot_type" varchar(50),
+  "run_state" varchar(16) NOT NULL,
+  "result_status" varchar(16),
+  "failure_code" text,
+  "failure_context" jsonb,
+  "evaluation_clock" timestamp with time zone NOT NULL,
+  "terminal_mode" varchar(24) NOT NULL,
+  "engine_version" text NOT NULL,
+  "methodology_version" text NOT NULL,
+  "input_hash" varchar(64) NOT NULL,
+  "result_hash" varchar(64),
+  "created_by" integer,
+  "idempotency_key" varchar(128) NOT NULL,
+  "request_hash" varchar(64) NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "internal_lp_economics_runs_fund_id_funds_id_fk"
+    FOREIGN KEY ("fund_id") REFERENCES "public"."funds"("id") ON DELETE cascade,
+  CONSTRAINT "internal_lp_economics_runs_policy_version_fund_fk"
+    FOREIGN KEY ("policy_version_id", "fund_id")
+    REFERENCES "public"."internal_economics_policy_versions"("id", "fund_id") ON DELETE restrict,
+  CONSTRAINT "internal_lp_economics_runs_facts_snapshot_fund_fk"
+    FOREIGN KEY ("facts_snapshot_id", "fund_id")
+    REFERENCES "public"."financial_facts_snapshots"("id", "fund_id") ON DELETE restrict,
+  CONSTRAINT "internal_lp_economics_runs_plan_version_fk"
+    FOREIGN KEY ("plan_version_id")
+    REFERENCES "public"."current_plan_versions"("id") ON DELETE restrict,
+  CONSTRAINT "internal_lp_economics_runs_forecast_snapshot_type_fk"
+    FOREIGN KEY ("forecast_snapshot_id", "forecast_snapshot_type")
+    REFERENCES "public"."fund_snapshots"("id", "type") ON DELETE restrict,
+  CONSTRAINT "internal_lp_economics_runs_result_snapshot_type_fk"
+    FOREIGN KEY ("result_snapshot_id", "result_snapshot_type")
+    REFERENCES "public"."fund_snapshots"("id", "type") ON DELETE restrict,
+  CONSTRAINT "internal_lp_economics_runs_created_by_fk"
+    FOREIGN KEY ("created_by") REFERENCES "public"."users"("id"),
+  CONSTRAINT "internal_lp_economics_runs_id_fund_unique"
+    UNIQUE ("id", "fund_id"),
+  CONSTRAINT "internal_lp_economics_runs_fund_idempotency_unique"
+    UNIQUE ("fund_id", "idempotency_key"),
+  CONSTRAINT "internal_lp_economics_runs_run_state_check"
+    CHECK ("run_state" IN ('completed','failed')),
+  CONSTRAINT "internal_lp_economics_runs_result_status_check"
+    CHECK ("result_status" IS NULL OR "result_status" IN ('indicative','unavailable')),
+  CONSTRAINT "internal_lp_economics_runs_terminal_mode_check"
+    CHECK ("terminal_mode" IN ('liquidate_at_horizon','hold_unrealized')),
+  CONSTRAINT "internal_lp_economics_runs_forecast_snapshot_type_check"
+    CHECK ("forecast_snapshot_type" = 'CURRENT_FORECAST_V2'),
+  CONSTRAINT "internal_lp_economics_runs_result_snapshot_type_check"
+    CHECK ("result_snapshot_type" IS NULL OR "result_snapshot_type" = 'INTERNAL_LP_ECONOMICS'),
+  CONSTRAINT "internal_lp_economics_runs_state_coupling_check"
+    CHECK (
+      (
+        "run_state" = 'completed'
+        AND "result_snapshot_id" IS NOT NULL
+        AND "result_snapshot_type" IS NOT NULL
+        AND "result_status" IS NOT NULL
+        AND "result_hash" IS NOT NULL
+        AND "failure_code" IS NULL
+        AND "failure_context" IS NULL
+      )
+      OR (
+        "run_state" = 'failed'
+        AND "result_snapshot_id" IS NULL
+        AND "result_snapshot_type" IS NULL
+        AND "result_status" IS NULL
+        AND "result_hash" IS NULL
+        AND "failure_code" IS NOT NULL
+        AND "failure_context" IS NOT NULL
+      )
+    )
+);
+--> statement-breakpoint
+
+-- Exactly one run may pin a given result snapshot (P-D4 one-to-one linkage;
+-- partial uniques cannot be UNIQUE constraints in PG, and nothing FKs this
+-- index, so the 42830 unique()-not-uniqueIndex lesson does not apply here).
+CREATE UNIQUE INDEX IF NOT EXISTS "internal_lp_economics_runs_result_snapshot_unique"
+  ON "internal_lp_economics_runs" ("result_snapshot_id")
+  WHERE "result_snapshot_id" IS NOT NULL;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_internal_lp_economics_runs_fund_created"
+  ON "internal_lp_economics_runs" ("fund_id", "created_at" DESC);
+--> statement-breakpoint
+
+-- P-D2: one shared BEFORE UPDATE forbid function. Whole-row: every UPDATE is
+-- forbidden (strictly contains ADR-065 item 2's "immutability of body, hash,
+-- and provenance"). DELETE is deliberately NOT trigger-blocked: direct deletes
+-- of referenced rows already fail via the restrict FK web, and DB-enforced
+-- immutability only ever meant no-UPDATE.
+CREATE OR REPLACE FUNCTION "internal_economics_forbid_update"() RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RAISE EXCEPTION 'immutable_row_update_forbidden: %', TG_TABLE_NAME;
+END;
+$$;
+--> statement-breakpoint
+DROP TRIGGER IF EXISTS "internal_capital_envelope_versions_forbid_update_trigger"
+  ON "internal_capital_envelope_versions";
+--> statement-breakpoint
+CREATE TRIGGER "internal_capital_envelope_versions_forbid_update_trigger"
+  BEFORE UPDATE ON "internal_capital_envelope_versions"
+  FOR EACH ROW EXECUTE FUNCTION "internal_economics_forbid_update"();
+--> statement-breakpoint
+DROP TRIGGER IF EXISTS "internal_economics_policy_versions_forbid_update_trigger"
+  ON "internal_economics_policy_versions";
+--> statement-breakpoint
+CREATE TRIGGER "internal_economics_policy_versions_forbid_update_trigger"
+  BEFORE UPDATE ON "internal_economics_policy_versions"
+  FOR EACH ROW EXECUTE FUNCTION "internal_economics_forbid_update"();
+--> statement-breakpoint
+DROP TRIGGER IF EXISTS "internal_lp_economics_runs_forbid_update_trigger"
+  ON "internal_lp_economics_runs";
+--> statement-breakpoint
+CREATE TRIGGER "internal_lp_economics_runs_forbid_update_trigger"
+  BEFORE UPDATE ON "internal_lp_economics_runs"
+  FOR EACH ROW EXECUTE FUNCTION "internal_economics_forbid_update"();
+--> statement-breakpoint
+
+-- Type-scoped fourth trigger (P-D2 R1/R3 amendments): the result VALUE payload
+-- lives in fund_snapshots, which has a live in-place UPDATE code path for
+-- other snapshot types. The WHEN clause covers BOTH directions — updating a
+-- protected row AND laundering another row INTO the protected type — while
+-- leaving every other snapshot type's existing mutability untouched.
+DROP TRIGGER IF EXISTS "fund_snapshots_internal_economics_forbid_update_trigger"
+  ON "fund_snapshots";
+--> statement-breakpoint
+CREATE TRIGGER "fund_snapshots_internal_economics_forbid_update_trigger"
+  BEFORE UPDATE ON "fund_snapshots"
+  FOR EACH ROW
+  WHEN (OLD."type" = 'INTERNAL_LP_ECONOMICS' OR NEW."type" = 'INTERNAL_LP_ECONOMICS')
+  EXECUTE FUNCTION "internal_economics_forbid_update"();

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1785282000000,
       "tag": "0044_internal_analysis",
       "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1785368400000,
+      "tag": "0045_internal_economics_policy_runs",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/prod-schema-manifests/22-internal-economics-policy-runs.json
+++ b/scripts/prod-schema-manifests/22-internal-economics-policy-runs.json
@@ -1,0 +1,460 @@
+{
+  "name": "internal-economics-policy-runs",
+  "order": 22,
+  "description": "Task 16.3 WP-L3 Phase A internal LP economics persistence tier: immutable capital-envelope versions, immutable economics-policy versions, and pure-lineage run rows, landing dormant. Includes the fund_snapshots (id, type) unique for typed snapshot composite FKs and the internal_economics_forbid_update trigger web (three new tables plus the type-scoped fund_snapshots trigger). Trigger and function DDL cannot ride the additive-safe automated apply path (DROP TRIGGER is an unknown drop), so trigger drift audits REFUSE-FOR-HUMAN: the operator applies migrations/0045 manually and the audit must then end SKIP-clean.",
+  "missingTablePolicy": "create_or_repair",
+  "sqlFiles": ["migrations/0045_internal_economics_policy_runs.sql"],
+  "allowedCreateTables": [
+    "internal_capital_envelope_versions",
+    "internal_economics_policy_versions",
+    "internal_lp_economics_runs"
+  ],
+  "functionDefinitions": [
+    {
+      "name": "internal_economics_forbid_update",
+      "expectedDefinition": {
+        "exactDefinition": "CREATE OR REPLACE FUNCTION public.internal_economics_forbid_update()\n RETURNS trigger\n LANGUAGE plpgsql\nAS $function$\nBEGIN\n  RAISE EXCEPTION 'immutable_row_update_forbidden: %', TG_TABLE_NAME;\nEND;\n$function$\n",
+        "orderedFragments": [
+          "CREATE OR REPLACE FUNCTION public.internal_economics_forbid_update()",
+          "RETURNS trigger",
+          "LANGUAGE plpgsql",
+          "RAISE EXCEPTION",
+          "TG_TABLE_NAME"
+        ],
+        "stringLiterals": ["immutable_row_update_forbidden: %"]
+      }
+    }
+  ],
+  "expectedTables": [
+    {
+      "name": "internal_capital_envelope_versions",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "fund_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "version",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "main_fund_vehicle_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "lp_commitment_usd",
+          "type": "numeric",
+          "nullable": false
+        },
+        {
+          "name": "gp_commitment_usd",
+          "type": "numeric",
+          "nullable": false
+        },
+        {
+          "name": "total_commitment_usd",
+          "type": "numeric",
+          "nullable": false
+        },
+        {
+          "name": "currency",
+          "type": "varchar",
+          "nullable": false
+        },
+        {
+          "name": "effective_at",
+          "type": "timestamptz",
+          "nullable": false
+        },
+        {
+          "name": "source_artifact_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "source_config_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "source_config_version",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "source_config_hash",
+          "type": "varchar",
+          "nullable": false
+        },
+        {
+          "name": "attested_by",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "attested_at",
+          "type": "timestamptz",
+          "nullable": false
+        },
+        {
+          "name": "envelope_hash",
+          "type": "varchar",
+          "nullable": false
+        },
+        {
+          "name": "parent_envelope_version_id",
+          "type": "integer",
+          "nullable": true
+        },
+        {
+          "name": "idempotency_key",
+          "type": "varchar",
+          "nullable": false
+        },
+        {
+          "name": "request_hash",
+          "type": "varchar",
+          "nullable": false
+        },
+        {
+          "name": "created_at",
+          "type": "timestamptz",
+          "nullable": false
+        }
+      ],
+      "constraints": [
+        "internal_capital_envelope_versions_fund_id_funds_id_fk",
+        "internal_capital_envelope_versions_vehicle_fund_fk",
+        "internal_capital_envelope_versions_source_artifact_fund_fk",
+        "internal_capital_envelope_versions_attested_by_fk",
+        "internal_capital_envelope_versions_parent_fund_fk",
+        "internal_capital_envelope_versions_id_fund_unique",
+        "internal_capital_envelope_versions_fund_version_unique",
+        "internal_capital_envelope_versions_fund_idempotency_unique",
+        "internal_capital_envelope_versions_currency_check",
+        "internal_capital_envelope_versions_lp_nonnegative_check",
+        "internal_capital_envelope_versions_gp_nonnegative_check",
+        "internal_capital_envelope_versions_total_positive_check",
+        "internal_capital_envelope_versions_commitment_sum_check",
+        "internal_capital_envelope_versions_no_self_parent_check"
+      ],
+      "triggerDefinitions": [
+        {
+          "name": "internal_capital_envelope_versions_forbid_update_trigger",
+          "expectedDefinition": {
+            "exactDefinition": "CREATE TRIGGER internal_capital_envelope_versions_forbid_update_trigger BEFORE UPDATE ON public.internal_capital_envelope_versions FOR EACH ROW EXECUTE FUNCTION internal_economics_forbid_update()",
+            "orderedFragments": [
+              "CREATE TRIGGER",
+              "BEFORE UPDATE ON public.internal_capital_envelope_versions",
+              "FOR EACH ROW",
+              "EXECUTE FUNCTION internal_economics_forbid_update()"
+            ],
+            "stringLiterals": []
+          }
+        }
+      ]
+    },
+    {
+      "name": "internal_economics_policy_versions",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "fund_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "version",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "policy_schema_version",
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "policy_body",
+          "type": "jsonb",
+          "nullable": false
+        },
+        {
+          "name": "normalization_warnings",
+          "type": "jsonb",
+          "nullable": false
+        },
+        {
+          "name": "terminal_period_end",
+          "type": "date",
+          "nullable": false
+        },
+        {
+          "name": "terminal_resolution_methodology_version",
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "capital_envelope_version_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "assumptions_hash",
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "source_config_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "source_config_version",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "parent_policy_version_id",
+          "type": "integer",
+          "nullable": true
+        },
+        {
+          "name": "created_by",
+          "type": "integer",
+          "nullable": true
+        },
+        {
+          "name": "idempotency_key",
+          "type": "varchar",
+          "nullable": false
+        },
+        {
+          "name": "request_hash",
+          "type": "varchar",
+          "nullable": false
+        },
+        {
+          "name": "created_at",
+          "type": "timestamptz",
+          "nullable": false
+        }
+      ],
+      "constraints": [
+        "internal_economics_policy_versions_fund_id_funds_id_fk",
+        "internal_economics_policy_versions_envelope_fund_fk",
+        "internal_economics_policy_versions_parent_fund_fk",
+        "internal_economics_policy_versions_created_by_fk",
+        "internal_economics_policy_versions_id_fund_unique",
+        "internal_economics_policy_versions_fund_version_unique",
+        "internal_economics_policy_versions_fund_idempotency_unique",
+        "internal_economics_policy_versions_no_self_parent_check"
+      ],
+      "triggerDefinitions": [
+        {
+          "name": "internal_economics_policy_versions_forbid_update_trigger",
+          "expectedDefinition": {
+            "exactDefinition": "CREATE TRIGGER internal_economics_policy_versions_forbid_update_trigger BEFORE UPDATE ON public.internal_economics_policy_versions FOR EACH ROW EXECUTE FUNCTION internal_economics_forbid_update()",
+            "orderedFragments": [
+              "CREATE TRIGGER",
+              "BEFORE UPDATE ON public.internal_economics_policy_versions",
+              "FOR EACH ROW",
+              "EXECUTE FUNCTION internal_economics_forbid_update()"
+            ],
+            "stringLiterals": []
+          }
+        }
+      ]
+    },
+    {
+      "name": "internal_lp_economics_runs",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "fund_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "policy_version_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "facts_snapshot_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "plan_version_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "forecast_snapshot_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "forecast_snapshot_type",
+          "type": "varchar",
+          "nullable": false
+        },
+        {
+          "name": "result_snapshot_id",
+          "type": "integer",
+          "nullable": true
+        },
+        {
+          "name": "result_snapshot_type",
+          "type": "varchar",
+          "nullable": true
+        },
+        {
+          "name": "run_state",
+          "type": "varchar",
+          "nullable": false
+        },
+        {
+          "name": "result_status",
+          "type": "varchar",
+          "nullable": true
+        },
+        {
+          "name": "failure_code",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "failure_context",
+          "type": "jsonb",
+          "nullable": true
+        },
+        {
+          "name": "evaluation_clock",
+          "type": "timestamptz",
+          "nullable": false
+        },
+        {
+          "name": "terminal_mode",
+          "type": "varchar",
+          "nullable": false
+        },
+        {
+          "name": "engine_version",
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "methodology_version",
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "input_hash",
+          "type": "varchar",
+          "nullable": false
+        },
+        {
+          "name": "result_hash",
+          "type": "varchar",
+          "nullable": true
+        },
+        {
+          "name": "created_by",
+          "type": "integer",
+          "nullable": true
+        },
+        {
+          "name": "idempotency_key",
+          "type": "varchar",
+          "nullable": false
+        },
+        {
+          "name": "request_hash",
+          "type": "varchar",
+          "nullable": false
+        },
+        {
+          "name": "created_at",
+          "type": "timestamptz",
+          "nullable": false
+        }
+      ],
+      "constraints": [
+        "internal_lp_economics_runs_fund_id_funds_id_fk",
+        "internal_lp_economics_runs_policy_version_fund_fk",
+        "internal_lp_economics_runs_facts_snapshot_fund_fk",
+        "internal_lp_economics_runs_plan_version_fk",
+        "internal_lp_economics_runs_forecast_snapshot_type_fk",
+        "internal_lp_economics_runs_result_snapshot_type_fk",
+        "internal_lp_economics_runs_created_by_fk",
+        "internal_lp_economics_runs_id_fund_unique",
+        "internal_lp_economics_runs_fund_idempotency_unique",
+        "internal_lp_economics_runs_run_state_check",
+        "internal_lp_economics_runs_result_status_check",
+        "internal_lp_economics_runs_terminal_mode_check",
+        "internal_lp_economics_runs_forecast_snapshot_type_check",
+        "internal_lp_economics_runs_result_snapshot_type_check",
+        "internal_lp_economics_runs_state_coupling_check"
+      ],
+      "indexes": [
+        "internal_lp_economics_runs_result_snapshot_unique",
+        "idx_internal_lp_economics_runs_fund_created"
+      ],
+      "triggerDefinitions": [
+        {
+          "name": "internal_lp_economics_runs_forbid_update_trigger",
+          "expectedDefinition": {
+            "exactDefinition": "CREATE TRIGGER internal_lp_economics_runs_forbid_update_trigger BEFORE UPDATE ON public.internal_lp_economics_runs FOR EACH ROW EXECUTE FUNCTION internal_economics_forbid_update()",
+            "orderedFragments": [
+              "CREATE TRIGGER",
+              "BEFORE UPDATE ON public.internal_lp_economics_runs",
+              "FOR EACH ROW",
+              "EXECUTE FUNCTION internal_economics_forbid_update()"
+            ],
+            "stringLiterals": []
+          }
+        }
+      ]
+    },
+    {
+      "name": "fund_snapshots",
+      "sharedTable": true,
+      "constraints": ["fund_snapshots_id_type_unique"],
+      "triggerDefinitions": [
+        {
+          "name": "fund_snapshots_internal_economics_forbid_update_trigger",
+          "expectedDefinition": {
+            "exactDefinition": "CREATE TRIGGER fund_snapshots_internal_economics_forbid_update_trigger BEFORE UPDATE ON public.fund_snapshots FOR EACH ROW WHEN ((((old.type)::text = 'INTERNAL_LP_ECONOMICS'::text) OR ((new.type)::text = 'INTERNAL_LP_ECONOMICS'::text))) EXECUTE FUNCTION internal_economics_forbid_update()",
+            "orderedFragments": [
+              "CREATE TRIGGER",
+              "BEFORE UPDATE ON public.fund_snapshots",
+              "FOR EACH ROW",
+              "WHEN",
+              "old.type",
+              "new.type",
+              "EXECUTE FUNCTION internal_economics_forbid_update()"
+            ],
+            "stringLiterals": ["INTERNAL_LP_ECONOMICS", "INTERNAL_LP_ECONOMICS"]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/reconcile-prod-schema.mjs
+++ b/scripts/reconcile-prod-schema.mjs
@@ -45,6 +45,9 @@ const KNOWN_MANIFEST_KEYS = new Set([
   'applyPolicy',
   'missingTablePolicy',
   'manifestPath',
+  // WP-L3 T-A5: pg_proc-backed function-body pins (see functionDefinitions
+  // validation below; the per-table sibling is expectedTables[].triggerDefinitions).
+  'functionDefinitions',
 ]);
 const MISSING_TABLE_POLICIES = new Set([
   MISSING_TABLE_POLICY_CREATE_OR_REPAIR,
@@ -166,6 +169,11 @@ export function manifestChecksum(manifest, sqlFiles) {
       // (s8.1 red-team F3). Safe to add while the prod ledger is empty.
       dropObjects: manifest.dropObjects ?? [],
       applyPolicy: manifest.applyPolicy ?? {},
+      // Only manifests that PIN function bodies carry the key, so every
+      // pre-existing manifest checksum stays byte-identical (ledger dedupe).
+      ...(manifest.functionDefinitions
+        ? { functionDefinitions: manifest.functionDefinitions }
+        : {}),
     })
   );
 }
@@ -209,7 +217,48 @@ function validateManifest(manifest) {
   validateManifestKeys(manifest);
   validateMissingTablePolicyValue(manifest);
   validateExpectedTables(manifest);
+  validateFunctionDefinitions(manifest);
   validateApplyPolicy(manifest);
+}
+
+/** Shared shape contract for indexDefinitions / triggerDefinitions /
+ * functionDefinitions expected-definition pins. */
+function isValidExpectedDefinition(expectedDefinition) {
+  return (
+    Boolean(expectedDefinition) &&
+    typeof expectedDefinition.exactDefinition === 'string' &&
+    expectedDefinition.exactDefinition.trim().length > 0 &&
+    Array.isArray(expectedDefinition.orderedFragments) &&
+    expectedDefinition.orderedFragments.length > 0 &&
+    expectedDefinition.orderedFragments.every(
+      (fragment) => typeof fragment === 'string' && fragment.trim().length > 0
+    ) &&
+    Array.isArray(expectedDefinition.stringLiterals) &&
+    expectedDefinition.stringLiterals.every(
+      (literal) => typeof literal === 'string' && literal.length > 0
+    )
+  );
+}
+
+function validateFunctionDefinitions(manifest) {
+  const seenNames = new Set();
+  for (const functionDefinition of manifest?.functionDefinitions ?? []) {
+    assertSafeIdentifier(String(functionDefinition.name ?? ''));
+    if (
+      seenNames.has(functionDefinition.name) ||
+      !isValidExpectedDefinition(functionDefinition.expectedDefinition)
+    ) {
+      throw new ReconcileError(
+        `Manifest ${manifestLabel(manifest)} functionDefinitions target ${String(functionDefinition.name)} must be named exactly once and provide an exact definition, ordered fragments, and string literals`,
+        {
+          kind: 'invalid-function-definition',
+          manifest: manifestLabel(manifest),
+          name: functionDefinition.name,
+        }
+      );
+    }
+    seenNames.add(functionDefinition.name);
+  }
 }
 
 function validateExpectedTables(manifest) {
@@ -219,22 +268,10 @@ function validateExpectedTables(manifest) {
 
     for (const indexDefinition of table.indexDefinitions ?? []) {
       assertSafeIdentifier(String(indexDefinition.name ?? ''));
-      const expectedDefinition = indexDefinition.expectedDefinition;
       if (
         !indexes.has(indexDefinition.name) ||
         seenDefinitions.has(indexDefinition.name) ||
-        !expectedDefinition ||
-        typeof expectedDefinition.exactDefinition !== 'string' ||
-        expectedDefinition.exactDefinition.trim().length === 0 ||
-        !Array.isArray(expectedDefinition.orderedFragments) ||
-        expectedDefinition.orderedFragments.length === 0 ||
-        expectedDefinition.orderedFragments.some(
-          (fragment) => typeof fragment !== 'string' || fragment.trim().length === 0
-        ) ||
-        !Array.isArray(expectedDefinition.stringLiterals) ||
-        expectedDefinition.stringLiterals.some(
-          (literal) => typeof literal !== 'string' || literal.length === 0
-        )
+        !isValidExpectedDefinition(indexDefinition.expectedDefinition)
       ) {
         throw new ReconcileError(
           `Manifest ${manifestLabel(manifest)} indexDefinitions target ${table.name}.${String(indexDefinition.name)} must name an expected index exactly once and provide an exact definition, ordered fragments, and string literals`,
@@ -247,6 +284,26 @@ function validateExpectedTables(manifest) {
         );
       }
       seenDefinitions.add(indexDefinition.name);
+    }
+
+    const seenTriggers = new Set();
+    for (const triggerDefinition of table.triggerDefinitions ?? []) {
+      assertSafeIdentifier(String(triggerDefinition.name ?? ''));
+      if (
+        seenTriggers.has(triggerDefinition.name) ||
+        !isValidExpectedDefinition(triggerDefinition.expectedDefinition)
+      ) {
+        throw new ReconcileError(
+          `Manifest ${manifestLabel(manifest)} triggerDefinitions target ${table.name}.${String(triggerDefinition.name)} must be named exactly once and provide an exact definition, ordered fragments, and string literals`,
+          {
+            kind: 'invalid-trigger-definition',
+            manifest: manifestLabel(manifest),
+            table: table.name,
+            name: triggerDefinition.name,
+          }
+        );
+      }
+      seenTriggers.add(triggerDefinition.name);
     }
   }
 }
@@ -680,8 +737,9 @@ export async function auditManifest(client, manifest) {
   const missingTablePolicy = resolveMissingTablePolicy(manifest);
   const expectedTables = manifest.expectedTables ?? [];
   const dropObjects = manifest.dropObjects ?? [];
+  const functionDefinitions = manifest.functionDefinitions ?? [];
   const tableNames = expectedTables.map((table) => table.name);
-  if (tableNames.length === 0 && dropObjects.length === 0) {
+  if (tableNames.length === 0 && dropObjects.length === 0 && functionDefinitions.length === 0) {
     return {
       manifest: manifest.name,
       missingTablePolicy,
@@ -697,6 +755,7 @@ export async function auditManifest(client, manifest) {
     const columns = await loadColumns(client, tableNames);
     const constraints = await loadConstraints(client, tableNames, expectedTables);
     const indexes = await loadIndexes(client, expectedTables);
+    const triggers = await loadTriggers(client, expectedTables);
 
     for (const expectedTable of expectedTables) {
       const tableConstraints = constraints.filter(
@@ -710,6 +769,7 @@ export async function auditManifest(client, manifest) {
           columns: columns.get(expectedTable.name) ?? new Map(),
           constraints: tableConstraints,
           indexes,
+          triggers,
           nonNullColumnAdds: (manifest.applyPolicy?.allowNonNullColumnAdds ?? []).filter(
             (target) => target.table === expectedTable.name
           ),
@@ -722,6 +782,10 @@ export async function auditManifest(client, manifest) {
     }
   }
 
+  if (functionDefinitions.length > 0) {
+    objects.push(...(await auditFunctionDefinitions(client, functionDefinitions, missingTablePolicy)));
+  }
+
   if (dropObjects.length > 0) {
     objects.push(...(await auditDropObjects(client, dropObjects)));
   }
@@ -732,6 +796,113 @@ export async function auditManifest(client, manifest) {
     action: summarizeAction(objects.map((object) => object.action)),
     objects,
   };
+}
+
+/**
+ * WP-L3 T-A5: pg_proc-sourced function-body audit, the sibling of the
+ * per-table trigger wiring audit below. Function DDL cannot ride the
+ * additive-safe automated apply path, so any drift is humanReviewRequired:
+ * ACTION_REFUSE_FOR_HUMAN until the operator reconciles manually, ACTION_SKIP
+ * only once the live pg_get_functiondef body matches the manifest pin.
+ */
+async function auditFunctionDefinitions(client, functionDefinitions, missingTablePolicy) {
+  const rows = await loadFunctions(
+    client,
+    functionDefinitions.map((functionDefinition) => functionDefinition.name)
+  );
+
+  return functionDefinitions.map((functionDefinition) => {
+    const matches = rows.filter(
+      (row) => row.proname === pgIdentifier(functionDefinition.name)
+    );
+    const deltas = [];
+    if (matches.length === 0) {
+      deltas.push({
+        kind: 'missing-function',
+        name: functionDefinition.name,
+        additiveSafe: false,
+        humanReviewRequired: true,
+      });
+    } else if (matches.length > 1) {
+      deltas.push({
+        kind: 'function-overload-ambiguous',
+        name: functionDefinition.name,
+        additiveSafe: false,
+        humanReviewRequired: true,
+      });
+    } else if (
+      !indexDefinitionMatches(matches[0].definition, functionDefinition.expectedDefinition)
+    ) {
+      deltas.push({
+        kind: 'function-definition-mismatch',
+        name: functionDefinition.name,
+        expected: functionDefinition.expectedDefinition,
+        actual: matches[0].definition,
+        additiveSafe: false,
+        humanReviewRequired: true,
+      });
+    }
+
+    return {
+      table: `function:${functionDefinition.name}`,
+      present: matches.length > 0,
+      populated: false,
+      deltas,
+      action: decideObjectAction({
+        tablePresent: true,
+        deltas,
+        populated: false,
+        missingTablePolicy,
+      }),
+    };
+  });
+}
+
+async function loadFunctions(client, functionNames) {
+  if (functionNames.length === 0) return [];
+  const lookupNames = functionNames.map(pgIdentifier);
+
+  const result = await client.query(
+    `
+      SELECT p.proname, pg_get_functiondef(p.oid) AS definition
+      FROM pg_proc p
+      JOIN pg_namespace n ON n.oid = p.pronamespace
+      WHERE n.nspname = 'public'
+        AND p.proname = ANY($1::text[])
+    `,
+    [lookupNames]
+  );
+  return result.rows;
+}
+
+async function loadTriggers(client, expectedTables) {
+  const triggerNames = expectedTables.flatMap((table) =>
+    (table.triggerDefinitions ?? []).map((triggerDefinition) => triggerDefinition.name)
+  );
+  if (triggerNames.length === 0) return [];
+  const lookupNames = triggerNames.map(pgIdentifier);
+  const tableNames = expectedTables
+    .filter((table) => (table.triggerDefinitions ?? []).length > 0)
+    .map((table) => table.name);
+
+  const result = await client.query(
+    `
+      SELECT
+        c.relname AS table_name,
+        t.tgname,
+        t.tgenabled,
+        pg_get_triggerdef(t.oid) AS definition
+      FROM pg_trigger t
+      JOIN pg_class c ON c.oid = t.tgrelid
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public'
+        AND NOT t.tgisinternal
+        AND c.relname = ANY($1::text[])
+        AND t.tgname = ANY($2::text[])
+    `,
+    [tableNames, lookupNames]
+  );
+  return result.rows;
 }
 
 // Extra-objects audit: a dropObject PRESENT on the target means the manifest
@@ -1011,6 +1182,7 @@ async function auditTable({
   columns,
   constraints,
   indexes,
+  triggers = [],
   nonNullColumnAdds,
   constraintReplacements,
   missingTablePolicy,
@@ -1018,6 +1190,12 @@ async function auditTable({
   const deltas = [];
   const indexTableMismatches = findIndexTableMismatches(expectedTable, indexes);
   deltas.push(...indexTableMismatches);
+  // WP-L3 T-A5: trigger wiring deltas are computed BEFORE the missing-table
+  // early return so the pre-reconciliation state (table and trigger both
+  // absent) surfaces as ACTION_REFUSE_FOR_HUMAN, never as an automated
+  // create-and-apply — trigger DDL cannot ride the additive-safe apply path
+  // (DROP TRIGGER is an unknown drop for prod-schema-apply-policy.mjs).
+  deltas.push(...triggerDefinitionDeltas(expectedTable, triggers));
 
   if (!tablePresent) {
     deltas.push({ kind: 'missing-table', name: expectedTable.name, additiveSafe: true });
@@ -1244,6 +1422,55 @@ function indexDefinitionMatches(actualDefinition, expectedDefinition) {
     actualLiterals.length === expectedLiterals.length &&
     actualLiterals.every((literal, index) => literal === expectedLiterals[index])
   );
+}
+
+/**
+ * WP-L3 T-A5: pg_trigger/pg_get_triggerdef wiring audit, analogous to
+ * 0034's indexDefinitions. Every discrepancy — missing trigger, disabled
+ * trigger (tgenabled <> 'O'), or drifted definition — is humanReviewRequired,
+ * so the manifest audits ACTION_REFUSE_FOR_HUMAN until the operator applies
+ * the journaled migration manually, and ACTION_SKIP only once the live
+ * definition matches the manifest pin exactly.
+ */
+function triggerDefinitionDeltas(expectedTable, triggers) {
+  const deltas = [];
+  for (const triggerDefinition of expectedTable.triggerDefinitions ?? []) {
+    const trigger = triggers.find(
+      (row) =>
+        row.tgname === pgIdentifier(triggerDefinition.name) &&
+        row.table_name === expectedTable.name
+    );
+    if (!trigger) {
+      deltas.push({
+        kind: 'missing-trigger',
+        name: triggerDefinition.name,
+        additiveSafe: false,
+        humanReviewRequired: true,
+      });
+      continue;
+    }
+    if (trigger.tgenabled !== 'O') {
+      deltas.push({
+        kind: 'trigger-disabled',
+        name: triggerDefinition.name,
+        actual: trigger.tgenabled,
+        additiveSafe: false,
+        humanReviewRequired: true,
+      });
+      continue;
+    }
+    if (!indexDefinitionMatches(trigger.definition, triggerDefinition.expectedDefinition)) {
+      deltas.push({
+        kind: 'trigger-definition-mismatch',
+        name: triggerDefinition.name,
+        expected: triggerDefinition.expectedDefinition,
+        actual: trigger.definition,
+        additiveSafe: false,
+        humanReviewRequired: true,
+      });
+    }
+  }
+  return deltas;
 }
 
 function findIndexTableMismatches(expectedTable, indexes) {

--- a/server/lib/fund-scoped-ownership.ts
+++ b/server/lib/fund-scoped-ownership.ts
@@ -4,6 +4,11 @@ import { currentPlanVersions } from '../../shared/schema/current-plans';
 import { financialFactsSnapshots } from '../../shared/schema/financial-facts-snapshots';
 import { fundSnapshots } from '../../shared/schema/fund';
 import { internalAnalysisReferences } from '../../shared/schema/internal-analysis';
+import {
+  internalCapitalEnvelopeVersions,
+  internalEconomicsPolicyVersions,
+  internalLpEconomicsRuns,
+} from '../../shared/schema/internal-economics';
 import { financingEvents, financingTranches } from '../../shared/schema/investment-ledger';
 import { vehicles } from '../../shared/schema/lp-reporting-evidence';
 import { vehicleFinancingParticipations } from '../../shared/schema/vehicle-financing-participations';
@@ -17,7 +22,10 @@ export type FundScopedReference = {
     | 'vehicle'
     | 'financing_event'
     | 'financing_tranche'
-    | 'participation';
+    | 'participation'
+    | 'capital_envelope_version'
+    | 'economics_policy_version'
+    | 'lp_economics_run';
   id: string | number;
 };
 
@@ -186,6 +194,57 @@ export async function assertOwnedByFund(opts: {
           eq(vehicleFinancingParticipations.id, id),
           eq(vehicleFinancingParticipations.fundId, opts.fundId)
         )
+      )
+      .limit(1);
+
+    if (rows.length === 0) {
+      throw new FundScopeError(opts.ref);
+    }
+    return;
+  }
+
+  if (opts.ref.kind === 'capital_envelope_version') {
+    const rows = await opts.db
+      .select({ id: internalCapitalEnvelopeVersions.id })
+      .from(internalCapitalEnvelopeVersions)
+      .where(
+        and(
+          eq(internalCapitalEnvelopeVersions.id, id),
+          eq(internalCapitalEnvelopeVersions.fundId, opts.fundId)
+        )
+      )
+      .limit(1);
+
+    if (rows.length === 0) {
+      throw new FundScopeError(opts.ref);
+    }
+    return;
+  }
+
+  if (opts.ref.kind === 'economics_policy_version') {
+    const rows = await opts.db
+      .select({ id: internalEconomicsPolicyVersions.id })
+      .from(internalEconomicsPolicyVersions)
+      .where(
+        and(
+          eq(internalEconomicsPolicyVersions.id, id),
+          eq(internalEconomicsPolicyVersions.fundId, opts.fundId)
+        )
+      )
+      .limit(1);
+
+    if (rows.length === 0) {
+      throw new FundScopeError(opts.ref);
+    }
+    return;
+  }
+
+  if (opts.ref.kind === 'lp_economics_run') {
+    const rows = await opts.db
+      .select({ id: internalLpEconomicsRuns.id })
+      .from(internalLpEconomicsRuns)
+      .where(
+        and(eq(internalLpEconomicsRuns.id, id), eq(internalLpEconomicsRuns.fundId, opts.fundId))
       )
       .limit(1);
 

--- a/server/routes/financial-facts.ts
+++ b/server/routes/financial-facts.ts
@@ -7,6 +7,7 @@ import {
   FINANCIAL_FACTS_POLICY_VERSION,
   FINANCIAL_FACTS_POLICY_VERSION_1_1_0,
   FINANCIAL_FACTS_POLICY_VERSION_1_2_0,
+  FINANCIAL_FACTS_POLICY_VERSION_1_3_0,
   PersistedFinancialFactsSnapshotV1Schema,
 } from '@shared/contracts/financial-facts-snapshot-v1.contract';
 import { toNumber } from '@shared/number';
@@ -93,7 +94,8 @@ function snapshotResponse(row: FinancialFactsSnapshot) {
   return PersistedFinancialFactsSnapshotV1Schema.parse({
     ...persisted,
     ...(row.policyVersion === FINANCIAL_FACTS_POLICY_VERSION_1_1_0 ||
-    row.policyVersion === FINANCIAL_FACTS_POLICY_VERSION_1_2_0
+    row.policyVersion === FINANCIAL_FACTS_POLICY_VERSION_1_2_0 ||
+    row.policyVersion === FINANCIAL_FACTS_POLICY_VERSION_1_3_0
       ? { payloadSchemaId: row.payloadSchemaId }
       : { payloadSchemaId: undefined }),
   });

--- a/server/services/current-forecast-v2-service.ts
+++ b/server/services/current-forecast-v2-service.ts
@@ -115,7 +115,8 @@ function factsSnapshotFromRow(row: FinancialFactsSnapshot): FactsWithId {
   const snapshot = PersistedFinancialFactsSnapshotV1Schema.parse({
     policyVersion: row.policyVersion,
     ...(row.policyVersion === 'financial-facts-policy/1.1.0' ||
-    row.policyVersion === 'financial-facts-policy/1.2.0'
+    row.policyVersion === 'financial-facts-policy/1.2.0' ||
+    row.policyVersion === 'financial-facts-policy/1.3.0'
       ? { payloadSchemaId: row.payloadSchemaId }
       : {}),
     fundId: row.fundId,

--- a/server/services/financial-facts-snapshot-service.ts
+++ b/server/services/financial-facts-snapshot-service.ts
@@ -4,12 +4,11 @@ import { db } from '../db';
 import { assertOwnedByFund, type FundScopedOwnershipDatabase } from '../lib/fund-scoped-ownership';
 import { replayIdempotentCommandIfPresent, runIdempotentCommand } from '../lib/idempotent-command';
 import {
-  FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID,
-  FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID_3,
+  FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID_4,
   FINANCIAL_FACTS_POLICY_VERSION,
   FinancialFactsPayloadV1Schema,
   FinancialFactsPayloadV2Schema,
-  FinancialFactsPayloadV3Schema,
+  FinancialFactsPayloadV4Schema,
   PersistedFinancialFactsSnapshotV1Schema,
   VolatileStrippedFundCompanyActualsFactsResponseSchema,
   buildSelectionSetHash,
@@ -30,7 +29,6 @@ import {
   type FinancialFactsConsumerKey,
 } from '../../shared/contracts/financial-facts-consumer-policies';
 import { Decimal } from '../../shared/lib/decimal-config';
-import { canonicalSha256 } from '../../shared/lib/canonical-hash';
 import { toFixedDecimalString } from '../../shared/lib/decimal-string';
 import { financialFactsSnapshots } from '../../shared/schema/financial-facts-snapshots';
 import {
@@ -1134,38 +1132,6 @@ async function readDerivedValuationRefs(params: {
   }));
 }
 
-function computeSnapshotInputHash(input: Parameters<typeof buildSnapshotInputHash>[0]): string {
-  try {
-    return buildSnapshotInputHash(input);
-  } catch (error) {
-    if (
-      !(error instanceof Error) ||
-      error.message !== 'Scientific notation is not allowed in decimal-string hash inputs.'
-    ) {
-      throw error;
-    }
-
-    // Wave A's unanchored scientific-notation guard also matches SHA-256
-    // substrings such as the policy 1.0.0 empty-selection hash (`be150...`).
-    // The payload has already passed its decimal-string schemas, so retain the
-    // contract's exact canonical preimage while leaving the protected helper
-    // unchanged in this service-only slice.
-    return canonicalSha256({
-      fundId: input.fundId,
-      vehicleIds: [...input.vehicleIds].sort((left, right) => left - right),
-      asOfDate: input.asOfDate,
-      knowledgeCutoff: input.knowledgeCutoff,
-      policyVersion: input.policyVersion,
-      selectionSetHash: input.selectionSetHash,
-      payloadSchemaId:
-        'payloadSchemaId' in input && input.payloadSchemaId !== undefined
-          ? input.payloadSchemaId
-          : FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID,
-      payload: input.payload,
-    });
-  }
-}
-
 function snapshotFromRow(row: SnapshotRow): PersistedFinancialFactsSnapshotV1 {
   const persisted = {
     policyVersion: row.policyVersion,
@@ -1972,17 +1938,17 @@ async function buildFinancialFactsSnapshotInTransaction(params: {
     consumerEvaluations: lineage.consumerEvaluations,
   });
   const { consumerEvaluations } = payloadV2;
-  const payload = FinancialFactsPayloadV3Schema.parse({
+  const payload = FinancialFactsPayloadV4Schema.parse({
     ...payloadV2.payload,
     openingAccountingState,
   });
-  const snapshotInputHash = computeSnapshotInputHash({
+  const snapshotInputHash = buildSnapshotInputHash({
     fundId: input.fundId,
     vehicleIds,
     asOfDate: input.asOfDate,
     knowledgeCutoff,
     policyVersion: FINANCIAL_FACTS_POLICY_VERSION,
-    payloadSchemaId: FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID_3,
+    payloadSchemaId: FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID_4,
     selectionSetHash,
     payload,
   });
@@ -2000,7 +1966,7 @@ async function buildFinancialFactsSnapshotInTransaction(params: {
         .values({
           fundId: input.fundId,
           policyVersion: FINANCIAL_FACTS_POLICY_VERSION,
-          payloadSchemaId: FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID_3,
+          payloadSchemaId: FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID_4,
           asOfDate: input.asOfDate,
           knowledgeCutoff: now,
           vehicleScope: 'fund_all',

--- a/server/services/financial-facts/opening-accounting-state-artifact.ts
+++ b/server/services/financial-facts/opening-accounting-state-artifact.ts
@@ -1,10 +1,12 @@
 import { createHash } from 'node:crypto';
 
+import { EmbeddedFundAccountingStateSnapshotRefV1_1Schema } from '../../../shared/contracts/financial-facts-snapshot-v1.contract';
 import {
-  FundAccountingStateObservationV1Schema,
-  FundAccountingStateSnapshotRefV1Schema,
-  type FundAccountingStateSnapshotRefV1,
-} from '../../../shared/contracts/internal-economics/fund-accounting-state-observation-v1.contract';
+  FUND_ACCOUNTING_STATE_OBSERVATION_VERSION_1_1_0,
+  FundAccountingStateObservationV1_1Schema,
+  type FundAccountingStateObservationV1_1,
+  type FundAccountingStateSnapshotRefV1_1,
+} from '../../../shared/contracts/internal-economics/fund-accounting-state-observation-v1.1.contract';
 
 export interface OpeningAccountingStateArtifactRow {
   id: number;
@@ -69,13 +71,31 @@ function compareRfc3339UtcInstants(left: string, right: string): number {
   return 0;
 }
 
+/**
+ * Best-effort extraction of a JSON value's `contractVersion` field, used only
+ * to add version context to the INVALID error below. Never throws; an
+ * unreadable shape simply reports as "unknown".
+ */
+function observedContractVersion(rawObservation: unknown): string {
+  if (
+    typeof rawObservation === 'object' &&
+    rawObservation !== null &&
+    !Array.isArray(rawObservation) &&
+    'contractVersion' in rawObservation
+  ) {
+    const value = (rawObservation as Record<string, unknown>)['contractVersion'];
+    if (typeof value === 'string') return value;
+  }
+  return 'unknown';
+}
+
 export function parseOpeningAccountingStateArtifact(input: {
   row: OpeningAccountingStateArtifactRow | null | undefined;
   fundId: number;
   asOfDate: string;
   knowledgeCutoff: string;
   actorId: number;
-}): FundAccountingStateSnapshotRefV1 {
+}): FundAccountingStateSnapshotRefV1_1 {
   const { row } = input;
   if (row == null || row.fundId !== input.fundId) {
     throw new OpeningAccountingStateArtifactError(
@@ -103,16 +123,30 @@ export function parseOpeningAccountingStateArtifact(input: {
     invalidArtifact('Opening accounting-state artifact digest does not match its stored bytes.');
   }
 
-  let observation: ReturnType<typeof FundAccountingStateObservationV1Schema.parse>;
+  let rawObservation: unknown;
   try {
-    observation = FundAccountingStateObservationV1Schema.parse(
-      JSON.parse(row.payload.toString('utf8'))
-    );
+    rawObservation = JSON.parse(row.payload.toString('utf8'));
   } catch {
+    invalidArtifact('Opening accounting-state artifact bytes are not valid JSON.');
+  }
+
+  // Frozen raw-input boundary (Brief 1, WP-L3 section 7 R10): the v1.1
+  // observation contract's strict input shape derives
+  // lpUnreturnedContributedCapitalUsd rather than accepting it, and rejects
+  // any older (e.g. v1.0.0) artifact outright. A stored v1 artifact failing
+  // this parse is the normal, expected path for pre-migration data, not a
+  // bug -- the historical artifact row itself remains stored and untouched;
+  // the operator must re-attest a v1.1 artifact to resolve opening state for
+  // new snapshots.
+  const parsedObservation = FundAccountingStateObservationV1_1Schema.safeParse(rawObservation);
+  if (!parsedObservation.success) {
     invalidArtifact(
-      'Opening accounting-state artifact bytes do not satisfy the observation contract.'
+      `Opening accounting-state artifact bytes do not satisfy the ${FUND_ACCOUNTING_STATE_OBSERVATION_VERSION_1_1_0} observation contract (observed contractVersion "${observedContractVersion(
+        rawObservation
+      )}"). Re-attest a v1.1 artifact.`
     );
   }
+  const observation: FundAccountingStateObservationV1_1 = parsedObservation.data;
 
   const cutoff = new Date(input.knowledgeCutoff);
   if (
@@ -133,7 +167,13 @@ export function parseOpeningAccountingStateArtifact(input: {
     );
   }
 
-  return FundAccountingStateSnapshotRefV1Schema.parse({
+  // Resolved/persisted embedding boundary (WP-L3 section 7 R10): `observation`
+  // already carries the frozen schema's derived lpUnreturnedContributedCapitalUsd,
+  // so the ref is emitted through Commit A's idempotent adapter rather than
+  // the frozen ref schema directly (which would reject the derived field on
+  // a second pass). The adapter re-delegates to the same frozen schema and
+  // requires the derived value to match its own recomputation byte-for-byte.
+  return EmbeddedFundAccountingStateSnapshotRefV1_1Schema.parse({
     sourceArtifactId: row.id,
     sourceArtifactSha256: row.payloadSha256,
     sourceArtifactCreatedAt: row.createdAt.toISOString(),

--- a/server/services/internal-economics/capital-envelope-service.ts
+++ b/server/services/internal-economics/capital-envelope-service.ts
@@ -1,0 +1,292 @@
+/**
+ * Capital envelope service (Task 16.3 WP-L3 Phase B).
+ *
+ * Creates immutable, versioned `internal_capital_envelope_versions` rows
+ * (Brief 3's operator-attested legal capital envelope). Every create call is
+ * idempotency-key replay-aware (G16 fail-closed lesson: replay check runs
+ * before any DB read) and version allocation is serialized per fund via a
+ * `pg_advisory_xact_lock` acquired only on the non-replay path, immediately
+ * before version-number resolution and INSERT (P-D11). Corrections are
+ * modeled as new versions chained via `parent_envelope_version_id`; rows are
+ * never updated (DB-enforced by migration 0045's trigger).
+ *
+ * Governing plan: docs/superpowers/plans/
+ * 2026-07-31-task163-wp-l3-service-persistence-plan.md (section 2 G4/G16,
+ * section 3 P-D6/P-D11, section 5, section 11 T-B1/T-B5).
+ *
+ * @module server/services/internal-economics/capital-envelope-service
+ */
+
+import { and, desc, eq, sql } from 'drizzle-orm';
+
+import { db } from '../../db';
+import {
+  assertOwnedByFund,
+  FundScopeError,
+  type FundScopedOwnershipDatabase,
+} from '../../lib/fund-scoped-ownership';
+import {
+  replayIdempotentCommandIfPresent,
+  runIdempotentCommand,
+} from '../../lib/idempotent-command';
+import {
+  buildCapitalEnvelopeHashPreimageV1,
+  CAPITAL_ENVELOPE_CONTRACT_VERSION,
+  CapitalEnvelopeCreateRequestV1Schema,
+  type CapitalEnvelopeCreateRequestV1,
+} from '../../../shared/contracts/internal-economics/capital-envelope-v1.contract';
+import { canonicalSha256 } from '../../../shared/lib/canonical-hash';
+import {
+  internalCapitalEnvelopeVersions,
+  type InternalCapitalEnvelopeVersionRow,
+} from '../../../shared/schema/internal-economics';
+import { vehicles } from '../../../shared/schema/vehicles';
+
+type CapitalEnvelopeDatabase = typeof db;
+
+export class CapitalEnvelopeServiceError extends Error {
+  readonly statusCode: number;
+
+  constructor(
+    readonly status: number,
+    readonly code: string,
+    message: string,
+    readonly details?: Readonly<Record<string, unknown>>
+  ) {
+    super(message);
+    this.name = 'CapitalEnvelopeServiceError';
+    this.statusCode = status;
+  }
+}
+
+export interface CreateCapitalEnvelopeVersionOptions {
+  readonly fundId: number;
+  readonly actorId: number;
+  readonly idempotencyKey: string;
+  readonly request: CapitalEnvelopeCreateRequestV1;
+  /** Test-injection seam; defaults to the shared app database (repo idiom). */
+  readonly database?: CapitalEnvelopeDatabase;
+}
+
+/** G4 namespace convention, entity-scoped per P-D11 so envelope and policy
+ * creation for the same fund never unnecessarily serialize each other. */
+function envelopeLockKey(fundId: number): string {
+  return `internal-economics:envelope:${fundId}`;
+}
+
+/**
+ * Re-validates the request against Brief 3's schema (arithmetic invariants
+ * live in `enforceCommitmentInvariants`). Pure and side-effect-free, so
+ * running it before the idempotent-replay check never risks a premature DB
+ * read (G16 concerns mutable-state reads, not input validation).
+ */
+function parseCapitalEnvelopeCreateRequest(
+  request: CapitalEnvelopeCreateRequestV1
+): CapitalEnvelopeCreateRequestV1 {
+  const parsed = CapitalEnvelopeCreateRequestV1Schema.safeParse(request);
+  if (parsed.success) return parsed.data;
+
+  const code = parsed.error.issues[0]?.message ?? 'ENVELOPE_REQUEST_INVALID';
+  throw new CapitalEnvelopeServiceError(
+    422,
+    code,
+    `Capital envelope creation request failed Brief 3 invariant validation: ${code}.`,
+    { issues: parsed.error.issues }
+  );
+}
+
+/** Client-authoritative fields hashed for idempotency-key replay detection
+ * (distinct from `envelope_hash`, the permanent legal-content identity). */
+function buildIdempotencyRequestRecord(
+  fundId: number,
+  request: CapitalEnvelopeCreateRequestV1
+): Record<string, unknown> {
+  return {
+    fundId,
+    contractVersion: CAPITAL_ENVELOPE_CONTRACT_VERSION,
+    mainFundVehicleId: request.mainFundVehicleId,
+    lpCommitmentUsd: request.lpCommitmentUsd,
+    gpCommitmentUsd: request.gpCommitmentUsd,
+    totalCommitmentUsd: request.totalCommitmentUsd,
+    currency: request.currency,
+    effectiveAt: request.effectiveAt,
+    sourceArtifactId: request.sourceArtifactId,
+    sourceConfigId: request.sourceConfigId,
+    sourceConfigVersion: request.sourceConfigVersion,
+    sourceConfigHash: request.sourceConfigHash,
+    attestedBy: request.attestedBy,
+    attestedAt: request.attestedAt,
+  };
+}
+
+async function loadExistingByIdempotencyKey(
+  database: CapitalEnvelopeDatabase,
+  fundId: number,
+  idempotencyKey: string
+): Promise<{ row: InternalCapitalEnvelopeVersionRow; requestHash: string } | null> {
+  const [existingRow] = await database
+    .select()
+    .from(internalCapitalEnvelopeVersions)
+    .where(
+      and(
+        eq(internalCapitalEnvelopeVersions.fundId, fundId),
+        eq(internalCapitalEnvelopeVersions.idempotencyKey, idempotencyKey)
+      )
+    )
+    .limit(1);
+  return existingRow ? { row: existingRow, requestHash: existingRow.requestHash } : null;
+}
+
+/** DB-side Brief 3 checks (the contract schema already enforces the
+ * arithmetic invariants): the pinned vehicle must exist, be fund-scoped, and
+ * be the fund's `main_fund`-typed vehicle. Refuses 422, nothing persisted. */
+async function assertMainFundVehicle(params: {
+  readonly database: CapitalEnvelopeDatabase;
+  readonly fundId: number;
+  readonly mainFundVehicleId: number;
+}): Promise<void> {
+  try {
+    await assertOwnedByFund({
+      db: params.database as unknown as FundScopedOwnershipDatabase,
+      fundId: params.fundId,
+      ref: { kind: 'vehicle', id: params.mainFundVehicleId },
+    });
+  } catch (error) {
+    if (error instanceof FundScopeError) {
+      throw new CapitalEnvelopeServiceError(
+        422,
+        'ENVELOPE_VEHICLE_NOT_IN_FUND',
+        `Vehicle ${params.mainFundVehicleId} is not owned by fund ${params.fundId}.`,
+        { mainFundVehicleId: params.mainFundVehicleId, fundId: params.fundId }
+      );
+    }
+    throw error;
+  }
+
+  const [vehicleRow] = await params.database
+    .select({ vehicleType: vehicles.vehicleType })
+    .from(vehicles)
+    .where(and(eq(vehicles.id, params.mainFundVehicleId), eq(vehicles.fundId, params.fundId)))
+    .limit(1);
+
+  if (vehicleRow === undefined || vehicleRow.vehicleType !== 'main_fund') {
+    throw new CapitalEnvelopeServiceError(
+      422,
+      'ENVELOPE_VEHICLE_NOT_MAIN_FUND',
+      `Vehicle ${params.mainFundVehicleId} is not the fund's main_fund vehicle.`,
+      { mainFundVehicleId: params.mainFundVehicleId, fundId: params.fundId }
+    );
+  }
+}
+
+/** MAX(version) for this fund, read under the P-D11 advisory lock. */
+async function loadLatestEnvelopeVersion(
+  database: CapitalEnvelopeDatabase,
+  fundId: number
+): Promise<{ readonly id: number; readonly version: number } | null> {
+  const rows = await database
+    .select({
+      id: internalCapitalEnvelopeVersions.id,
+      version: internalCapitalEnvelopeVersions.version,
+    })
+    .from(internalCapitalEnvelopeVersions)
+    .where(eq(internalCapitalEnvelopeVersions.fundId, fundId))
+    .orderBy(desc(internalCapitalEnvelopeVersions.version))
+    .limit(1);
+  const [latest] = rows;
+  return latest ?? null;
+}
+
+/**
+ * Creates a new immutable capital envelope version for a fund (Brief 3).
+ *
+ * Sequencing (P-D11, G16): (1) idempotent replay check first, before any
+ * lock or other read; (2) on the non-replay path, DB-side Brief 3 checks
+ * (vehicle exists, fund-scoped, main_fund typed); (3) advisory lock,
+ * immediately before version-number resolution and INSERT; (4) version =
+ * MAX(version for this fund) + 1 (or 1 if none), with the prior latest
+ * version's id as `parentEnvelopeVersionId` (null for the first version) —
+ * corrections are always chained to the fund's current latest version.
+ */
+export async function createCapitalEnvelopeVersion(
+  opts: CreateCapitalEnvelopeVersionOptions
+): Promise<InternalCapitalEnvelopeVersionRow> {
+  const parsedRequest = parseCapitalEnvelopeCreateRequest(opts.request);
+  const database = opts.database ?? db;
+  const idempotencyRequest = buildIdempotencyRequestRecord(opts.fundId, parsedRequest);
+
+  const replay = await replayIdempotentCommandIfPresent<InternalCapitalEnvelopeVersionRow>({
+    db: database,
+    fundId: opts.fundId,
+    idempotencyKey: opts.idempotencyKey,
+    contractVersion: CAPITAL_ENVELOPE_CONTRACT_VERSION,
+    request: idempotencyRequest,
+    loadExisting: () => loadExistingByIdempotencyKey(database, opts.fundId, opts.idempotencyKey),
+  });
+  if (replay !== null) return replay.row;
+
+  return database.transaction(async (tx) => {
+    const transactionDb = tx as unknown as CapitalEnvelopeDatabase;
+
+    await assertMainFundVehicle({
+      database: transactionDb,
+      fundId: opts.fundId,
+      mainFundVehicleId: parsedRequest.mainFundVehicleId,
+    });
+
+    await transactionDb.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtext(${envelopeLockKey(opts.fundId)}))`
+    );
+
+    const latest = await loadLatestEnvelopeVersion(transactionDb, opts.fundId);
+    const version = latest === null ? 1 : latest.version + 1;
+    const parentEnvelopeVersionId = latest === null ? null : latest.id;
+    const envelopeHash = canonicalSha256(
+      buildCapitalEnvelopeHashPreimageV1({ fundId: opts.fundId, request: parsedRequest })
+    );
+
+    const result = await runIdempotentCommand<InternalCapitalEnvelopeVersionRow>({
+      db: transactionDb,
+      fundId: opts.fundId,
+      idempotencyKey: opts.idempotencyKey,
+      contractVersion: CAPITAL_ENVELOPE_CONTRACT_VERSION,
+      request: idempotencyRequest,
+      loadExisting: () =>
+        loadExistingByIdempotencyKey(transactionDb, opts.fundId, opts.idempotencyKey),
+      insert: async (requestHash) => {
+        const [inserted] = await transactionDb
+          .insert(internalCapitalEnvelopeVersions)
+          .values({
+            fundId: opts.fundId,
+            version,
+            mainFundVehicleId: parsedRequest.mainFundVehicleId,
+            lpCommitmentUsd: parsedRequest.lpCommitmentUsd,
+            gpCommitmentUsd: parsedRequest.gpCommitmentUsd,
+            totalCommitmentUsd: parsedRequest.totalCommitmentUsd,
+            currency: parsedRequest.currency,
+            effectiveAt: new Date(parsedRequest.effectiveAt),
+            sourceArtifactId: parsedRequest.sourceArtifactId,
+            sourceConfigId: parsedRequest.sourceConfigId,
+            sourceConfigVersion: parsedRequest.sourceConfigVersion,
+            sourceConfigHash: parsedRequest.sourceConfigHash,
+            attestedBy: parsedRequest.attestedBy,
+            attestedAt: new Date(parsedRequest.attestedAt),
+            envelopeHash,
+            parentEnvelopeVersionId,
+            idempotencyKey: opts.idempotencyKey,
+            requestHash,
+          })
+          .onConflictDoNothing({
+            target: [
+              internalCapitalEnvelopeVersions.fundId,
+              internalCapitalEnvelopeVersions.idempotencyKey,
+            ],
+          })
+          .returning();
+        return inserted ?? null;
+      },
+    });
+
+    return result.row;
+  });
+}

--- a/server/services/internal-economics/economics-policy-service.ts
+++ b/server/services/internal-economics/economics-policy-service.ts
@@ -1,0 +1,662 @@
+/**
+ * Economics policy service (Task 16.3 WP-L3 Phase B).
+ *
+ * Creates immutable, versioned `internal_economics_policy_versions` rows
+ * (D3/P-D6). Every create call is idempotency-key replay-aware (G16
+ * fail-closed lesson: replay check runs before any DB read) and version
+ * allocation is serialized per fund via a `pg_advisory_xact_lock` acquired
+ * only on the non-replay path, immediately before version-number resolution
+ * and INSERT (P-D11) -- mirroring `capital-envelope-service.ts`'s proven
+ * structure exactly. Corrections are modeled as new versions chained via
+ * `parent_policy_version_id`; rows are never updated (DB-enforced by
+ * migration 0045's trigger).
+ *
+ * Seed-refusal registry (section 5, scoping-design.md:774-797): the create
+ * path reads the pinned `fundConfigs.config` row (never the request body)
+ * and independently validates that the fund's REAL configured GP economics
+ * are representable by policy schema V1, refusing 422 on the first active
+ * (non-dormant) unsupported feature. Dormant params that pass normalize
+ * into `normalization_warnings`, which participate in `assumptions_hash`
+ * (D4) so two policies differing only in dormant params hash differently.
+ *
+ * Implementation note on check order: the ratified registry documents
+ * FUND_LIFE_GRID_UNREPRESENTABLE (position 7) before FUND_TERM_START_ABSENT
+ * (position 8), but grid representability can only be evaluated by calling
+ * the exported `resolveTerminalPeriodEndV1` helper, which requires a term
+ * start date -- and this module never performs raw date arithmetic of its
+ * own (section 10b). This module therefore validates term-start presence
+ * before invoking that helper. No realistic fixture distinguishes the two
+ * orders (grid-unrepresentability without a term start cannot be evaluated
+ * at all), so this reordering changes no observable behavior.
+ *
+ * The terminal pair is written exclusively via `resolveTerminalPeriodEndV1`
+ * + `persistedTerminalResolutionFromPolicyV1`, and readback runs
+ * `assertPersistedTerminalResolutionMatchesPolicyV1` +
+ * `validatePersistedTerminalResolutionV1` before a row is served (G11).
+ *
+ * Governing plan: docs/superpowers/plans/
+ * 2026-07-31-task163-wp-l3-service-persistence-plan.md (section 2 G7/G9/G11/
+ * G14/G16, section 3 P-D1/P-D2/P-D6/P-D11, section 5, section 10, section 11
+ * T-B2/T-B3/T-B4/T-B5).
+ *
+ * @module server/services/internal-economics/economics-policy-service
+ */
+
+import { and, desc, eq, lt, or, sql, type SQL } from 'drizzle-orm';
+import { z } from 'zod';
+
+import { db } from '../../db';
+import {
+  assertOwnedByFund,
+  FundScopeError,
+  type FundScopedOwnershipDatabase,
+} from '../../lib/fund-scoped-ownership';
+import {
+  replayIdempotentCommandIfPresent,
+  runIdempotentCommand,
+} from '../../lib/idempotent-command';
+import {
+  FundDraftWriteV1Schema,
+  type FundDraftWriteV1,
+} from '../../../shared/contracts/fund-draft-write-v1.contract';
+import {
+  ECONOMICS_POLICY_CONTRACT_VERSION,
+  EconomicsPolicyBodyV1Schema,
+  EconomicsPolicyCreateRequestV1Schema,
+  type EconomicsPolicyCreateRequestV1,
+  type EconomicsPolicyNormalizationWarningV1,
+  type EconomicsPolicySeedRefusalCodeV1,
+} from '../../../shared/contracts/internal-economics/economics-policy-v1.contract';
+import {
+  assertPersistedTerminalResolutionMatchesPolicyV1,
+  persistedTerminalResolutionFromPolicyV1,
+  resolveTerminalPeriodEndV1,
+  TerminalPolicyV1Error,
+  validatePersistedTerminalResolutionV1,
+} from '../../../shared/contracts/internal-economics/terminal-policy-v1.contract';
+import { canonicalSha256 } from '../../../shared/lib/canonical-hash';
+import { fundConfigs } from '../../../shared/schema/fund';
+import {
+  internalEconomicsPolicyVersions,
+  type InternalEconomicsPolicyVersionRow,
+} from '../../../shared/schema/internal-economics';
+
+type EconomicsPolicyDatabase = typeof db;
+
+const DEFAULT_POLICY_LIST_LIMIT = 20;
+const CalendarDateFormatSchema = z.string().date();
+
+export class EconomicsPolicySeedRefusalError extends Error {
+  readonly statusCode: number;
+
+  constructor(
+    readonly status: number,
+    readonly code: EconomicsPolicySeedRefusalCodeV1,
+    message: string,
+    readonly context?: Readonly<Record<string, unknown>>
+  ) {
+    super(message);
+    this.name = 'EconomicsPolicySeedRefusalError';
+    this.statusCode = status;
+  }
+}
+
+export class EconomicsPolicyServiceError extends Error {
+  readonly statusCode: number;
+
+  constructor(
+    readonly status: number,
+    readonly code: string,
+    message: string,
+    readonly details?: Readonly<Record<string, unknown>>
+  ) {
+    super(message);
+    this.name = 'EconomicsPolicyServiceError';
+    this.statusCode = status;
+  }
+}
+
+export interface CreateEconomicsPolicyVersionOptions {
+  readonly fundId: number;
+  readonly actorId: number;
+  readonly idempotencyKey: string;
+  readonly request: EconomicsPolicyCreateRequestV1;
+  /** Test-injection seam; defaults to the shared app database (repo idiom). */
+  readonly database?: EconomicsPolicyDatabase;
+}
+
+export interface PolicyVersionListCursor {
+  readonly createdAt: string | Date;
+  readonly id: number;
+}
+
+/** G4 namespace convention, entity-scoped per P-D11 so envelope and policy
+ * creation for the same fund never unnecessarily serialize each other. */
+function policyLockKey(fundId: number): string {
+  return `internal-economics:policy:${fundId}`;
+}
+
+function isCalendarDateString(value: string | undefined): value is string {
+  return value !== undefined && CalendarDateFormatSchema.safeParse(value).success;
+}
+
+interface EconomicsPolicySeedResolution {
+  readonly warnings: EconomicsPolicyNormalizationWarningV1[];
+}
+
+function normalizationWarning(
+  parameter: string,
+  provenance: 'explicit' | 'defaulted',
+  resolvedValue: string,
+  detail: string
+): EconomicsPolicyNormalizationWarningV1 {
+  return { parameter, provenance, resolvedValue, detail };
+}
+
+function refuseSeed(
+  code: EconomicsPolicySeedRefusalCodeV1,
+  detail: string,
+  context?: Readonly<Record<string, unknown>>
+): never {
+  throw new EconomicsPolicySeedRefusalError(422, code, detail, context);
+}
+
+/**
+ * Registry-order seed-refusal check against the fund's REAL configured GP
+ * economics (never the request body -- see module docstring). Throws
+ * `EconomicsPolicySeedRefusalError` on the first active/unsupported feature;
+ * returns the dormant-parameter normalization warnings otherwise.
+ */
+function resolveEconomicsPolicySeed(config: FundDraftWriteV1): EconomicsPolicySeedResolution {
+  const warnings: EconomicsPolicyNormalizationWarningV1[] = [];
+  const waterfallModel = config.economicsAssumptions?.waterfallModel;
+  const tiers = config.waterfallTiers ?? [];
+  const primaryTier = tiers.find((tier) => (tier.gpSplit ?? 0) > 0) ?? tiers[0];
+
+  // 1. CATCH_UP_UNSUPPORTED -- checked independently of hurdle basis (strict
+  // ruling: an active catch-up refuses even when the hurdle itself is dormant).
+  const catchUpExplicit = waterfallModel !== undefined;
+  const prefCatchUp = catchUpExplicit
+    ? waterfallModel.prefCatchUp
+    : (primaryTier?.catchUp ?? 0) > 0;
+  if (prefCatchUp) {
+    refuseSeed('CATCH_UP_UNSUPPORTED', 'Source config resolves an active GP catch-up.');
+  }
+  warnings.push(
+    normalizationWarning(
+      'prefCatchUp',
+      catchUpExplicit || primaryTier?.catchUp !== undefined ? 'explicit' : 'defaulted',
+      'false',
+      'GP catch-up is dormant (off).'
+    )
+  );
+
+  // 2. CLAWBACK_UNSUPPORTED (G14: the legacy-derivation branch always
+  // resolves clawbackEnabled: true unconditionally, so it can only ever
+  // refuse here -- dormant clawback is reachable only via an explicit
+  // waterfallModel with clawbackEnabled: false).
+  const clawbackEnabled = waterfallModel !== undefined ? waterfallModel.clawbackEnabled : true;
+  if (clawbackEnabled) {
+    refuseSeed(
+      'CLAWBACK_UNSUPPORTED',
+      'Source config resolves active clawback (explicit or defaulted default).'
+    );
+  }
+  warnings.push(
+    normalizationWarning('clawbackEnabled', 'explicit', 'false', 'Clawback is dormant (off).')
+  );
+
+  // 3. ESCROW_UNSUPPORTED
+  const escrowPct = waterfallModel !== undefined ? waterfallModel.escrowPct : 0;
+  if (escrowPct > 0) {
+    refuseSeed('ESCROW_UNSUPPORTED', 'Source config resolves an active escrow percentage.');
+  }
+  warnings.push(
+    normalizationWarning(
+      'escrowPct',
+      waterfallModel !== undefined ? 'explicit' : 'defaulted',
+      '0',
+      'Escrow is dormant (zero).'
+    )
+  );
+
+  // 4. RECYCLING_UNSUPPORTED
+  const recyclingModel = config.economicsAssumptions?.recyclingModel;
+  const recyclingExplicit = recyclingModel !== undefined;
+  const recyclingEnabled = recyclingExplicit
+    ? recyclingModel.enabled
+    : (config.recyclingEnabled ?? false);
+  if (recyclingEnabled) {
+    refuseSeed('RECYCLING_UNSUPPORTED', 'Source config resolves active recycling.');
+  }
+  warnings.push(
+    normalizationWarning(
+      'recyclingEnabled',
+      recyclingExplicit || config.recyclingEnabled !== undefined ? 'explicit' : 'defaulted',
+      'false',
+      'Recycling is dormant (off).'
+    )
+  );
+
+  // 5. HURDLE_BASIS_UNSUPPORTED -- policy schema V1 admits basis 'none' only.
+  const hurdleExplicit = waterfallModel !== undefined;
+  const prefType = hurdleExplicit
+    ? waterfallModel.prefType
+    : primaryTier?.preferredReturn === 0
+      ? 'none'
+      : 'compounded';
+  if (prefType !== 'none') {
+    refuseSeed(
+      'HURDLE_BASIS_UNSUPPORTED',
+      'Source config resolves a pref-bearing hurdle; policy schema V1 supports basis "none" only.'
+    );
+  }
+  warnings.push(
+    normalizationWarning(
+      'hurdleBasis',
+      hurdleExplicit || primaryTier?.preferredReturn !== undefined ? 'explicit' : 'defaulted',
+      'none',
+      'Hurdle basis resolves to none (dormant).'
+    )
+  );
+
+  // 6. FUND_LIFE_ABSENT -- no silent engine-style default (DEFAULT_FUND_LIFE_YEARS
+  // is deliberately not reused here; seed refusal requires a real, resolvable value).
+  const fundLifeYears = config.economicsAssumptions?.timeline?.fundLifeYears ?? config.fundLife;
+  if (fundLifeYears === undefined) {
+    refuseSeed('FUND_LIFE_ABSENT', 'No fund life is resolvable from the source config.');
+  }
+
+  // 8 (checked ahead of 7 -- see module docstring). FUND_TERM_START_ABSENT
+  const termStartDate = config.establishmentDate;
+  if (!isCalendarDateString(termStartDate)) {
+    refuseSeed(
+      'FUND_TERM_START_ABSENT',
+      'No term start date is resolvable from the source config.'
+    );
+  }
+
+  // 7. FUND_LIFE_GRID_UNREPRESENTABLE -- exclusively via the exported helper.
+  try {
+    resolveTerminalPeriodEndV1({ termStartDate, fundLifeYears: String(fundLifeYears) });
+  } catch (error) {
+    if (error instanceof TerminalPolicyV1Error && error.code === 'FUND_LIFE_GRID_UNREPRESENTABLE') {
+      refuseSeed('FUND_LIFE_GRID_UNREPRESENTABLE', error.message);
+    }
+    throw error;
+  }
+
+  // 9. EVERGREEN_STATUS_ABSENT -- missing is never silently treated as false.
+  if (config.isEvergreen === undefined) {
+    refuseSeed('EVERGREEN_STATUS_ABSENT', 'Evergreen status is missing from the source config.');
+  }
+  // 10. EVERGREEN_UNSUPPORTED
+  if (config.isEvergreen) {
+    refuseSeed('EVERGREEN_UNSUPPORTED', 'Source config is evergreen.');
+  }
+  warnings.push(
+    normalizationWarning('isEvergreen', 'explicit', 'false', 'Fund is not evergreen (dormant).')
+  );
+
+  // 11. CREDIT_FACILITY_UNSUPPORTED -- issue-mandated, reserved. No field in
+  // FundDraftWriteV1Schema carries a credit-facility/line-of-credit concept,
+  // so this check is structurally unreachable against any schema-valid
+  // config; it exists so the registry's full code list is wired end to end.
+  const creditFacilityIdentifier = (config as Record<string, unknown>)['creditFacility'];
+  if (creditFacilityIdentifier !== undefined) {
+    refuseSeed(
+      'CREDIT_FACILITY_UNSUPPORTED',
+      'Source config specifies a credit-facility identifier.'
+    );
+  }
+
+  return { warnings };
+}
+
+async function loadFundConfigRow(
+  database: EconomicsPolicyDatabase,
+  fundId: number,
+  sourceConfigId: number
+): Promise<typeof fundConfigs.$inferSelect | undefined> {
+  const [row] = await database
+    .select()
+    .from(fundConfigs)
+    .where(and(eq(fundConfigs.id, sourceConfigId), eq(fundConfigs.fundId, fundId)))
+    .limit(1);
+  return row;
+}
+
+function parseEconomicsPolicyCreateRequest(
+  request: EconomicsPolicyCreateRequestV1
+): EconomicsPolicyCreateRequestV1 {
+  const parsed = EconomicsPolicyCreateRequestV1Schema.safeParse(request);
+  if (parsed.success) return parsed.data;
+
+  throw new EconomicsPolicyServiceError(
+    422,
+    'POLICY_REQUEST_INVALID',
+    'Economics policy creation request failed contract validation.',
+    { issues: parsed.error.issues }
+  );
+}
+
+/** Client-authoritative fields hashed for idempotency-key replay detection. */
+function buildIdempotencyRequestRecord(
+  fundId: number,
+  request: EconomicsPolicyCreateRequestV1
+): Record<string, unknown> {
+  return {
+    fundId,
+    contractVersion: ECONOMICS_POLICY_CONTRACT_VERSION,
+    capitalEnvelopeVersionId: request.capitalEnvelopeVersionId,
+    sourceConfigId: request.sourceConfigId,
+    sourceConfigVersion: request.sourceConfigVersion,
+    body: request.body,
+  };
+}
+
+async function loadExistingPolicyByIdempotencyKey(
+  database: EconomicsPolicyDatabase,
+  fundId: number,
+  idempotencyKey: string
+): Promise<{ row: InternalEconomicsPolicyVersionRow; requestHash: string } | null> {
+  const [existingRow] = await database
+    .select()
+    .from(internalEconomicsPolicyVersions)
+    .where(
+      and(
+        eq(internalEconomicsPolicyVersions.fundId, fundId),
+        eq(internalEconomicsPolicyVersions.idempotencyKey, idempotencyKey)
+      )
+    )
+    .limit(1);
+  return existingRow ? { row: existingRow, requestHash: existingRow.requestHash } : null;
+}
+
+/** MAX(version) for this fund, read under the P-D11 advisory lock. */
+async function loadLatestPolicyVersion(
+  database: EconomicsPolicyDatabase,
+  fundId: number
+): Promise<{ readonly id: number; readonly version: number } | null> {
+  const rows = await database
+    .select({
+      id: internalEconomicsPolicyVersions.id,
+      version: internalEconomicsPolicyVersions.version,
+    })
+    .from(internalEconomicsPolicyVersions)
+    .where(eq(internalEconomicsPolicyVersions.fundId, fundId))
+    .orderBy(desc(internalEconomicsPolicyVersions.version))
+    .limit(1);
+  const [latest] = rows;
+  return latest ?? null;
+}
+
+/** Loads the pinned `fundConfigs` row (id + fund + version all pinned),
+ * parses it as `FundDraftWriteV1` (the sanctioned shape for reading
+ * `config`, matching `lp-economics-run-service.ts`'s own convention). */
+async function loadSourceConfigForSeed(params: {
+  readonly database: EconomicsPolicyDatabase;
+  readonly fundId: number;
+  readonly sourceConfigId: number;
+  readonly sourceConfigVersion: number;
+}): Promise<FundDraftWriteV1> {
+  const row = await loadFundConfigRow(params.database, params.fundId, params.sourceConfigId);
+  if (row === undefined) {
+    throw new EconomicsPolicyServiceError(
+      404,
+      'SOURCE_CONFIG_NOT_FOUND',
+      `fundConfigs row ${params.sourceConfigId} was not found for fund ${params.fundId}.`,
+      { sourceConfigId: params.sourceConfigId, fundId: params.fundId }
+    );
+  }
+  if (row.version !== params.sourceConfigVersion) {
+    throw new EconomicsPolicyServiceError(
+      409,
+      'SOURCE_CONFIG_VERSION_MISMATCH',
+      `fundConfigs row ${params.sourceConfigId} is at version ${row.version}, not the requested ${params.sourceConfigVersion}.`,
+      {
+        sourceConfigId: params.sourceConfigId,
+        actualVersion: row.version,
+        requestedVersion: params.sourceConfigVersion,
+      }
+    );
+  }
+  const parsedConfig = FundDraftWriteV1Schema.safeParse(row.config);
+  if (!parsedConfig.success) {
+    throw new EconomicsPolicyServiceError(
+      422,
+      'SOURCE_CONFIG_MALFORMED',
+      'The source fund config does not parse as a valid draft-write shape.',
+      { sourceConfigId: params.sourceConfigId, issues: parsedConfig.error.issues }
+    );
+  }
+  return parsedConfig.data;
+}
+
+/** Catches the envelope-ownership 404 and rewraps as a 422 create-request
+ * validation failure (mirrors capital-envelope-service.ts's own vehicle
+ * ownership rewrap convention). */
+async function assertEnvelopeOwnedByFund(params: {
+  readonly database: EconomicsPolicyDatabase;
+  readonly fundId: number;
+  readonly capitalEnvelopeVersionId: number;
+}): Promise<void> {
+  try {
+    await assertOwnedByFund({
+      db: params.database as unknown as FundScopedOwnershipDatabase,
+      fundId: params.fundId,
+      ref: { kind: 'capital_envelope_version', id: params.capitalEnvelopeVersionId },
+    });
+  } catch (error) {
+    if (error instanceof FundScopeError) {
+      throw new EconomicsPolicyServiceError(
+        422,
+        'POLICY_CAPITAL_ENVELOPE_NOT_IN_FUND',
+        `Capital envelope version ${params.capitalEnvelopeVersionId} is not owned by fund ${params.fundId}.`,
+        { capitalEnvelopeVersionId: params.capitalEnvelopeVersionId, fundId: params.fundId }
+      );
+    }
+    throw error;
+  }
+}
+
+/**
+ * Creates a new immutable economics policy version for a fund (D3/P-D6).
+ *
+ * Sequencing (P-D11, G16): (1) idempotent replay check first, before any
+ * lock or other read; (2) on the non-replay path, the seed-refusal registry
+ * check against the pinned `fundConfigs.config` row, capital-envelope
+ * ownership, and terminal-pair resolution; (3) advisory lock, immediately
+ * before version-number resolution and INSERT; (4) version = MAX(version for
+ * this fund) + 1 (or 1 if none), with the prior latest version's id as
+ * `parentPolicyVersionId` (null for the first version) -- corrections are
+ * always chained to the fund's current latest version.
+ */
+export async function createEconomicsPolicyVersion(
+  opts: CreateEconomicsPolicyVersionOptions
+): Promise<InternalEconomicsPolicyVersionRow> {
+  const parsedRequest = parseEconomicsPolicyCreateRequest(opts.request);
+  const database = opts.database ?? db;
+  const idempotencyRequest = buildIdempotencyRequestRecord(opts.fundId, parsedRequest);
+
+  const replay = await replayIdempotentCommandIfPresent<InternalEconomicsPolicyVersionRow>({
+    db: database,
+    fundId: opts.fundId,
+    idempotencyKey: opts.idempotencyKey,
+    contractVersion: ECONOMICS_POLICY_CONTRACT_VERSION,
+    request: idempotencyRequest,
+    loadExisting: () =>
+      loadExistingPolicyByIdempotencyKey(database, opts.fundId, opts.idempotencyKey),
+  });
+  if (replay !== null) return replay.row;
+
+  return database.transaction(async (tx) => {
+    const transactionDb = tx as unknown as EconomicsPolicyDatabase;
+
+    const sourceConfig = await loadSourceConfigForSeed({
+      database: transactionDb,
+      fundId: opts.fundId,
+      sourceConfigId: parsedRequest.sourceConfigId,
+      sourceConfigVersion: parsedRequest.sourceConfigVersion,
+    });
+    const seed = resolveEconomicsPolicySeed(sourceConfig);
+
+    await assertEnvelopeOwnedByFund({
+      database: transactionDb,
+      fundId: opts.fundId,
+      capitalEnvelopeVersionId: parsedRequest.capitalEnvelopeVersionId,
+    });
+
+    const resolution = resolveTerminalPeriodEndV1({
+      termStartDate: parsedRequest.body.termStartDate,
+      fundLifeYears: parsedRequest.body.fundLifeYears,
+    });
+    const persistedTerminal = persistedTerminalResolutionFromPolicyV1(resolution);
+    const assumptionsHash = canonicalSha256({
+      policySchemaVersion: ECONOMICS_POLICY_CONTRACT_VERSION,
+      body: parsedRequest.body,
+      normalizationWarnings: seed.warnings,
+    });
+
+    await transactionDb.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtext(${policyLockKey(opts.fundId)}))`
+    );
+
+    const latest = await loadLatestPolicyVersion(transactionDb, opts.fundId);
+    const version = latest === null ? 1 : latest.version + 1;
+    const parentPolicyVersionId = latest === null ? null : latest.id;
+
+    const result = await runIdempotentCommand<InternalEconomicsPolicyVersionRow>({
+      db: transactionDb,
+      fundId: opts.fundId,
+      idempotencyKey: opts.idempotencyKey,
+      contractVersion: ECONOMICS_POLICY_CONTRACT_VERSION,
+      request: idempotencyRequest,
+      loadExisting: () =>
+        loadExistingPolicyByIdempotencyKey(transactionDb, opts.fundId, opts.idempotencyKey),
+      insert: async (requestHash) => {
+        const [inserted] = await transactionDb
+          .insert(internalEconomicsPolicyVersions)
+          .values({
+            fundId: opts.fundId,
+            version,
+            policySchemaVersion: ECONOMICS_POLICY_CONTRACT_VERSION,
+            policyBody: parsedRequest.body,
+            normalizationWarnings: seed.warnings,
+            terminalPeriodEnd: persistedTerminal.terminalPeriodEnd,
+            terminalResolutionMethodologyVersion:
+              persistedTerminal.terminalResolutionMethodologyVersion,
+            capitalEnvelopeVersionId: parsedRequest.capitalEnvelopeVersionId,
+            assumptionsHash,
+            sourceConfigId: parsedRequest.sourceConfigId,
+            sourceConfigVersion: parsedRequest.sourceConfigVersion,
+            parentPolicyVersionId,
+            createdBy: opts.actorId,
+            idempotencyKey: opts.idempotencyKey,
+            requestHash,
+          })
+          .onConflictDoNothing({
+            target: [
+              internalEconomicsPolicyVersions.fundId,
+              internalEconomicsPolicyVersions.idempotencyKey,
+            ],
+          })
+          .returning();
+        return inserted ?? null;
+      },
+    });
+
+    return result.row;
+  });
+}
+
+/**
+ * Readback terminal-pair validation (G11): re-validates the persisted body
+ * shape, then runs `assertPersistedTerminalResolutionMatchesPolicyV1`
+ * (rejects a row whose dedicated terminal columns were tampered with
+ * relative to its own policy body) and `validatePersistedTerminalResolutionV1`
+ * (methodology-version check; the degenerate single-point
+ * `forecastPeriodEnds: [row.terminalPeriodEnd]` trivially satisfies the
+ * horizon/representability checks, which need a real forecast grid this
+ * policy-only readback path does not have).
+ */
+function validatePolicyReadback(row: InternalEconomicsPolicyVersionRow): void {
+  const body = EconomicsPolicyBodyV1Schema.parse(row.policyBody);
+  const persisted = {
+    terminalPeriodEnd: row.terminalPeriodEnd,
+    terminalResolutionMethodologyVersion: row.terminalResolutionMethodologyVersion,
+  };
+  assertPersistedTerminalResolutionMatchesPolicyV1({
+    termStartDate: body.termStartDate,
+    fundLifeYears: body.fundLifeYears,
+    persisted,
+  });
+  validatePersistedTerminalResolutionV1({
+    persisted,
+    forecastPeriodEnds: [row.terminalPeriodEnd],
+  });
+}
+
+/** Fund-scoped fetch by id (G11 readback validators run before the row is
+ * served). Returns null if no row matches the (fundId, id) pair. */
+export async function getPolicyVersion(
+  fundId: number,
+  id: number,
+  database?: EconomicsPolicyDatabase
+): Promise<InternalEconomicsPolicyVersionRow | null> {
+  const activeDb = database ?? db;
+  const [row] = await activeDb
+    .select()
+    .from(internalEconomicsPolicyVersions)
+    .where(
+      and(
+        eq(internalEconomicsPolicyVersions.fundId, fundId),
+        eq(internalEconomicsPolicyVersions.id, id)
+      )
+    )
+    .limit(1);
+  if (row === undefined) return null;
+  validatePolicyReadback(row);
+  return row;
+}
+
+/**
+ * Bounded, fund-scoped history, ordered by createdAt DESC, id DESC, with a
+ * keyset `{createdAt, id}` cursor (`sensitivity-run-service.ts`'s own
+ * idiom). G11 readback validators run on every row before it is served.
+ */
+export async function listPolicyVersions(
+  fundId: number,
+  cursor?: PolicyVersionListCursor,
+  database?: EconomicsPolicyDatabase
+): Promise<InternalEconomicsPolicyVersionRow[]> {
+  const activeDb = database ?? db;
+  const baseWhere = eq(internalEconomicsPolicyVersions.fundId, fundId);
+
+  let whereClause: SQL<unknown> = baseWhere;
+  if (cursor) {
+    const cursorDate =
+      cursor.createdAt instanceof Date ? cursor.createdAt : new Date(cursor.createdAt);
+    const cursorClause = or(
+      lt(internalEconomicsPolicyVersions.createdAt, cursorDate),
+      and(
+        eq(internalEconomicsPolicyVersions.createdAt, cursorDate),
+        lt(internalEconomicsPolicyVersions.id, cursor.id)
+      )
+    ) as SQL<unknown>;
+    whereClause = and(baseWhere, cursorClause) as SQL<unknown>;
+  }
+
+  const rows = await activeDb
+    .select()
+    .from(internalEconomicsPolicyVersions)
+    .where(whereClause)
+    .orderBy(
+      desc(internalEconomicsPolicyVersions.createdAt),
+      desc(internalEconomicsPolicyVersions.id)
+    )
+    .limit(DEFAULT_POLICY_LIST_LIMIT);
+
+  for (const row of rows) validatePolicyReadback(row);
+  return rows;
+}

--- a/server/services/internal-economics/lp-economics-run-service.ts
+++ b/server/services/internal-economics/lp-economics-run-service.ts
@@ -1,0 +1,1736 @@
+/**
+ * lp-economics-run-service.ts
+ *
+ * WP-L3 Phase C: the internal LP economics run service. This module is an
+ * assembler/persister around the frozen `executeCashAssemblyPeriodLoopV1`
+ * seam (G10) — it converts pinned basis rows (policy, envelope, facts,
+ * plan, forecast) into the loop's exact input shape, invokes it exactly
+ * once, and persists the outcome atomically. It never re-implements any
+ * financial calculation and never re-derives loop output values (section 6:
+ * decimal strings pass through verbatim, with the single named exception of
+ * the section 6(c) totals aggregation implemented in this file).
+ *
+ * Atomicity protocol (P-D7, normative source for this file's transaction
+ * shape — implemented in this exact order):
+ *
+ *  1. `pg_advisory_xact_lock(hashtext('internal-economics-run:<fundId>'))`
+ *     (G4 namespace convention).
+ *  2. Early idempotent replay via `replayIdempotentCommandIfPresent` on the
+ *     stable client-authoritative preimage (fundId + contractVersion +
+ *     basis IDs + terminalMode + clock + engineVersion + methodologyVersion
+ *     — P-D8 R1 amendment), before any basis read (G16 fail-closed lesson).
+ *  3. Basis reads by explicit IDs only (ADR-065 item 1: no latest-resolution
+ *     anywhere) with ownership asserts via `fund-scoped-ownership.ts`
+ *     (P-D9). The run-supplied `terminalMode` is validated against the
+ *     pinned policy's terminal mode immediately after the policy read.
+ *  4. Two pre-invocation admission-control guards (period count / total
+ *     event count, D8's synchronous-execution-controls requirement). A
+ *     violation persists a `failed` run row (P-D7 R7 disposition): no
+ *     snapshot, COMMIT, idempotency key consumed.
+ *  5. Section 8's nine eligibility gates, in registry order. A gate hit is
+ *     a COMPLETED run: the D9 `unavailable` result envelope, persisted
+ *     snapshot + run row, commit.
+ *  6. `unfundedEnvelopeRemainingUsd` derivation (P-D7 step 4b).
+ *  7. Assemble `ExecuteCashAssemblyPeriodLoopV1Input` and invoke the frozen
+ *     loop exactly once.
+ *  8. Success: event enrichment + totals assembly (section 6) + reason
+ *     sort/dedupe, persist result snapshot + run row (`completed`), commit.
+ *  9. Typed engine failure: P-D7 step 6's per-class-per-code dispatch table
+ *     (reproduced verbatim below `LOOP_ERROR_DISPATCH_TABLE`).
+ * 10. Unexpected exception: full rollback, nothing persisted, key not
+ *     consumed.
+ *
+ * The whole protocol runs inside a single Drizzle transaction
+ * (`isolationLevel: 'repeatable read'`, `accessMode: 'read write'`),
+ * wrapped in a bounded 3-attempt retry on SQLSTATE 40001/40P01 — the exact
+ * pattern already proven by
+ * `buildFinancialFactsSnapshot` (`server/services/financial-facts-snapshot-service.ts`),
+ * confirmed via 3 independent specialist gate rounds (P-D7 R3/R4). Neither
+ * `server/db.ts` nor `server/db/pg-circuit.ts` provide retry-on-
+ * serialization-failure (P-D7 R4 finding); this bounded loop is the sole
+ * retry mechanism.
+ *
+ * Frozen and untouched by this file: `shared/lib/internal-economics/*`,
+ * both observation contracts, `terminal-policy-v1.contract.ts`,
+ * `event-ordering-v1.contract.ts`, `shared/schema/internal-economics.ts`,
+ * migration 0045, the three internal-economics contract files (Lane B's),
+ * `server/lib/fund-scoped-ownership.ts`,
+ * `financial-facts-snapshot-v1.contract.ts`,
+ * `financial-facts-snapshot-service.ts`,
+ * `opening-accounting-state-artifact.ts`. This file consumes them read-only.
+ *
+ * Governing plan: docs/superpowers/plans/
+ * 2026-07-31-task163-wp-l3-service-persistence-plan.md (P-D7, section 8,
+ * section 11 Phase C).
+ *
+ * @module server/services/internal-economics/lp-economics-run-service
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { and, eq, sql } from 'drizzle-orm';
+
+import { db } from '../../db';
+import {
+  assertOwnedByFund,
+  FundScopeError,
+  type FundScopedOwnershipDatabase,
+} from '../../lib/fund-scoped-ownership';
+import {
+  replayIdempotentCommandIfPresent,
+  runIdempotentCommand,
+} from '../../lib/idempotent-command';
+import { canonicalSha256 } from '../../../shared/lib/canonical-hash';
+import { Decimal } from '../../../shared/lib/decimal-config';
+import { buildEffectiveFeeExpenseBridgeV1 } from '../../../shared/lib/internal-economics/effective-fee-expense-bridge-v1';
+import {
+  CashAssemblyCallSizingV1Error,
+  type CallSizingQuarterNeedInputV1,
+} from '../../../shared/lib/internal-economics/cash-assembly-call-sizing-v1';
+import {
+  CashAssemblyEventStreamInvariantError,
+  CashAssemblyEventStreamV1Error,
+  type FactsCashAssemblyEventV1,
+  type FactsCashAssemblyNavMarkV1,
+  type FactsCashAssemblyPeriodNavV1,
+} from '../../../shared/lib/internal-economics/cash-assembly-event-stream-v1';
+import {
+  CashAssemblyPeriodLoopV1Error,
+  executeCashAssemblyPeriodLoopV1,
+  type CashAssemblyWaterfallEventV1,
+  type ExecuteCashAssemblyPeriodLoopV1Input,
+} from '../../../shared/lib/internal-economics/cash-assembly-period-loop-v1';
+import {
+  buildCashAssemblyPeriodGridV1,
+  type CashAssemblyQuarterRowV1,
+} from '../../../shared/lib/internal-economics/cash-assembly-types-v1';
+import { DecimalWaterfallCoreV1Error } from '../../../shared/lib/internal-economics/decimal-waterfall-core-v1';
+import { PresentationRoundingError } from '../../../shared/lib/internal-economics/presentation-rounding-v1';
+import {
+  TerminalPolicyV1Error,
+  assertPersistedTerminalResolutionMatchesPolicyV1,
+  terminalResolutionHashPreimageV1,
+  validatePersistedTerminalResolutionV1,
+  type PersistedTerminalResolutionV1,
+} from '../../../shared/contracts/internal-economics/terminal-policy-v1.contract';
+import {
+  EconomicsPolicyBodyV1Schema,
+  type EconomicsPolicyBodyV1,
+} from '../../../shared/contracts/internal-economics/economics-policy-v1.contract';
+import {
+  LP_ECONOMICS_RUN_CONTRACT_VERSION,
+  LpEconomicsResultV1Schema,
+  OPENING_STATE_CONTRACT_V1_INELIGIBLE_DETAIL,
+  OPENING_STATE_INELIGIBLE_FIELDS_V1,
+  buildLpEconomicsEventIdV1,
+  buildLpEconomicsRunIdempotencyPreimageV1,
+  sortAndDedupeLpEconomicsReasonsV1,
+  type LpEconomicsIndicativeReasonV1,
+  type LpEconomicsIrrBasisV1,
+  type LpEconomicsResultV1,
+  type LpEconomicsRunRequestV1,
+  type LpEconomicsRunUnavailabilityReasonV1,
+  type LpEconomicsTotalsV1,
+  type LpEconomicsWaterfallEventV1,
+} from '../../../shared/contracts/internal-economics/lp-economics-run-v1.contract';
+import {
+  PersistedFinancialFactsSnapshotV1Schema,
+  type PersistedFinancialFactsSnapshotV1,
+} from '../../../shared/contracts/financial-facts-snapshot-v1.contract';
+import { FundDraftWriteV1Schema } from '../../../shared/contracts/fund-draft-write-v1.contract';
+import {
+  CurrentForecastV2Schema,
+  type CurrentForecastSeriesPointV1,
+  type CurrentForecastV2,
+} from '../../../shared/contracts/current-forecast-v2.contract';
+import { CurrentPlanVersionV1Schema } from '../../../shared/contracts/current-plan-version-v1.contract';
+import type { FundAccountingStateObservationV1_1 } from '../../../shared/contracts/internal-economics/fund-accounting-state-observation-v1.1.contract';
+import {
+  internalCapitalEnvelopeVersions,
+  internalEconomicsPolicyVersions,
+  internalLpEconomicsRuns,
+  type InternalLpEconomicsRunRow,
+} from '../../../shared/schema/internal-economics';
+import { financialFactsSnapshots } from '../../../shared/schema/financial-facts-snapshots';
+import { currentPlanVersions } from '../../../shared/schema/current-plans';
+import { fundConfigs, fundSnapshots } from '../../../shared/schema/fund';
+
+type RunDatabase = typeof db;
+
+// ---------------------------------------------------------------------------
+// Service constants (P-D7 R5/R6 amendments — firm, not examples).
+// ---------------------------------------------------------------------------
+
+/** The engine identity stamped on every run row and fed to the frozen loop. */
+export const LP_ECONOMICS_RUN_ENGINE_VERSION = 'cash-assembly-period-loop-v1/1.0.0' as const;
+export const LP_ECONOMICS_RUN_METHODOLOGY_VERSION =
+  'cash-assembly-period-loop-methodology/1.0.0' as const;
+/** P-D4: 18 chars, fits the journaled `fund_snapshots.calc_version varchar(20)`. */
+export const LP_ECONOMICS_RESULT_CALC_VERSION = 'lp-economics/1.0.0' as const;
+
+/** P-D7 R5: firm service constant, not an example — pre-invocation guard. */
+export const MAX_CASH_ASSEMBLY_PERIOD_COUNT = 200;
+/** P-D7 R6: firm service constant — counts facts events + NAV marks +
+ * period-NAV observations + forecast series points across the assembled
+ * input. */
+export const MAX_CASH_ASSEMBLY_TOTAL_EVENT_COUNT = 10000;
+
+const RUN_TRANSACTION_MAX_ATTEMPTS = 3;
+const RETRYABLE_TRANSACTION_SQLSTATES = new Set(['40001', '40P01']);
+
+// ---------------------------------------------------------------------------
+// Service error (typed request-validation rejection — distinct from the
+// section 8 unavailability registry per section 5's terminal-mode-mismatch
+// amendment).
+// ---------------------------------------------------------------------------
+
+export type LpEconomicsRunServiceErrorCode =
+  | 'TERMINAL_MODE_MISMATCH'
+  | 'POLICY_VERSION_NOT_FOUND'
+  | 'FACTS_SNAPSHOT_NOT_FOUND'
+  | 'PLAN_VERSION_NOT_FOUND'
+  | 'FORECAST_SNAPSHOT_NOT_FOUND'
+  | 'RUN_NOT_FOUND'
+  | 'RUN_RESULT_SNAPSHOT_MISSING'
+  | 'SOURCE_CONFIG_VERSION_DRIFTED';
+
+export class LpEconomicsRunServiceError extends Error {
+  readonly statusCode: number;
+
+  constructor(
+    readonly status: number,
+    readonly code: LpEconomicsRunServiceErrorCode,
+    message: string,
+    readonly details?: Readonly<Record<string, unknown>>
+  ) {
+    super(message);
+    this.name = 'LpEconomicsRunServiceError';
+    this.statusCode = status;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// P-D7 step 6 (T-C3/T-C2 normative source): the seven-class dispatch table.
+// Every code below is independently re-verified against the live frozen
+// modules (see this module's docstring). `unavailable` = completed run,
+// persisted D9 envelope; `failed` = persisted run row with failure_code/
+// failure_context, no snapshot.
+// ---------------------------------------------------------------------------
+
+type LoopErrorDisposition = 'unavailable' | 'failed';
+
+/**
+ * `CashAssemblyPeriodLoopV1Error`: mixed dispatch. `OPENING_STATE_INELIGIBLE`
+ * -> unavailable (P-D7 R10: a deterministic pinned-basis outcome, not an
+ * engine defect — the service's own pre-invocation gate 5 check makes this
+ * a defensive catch only, on an already-covered code). Every other code ->
+ * failed (defect guards: FACT_AFTER_CUTOVER, PARTIAL_PROJECTED_PERIOD,
+ * SCHEDULE_GRID_MISMATCH, HISTORICAL_RECONCILIATION_MISMATCH,
+ * CORE_ROW_MAPPING_MISMATCH, TERMINAL_RECONCILIATION_FAILED,
+ * MONOTONICITY_VIOLATION, CARRY_PCT_INVALID).
+ */
+const PERIOD_LOOP_UNAVAILABLE_CODES: ReadonlySet<string> = new Set(['OPENING_STATE_INELIGIBLE']);
+
+/**
+ * `TerminalPolicyV1Error`: every code is a registry code -> unavailable.
+ * `NEGATIVE_SOURCE_MONEY`'s raw throw site is proven unreachable on the loop
+ * path (P-D7 R5 note); this table maps it identically as a defensive,
+ * untestable belt-and-braces branch (R5).
+ */
+const TERMINAL_POLICY_UNAVAILABLE_CODES: ReadonlySet<string> = new Set([
+  'TERMINAL_RESOLUTION_METHODOLOGY_UNSUPPORTED',
+  'TERMINAL_RESOLUTION_MISMATCH',
+  'TERMINAL_BEFORE_CUTOVER',
+  'FORECAST_HORIZON_SHORT',
+  'FORECAST_TERMINAL_PERIOD_UNREPRESENTABLE',
+  'NEGATIVE_SOURCE_MONEY',
+]);
+
+/** `CashAssemblyEventStreamV1Error`: all 3 codes are registry codes -> unavailable. */
+const EVENT_STREAM_UNAVAILABLE_CODES: ReadonlySet<string> = new Set([
+  'POST_TERM_ACTIVITY',
+  'NEGATIVE_SOURCE_MONEY',
+  'FORECAST_DEPLOYMENT_CUMULATIVE_DECREASE',
+]);
+
+/**
+ * `CashAssemblyCallSizingV1Error`: mixed dispatch.
+ * `OPENING_CASH_UNAVAILABLE`/`COMMITTED_CAPITAL_EXCEEDED` -> unavailable;
+ * `NEGATIVE_SCHEDULED_AMOUNT`/`NONZERO_FEE_EXPENSE_UNSUPPORTED_V1` -> failed.
+ */
+const CALL_SIZING_UNAVAILABLE_CODES: ReadonlySet<string> = new Set([
+  'OPENING_CASH_UNAVAILABLE',
+  'COMMITTED_CAPITAL_EXCEEDED',
+]);
+
+interface EngineFailureDisposition {
+  readonly disposition: LoopErrorDisposition;
+  readonly errorClass: string;
+  readonly code: string;
+  readonly message: string;
+  readonly context: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * P-D7 step 6's per-class-per-code table, implemented verbatim. Returns
+ * `null` for anything that is not one of the seven frozen error classes —
+ * the caller re-throws in that case (step 10: unexpected exception, full
+ * rollback).
+ */
+function classifyLoopError(error: unknown): EngineFailureDisposition | null {
+  if (error instanceof CashAssemblyPeriodLoopV1Error) {
+    return {
+      disposition: PERIOD_LOOP_UNAVAILABLE_CODES.has(error.code) ? 'unavailable' : 'failed',
+      errorClass: 'CashAssemblyPeriodLoopV1Error',
+      code: error.code,
+      message: error.message,
+      context: error.context,
+    };
+  }
+  if (error instanceof DecimalWaterfallCoreV1Error) {
+    // No registry code on this class -- always failed.
+    return {
+      disposition: 'failed',
+      errorClass: 'DecimalWaterfallCoreV1Error',
+      code: error.code,
+      message: error.message,
+      context: error.context,
+    };
+  }
+  if (error instanceof TerminalPolicyV1Error) {
+    return {
+      disposition: TERMINAL_POLICY_UNAVAILABLE_CODES.has(error.code) ? 'unavailable' : 'failed',
+      errorClass: 'TerminalPolicyV1Error',
+      code: error.code,
+      message: error.message,
+      context: {},
+    };
+  }
+  if (error instanceof CashAssemblyEventStreamV1Error) {
+    return {
+      disposition: EVENT_STREAM_UNAVAILABLE_CODES.has(error.code) ? 'unavailable' : 'failed',
+      errorClass: 'CashAssemblyEventStreamV1Error',
+      code: error.code,
+      message: error.message,
+      context: {},
+    };
+  }
+  if (error instanceof CashAssemblyEventStreamInvariantError) {
+    // Message-only, no code -- always failed.
+    return {
+      disposition: 'failed',
+      errorClass: 'CashAssemblyEventStreamInvariantError',
+      code: 'INVARIANT_VIOLATION',
+      message: error.message,
+      context: {},
+    };
+  }
+  if (error instanceof CashAssemblyCallSizingV1Error) {
+    return {
+      disposition: CALL_SIZING_UNAVAILABLE_CODES.has(error.code) ? 'unavailable' : 'failed',
+      errorClass: 'CashAssemblyCallSizingV1Error',
+      code: error.code,
+      message: error.message,
+      context: (error.context ?? {}) as Readonly<Record<string, unknown>>,
+    };
+  }
+  if (error instanceof PresentationRoundingError) {
+    // D9: "violation at either precision -> failed run, no result".
+    return {
+      disposition: 'failed',
+      errorClass: 'PresentationRoundingError',
+      code: error.code,
+      message: error.message,
+      context: {},
+    };
+  }
+  return null;
+}
+
+/** Maps a loop-error's registry code onto the D9 unavailability reason shape. */
+function unavailabilityReasonFromLoopError(
+  disposition: EngineFailureDisposition
+): LpEconomicsRunUnavailabilityReasonV1 {
+  if (disposition.code === 'OPENING_STATE_INELIGIBLE') {
+    // Defensive mapping only (P-D7 R10): the service's own pre-invocation
+    // gate 5 check makes this loop-seam path unreachable in practice.
+    logStructuredWarning('lp_economics_run_defensive_opening_state_ineligible_loop_hit', {
+      errorClass: disposition.errorClass,
+      code: disposition.code,
+    });
+    const field = disposition.context['field'];
+    const valueUsd = disposition.context['valueUsd'];
+    return {
+      code: 'OPENING_STATE_INELIGIBLE',
+      detail: disposition.message,
+      context: {
+        field: typeof field === 'string' ? field : 'unknown',
+        valueUsd: typeof valueUsd === 'string' ? valueUsd : '0.000000',
+      },
+    };
+  }
+  return {
+    code: disposition.code as LpEconomicsRunUnavailabilityReasonV1['code'],
+    detail: disposition.message,
+  };
+}
+
+function logStructuredWarning(event: string, fields: Readonly<Record<string, unknown>>): void {
+  // for an untestable defensive branch (P-D7 R6 phoenix observability note).
+  console.warn(JSON.stringify({ event, ...fields, module: 'lp-economics-run-service' }));
+}
+
+// ---------------------------------------------------------------------------
+// Transaction plumbing (mirrors financial-facts-snapshot-service.ts exactly
+// — the proven precedent for this atomicity shape, P-D7).
+// ---------------------------------------------------------------------------
+
+function transactionSqlState(error: unknown): string | undefined {
+  const seen = new Set<object>();
+  let current: unknown = error;
+  while (typeof current === 'object' && current !== null && !seen.has(current)) {
+    seen.add(current);
+    const record = current as Record<string, unknown>;
+    if (typeof record['code'] === 'string') return record['code'];
+    current = record['cause'];
+  }
+  return undefined;
+}
+
+async function lockRunGeneration(database: RunDatabase, fundId: number): Promise<void> {
+  await database.execute(
+    sql`SELECT pg_advisory_xact_lock(hashtext(${`internal-economics-run:${fundId}`}))`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Public surface.
+// ---------------------------------------------------------------------------
+
+export interface ExecuteLpEconomicsRunOptions {
+  readonly fundId: number;
+  readonly actorId: number | null;
+  readonly idempotencyKey: string;
+  readonly request: LpEconomicsRunRequestV1;
+  readonly database?: RunDatabase;
+}
+
+export interface LpEconomicsRunReceipt {
+  readonly run: InternalLpEconomicsRunRow;
+  readonly result: LpEconomicsResultV1 | null;
+}
+
+export async function executeLpEconomicsRun(
+  opts: ExecuteLpEconomicsRunOptions
+): Promise<LpEconomicsRunReceipt> {
+  const database = opts.database ?? db;
+
+  for (let attempt = 1; attempt <= RUN_TRANSACTION_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      return await database.transaction(
+        async (transaction) =>
+          executeLpEconomicsRunInTransaction({
+            opts,
+            database: transaction as unknown as RunDatabase,
+          }),
+        { isolationLevel: 'repeatable read', accessMode: 'read write' }
+      );
+    } catch (error) {
+      const retryable = RETRYABLE_TRANSACTION_SQLSTATES.has(transactionSqlState(error) ?? '');
+      if (!retryable || attempt === RUN_TRANSACTION_MAX_ATTEMPTS) throw error;
+    }
+  }
+
+  throw new Error('Internal LP economics run transaction retry bound was exhausted.');
+}
+
+export interface GetRunWithResultOptions {
+  readonly fundId: number;
+  readonly runId: number;
+  readonly database?: RunDatabase;
+}
+
+/** Read surface (section 5's closing paragraph): joins the result snapshot,
+ * validates type/ownership (T-C9). */
+export async function getRunWithResult(
+  opts: GetRunWithResultOptions
+): Promise<LpEconomicsRunReceipt> {
+  const database = opts.database ?? db;
+
+  await assertOwnedByFund({
+    db: database as unknown as FundScopedOwnershipDatabase,
+    fundId: opts.fundId,
+    ref: { kind: 'lp_economics_run', id: opts.runId },
+  });
+
+  const [run] = await database
+    .select()
+    .from(internalLpEconomicsRuns)
+    .where(
+      and(
+        eq(internalLpEconomicsRuns.id, opts.runId),
+        eq(internalLpEconomicsRuns.fundId, opts.fundId)
+      )
+    )
+    .limit(1);
+
+  if (run === undefined) {
+    throw new LpEconomicsRunServiceError(
+      404,
+      'RUN_NOT_FOUND',
+      'The internal LP economics run was not found.'
+    );
+  }
+
+  return buildReceiptFromRunRow(run, database);
+}
+
+// ---------------------------------------------------------------------------
+// Basis row types and readers (P-D7 step 3: explicit IDs only, ownership
+// asserted via fund-scoped-ownership.ts per P-D9).
+// ---------------------------------------------------------------------------
+
+type PolicyRow = typeof internalEconomicsPolicyVersions.$inferSelect;
+type EnvelopeRow = typeof internalCapitalEnvelopeVersions.$inferSelect;
+type FactsRow = typeof financialFactsSnapshots.$inferSelect;
+type PlanRow = typeof currentPlanVersions.$inferSelect;
+type ForecastSnapshotRow = typeof fundSnapshots.$inferSelect;
+type FundConfigRow = typeof fundConfigs.$inferSelect;
+
+interface LoadedBasis {
+  readonly policy: PolicyRow;
+  readonly policyBody: EconomicsPolicyBodyV1;
+  readonly persistedTerminalResolution: PersistedTerminalResolutionV1;
+  readonly envelope: EnvelopeRow;
+  readonly facts: PersistedFinancialFactsSnapshotV1 & { readonly id: number };
+  readonly plan: PlanRow;
+  readonly forecast: CurrentForecastV2;
+}
+
+async function loadPolicyRow(
+  database: RunDatabase,
+  fundId: number,
+  policyVersionId: number
+): Promise<PolicyRow> {
+  await assertOwnedByFund({
+    db: database as unknown as FundScopedOwnershipDatabase,
+    fundId,
+    ref: { kind: 'economics_policy_version', id: policyVersionId },
+  });
+  const [row] = await database
+    .select()
+    .from(internalEconomicsPolicyVersions)
+    .where(
+      and(
+        eq(internalEconomicsPolicyVersions.id, policyVersionId),
+        eq(internalEconomicsPolicyVersions.fundId, fundId)
+      )
+    )
+    .limit(1);
+  if (row === undefined) {
+    throw new LpEconomicsRunServiceError(
+      404,
+      'POLICY_VERSION_NOT_FOUND',
+      'The pinned economics policy version was not found.'
+    );
+  }
+  return row;
+}
+
+async function loadEnvelopeRow(
+  database: RunDatabase,
+  fundId: number,
+  envelopeVersionId: number
+): Promise<EnvelopeRow> {
+  await assertOwnedByFund({
+    db: database as unknown as FundScopedOwnershipDatabase,
+    fundId,
+    ref: { kind: 'capital_envelope_version', id: envelopeVersionId },
+  });
+  const [row] = await database
+    .select()
+    .from(internalCapitalEnvelopeVersions)
+    .where(
+      and(
+        eq(internalCapitalEnvelopeVersions.id, envelopeVersionId),
+        eq(internalCapitalEnvelopeVersions.fundId, fundId)
+      )
+    )
+    .limit(1);
+  if (row === undefined) {
+    // The policy's envelope FK is DB-enforced RESTRICT; reaching here without
+    // a row means fund-scoped ownership already failed, but keep a typed
+    // fallback in case a future caller re-scopes this function.
+    throw new FundScopeError({ kind: 'capital_envelope_version', id: envelopeVersionId });
+  }
+  return row;
+}
+
+function parseFactsSnapshotRow(
+  row: FactsRow
+): PersistedFinancialFactsSnapshotV1 & { readonly id: number } {
+  const parsed = PersistedFinancialFactsSnapshotV1Schema.parse({
+    policyVersion: row.policyVersion,
+    payloadSchemaId: row.payloadSchemaId,
+    fundId: row.fundId,
+    asOfDate: row.asOfDate,
+    knowledgeCutoff: row.knowledgeCutoff.toISOString(),
+    vehicleScope: row.vehicleScope,
+    vehicleIds: row.vehicleIds,
+    selectionSetHash: row.selectionSetHash,
+    sourceFactsInputHash: row.sourceFactsInputHash,
+    snapshotInputHash: row.snapshotInputHash,
+    consumerEvaluations: row.consumerEvaluations,
+    payload: row.payload,
+    actorId: row.actorId,
+    createdAt: row.createdAt.toISOString(),
+  });
+  return { ...parsed, id: row.id };
+}
+
+async function loadFactsRow(
+  database: RunDatabase,
+  fundId: number,
+  factsSnapshotId: number
+): Promise<PersistedFinancialFactsSnapshotV1 & { readonly id: number }> {
+  await assertOwnedByFund({
+    db: database as unknown as FundScopedOwnershipDatabase,
+    fundId,
+    ref: { kind: 'facts_snapshot', id: factsSnapshotId },
+  });
+  const [row] = await database
+    .select()
+    .from(financialFactsSnapshots)
+    .where(
+      and(
+        eq(financialFactsSnapshots.id, factsSnapshotId),
+        eq(financialFactsSnapshots.fundId, fundId)
+      )
+    )
+    .limit(1);
+  if (row === undefined) {
+    throw new LpEconomicsRunServiceError(
+      404,
+      'FACTS_SNAPSHOT_NOT_FOUND',
+      'The pinned financial-facts snapshot was not found.'
+    );
+  }
+  return parseFactsSnapshotRow(row);
+}
+
+async function loadPlanRow(
+  database: RunDatabase,
+  fundId: number,
+  planVersionId: number
+): Promise<PlanRow> {
+  await assertOwnedByFund({
+    db: database as unknown as FundScopedOwnershipDatabase,
+    fundId,
+    ref: { kind: 'current_plan_version', id: planVersionId },
+  });
+  const [row] = await database
+    .select()
+    .from(currentPlanVersions)
+    .where(and(eq(currentPlanVersions.id, planVersionId), eq(currentPlanVersions.fundId, fundId)))
+    .limit(1);
+  if (row === undefined) {
+    throw new LpEconomicsRunServiceError(
+      404,
+      'PLAN_VERSION_NOT_FOUND',
+      'The pinned current plan version was not found.'
+    );
+  }
+  return row;
+}
+
+/**
+ * Forecast basis read: the `fund_snapshot` ownership kind is type-blind
+ * (G15), so the type filter is baked directly into the WHERE clause — a
+ * type mismatch is indistinguishable from "not found" for this typed
+ * reference, exactly like every other basis-ID lookup in this file.
+ */
+async function loadForecastRow(
+  database: RunDatabase,
+  fundId: number,
+  forecastSnapshotId: number
+): Promise<{ readonly row: ForecastSnapshotRow; readonly forecast: CurrentForecastV2 }> {
+  await assertOwnedByFund({
+    db: database as unknown as FundScopedOwnershipDatabase,
+    fundId,
+    ref: { kind: 'fund_snapshot', id: forecastSnapshotId },
+  });
+  const [row] = await database
+    .select()
+    .from(fundSnapshots)
+    .where(
+      and(
+        eq(fundSnapshots.id, forecastSnapshotId),
+        eq(fundSnapshots.fundId, fundId),
+        eq(fundSnapshots.type, 'CURRENT_FORECAST_V2')
+      )
+    )
+    .limit(1);
+  if (row === undefined) {
+    throw new LpEconomicsRunServiceError(
+      404,
+      'FORECAST_SNAPSHOT_NOT_FOUND',
+      'The pinned Current Forecast V2 snapshot was not found.'
+    );
+  }
+  return { row, forecast: CurrentForecastV2Schema.parse(row.payload) };
+}
+
+async function loadFundConfigRow(
+  database: RunDatabase,
+  fundId: number,
+  sourceConfigId: number
+): Promise<FundConfigRow | undefined> {
+  const [row] = await database
+    .select()
+    .from(fundConfigs)
+    .where(and(eq(fundConfigs.id, sourceConfigId), eq(fundConfigs.fundId, fundId)))
+    .limit(1);
+  return row;
+}
+
+function planV1FromRow(row: PlanRow) {
+  return CurrentPlanVersionV1Schema.parse({
+    contractVersion: 'current-plan-version-v1',
+    id: String(row.id),
+    fundId: row.fundId,
+    version: row.version,
+    sourceConfigId: row.sourceConfigId,
+    sourceConfigVersion: row.sourceConfigVersion,
+    sourceFactsSnapshotId: String(row.sourceFactsSnapshotId),
+    deployableCapitalUsd: row.deployableCapitalUsd,
+    planTransformationVersion: row.planTransformationVersion,
+    allocations: row.allocations,
+    pacingAssumptions: row.pacingAssumptions,
+    cohortAssumptions: row.cohortAssumptions,
+    reservePolicyVersion: row.reservePolicyVersion,
+    assumptionsHash: row.assumptionsHash,
+    supersedesVersionId: row.supersedesVersionId === null ? null : String(row.supersedesVersionId),
+    supersededByVersionId:
+      row.supersededByVersionId === null ? null : String(row.supersededByVersionId),
+    createdAt: row.createdAt.toISOString(),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// P-D10: opening-state eligibility maps facts payload contract versions to
+// registry reasons. The service reads `openingAccountingState.observation`
+// directly off the already-persisted facts snapshot payload row — it never
+// touches `source_artifacts` and never re-parses raw artifact bytes (P-D10
+// R1 amendment; the producer-boundary purity rule is absolute).
+// ---------------------------------------------------------------------------
+
+type OpeningStateOutcome =
+  | { readonly kind: 'eligible'; readonly observation: FundAccountingStateObservationV1_1 }
+  | { readonly kind: 'absent' }
+  | { readonly kind: 'contract_ineligible' };
+
+function readOpeningStateFromFacts(
+  facts: PersistedFinancialFactsSnapshotV1 & { readonly id: number }
+): OpeningStateOutcome {
+  if (!('openingAccountingState' in facts.payload)) {
+    // Pre-V3 payload: the opening-state concept does not exist yet, treated
+    // identically to a V3 payload with a null ref.
+    return { kind: 'absent' };
+  }
+  if (facts.payload.openingAccountingState === null) {
+    return { kind: 'absent' };
+  }
+  if (facts.policyVersion === 'financial-facts-policy/1.3.0') {
+    // Re-accessed (not hoisted to a pre-narrowing local) so TypeScript
+    // narrows `facts.payload` to the V4 member here: the already-resolved
+    // v1.1 ref (validated by the V4 embedded-ref adapter at parse time).
+    return { kind: 'eligible', observation: facts.payload.openingAccountingState.observation };
+  }
+  // Any other policy version carrying a non-null ref (V3's v1-only ref) is
+  // contract-ineligible (L3-Q6/P-D10 R5): a v1 attested
+  // `lpUnreturnedContributedCapitalUsd` is never trusted by the core path.
+  return { kind: 'contract_ineligible' };
+}
+
+/**
+ * R10: the frozen loop's own fixed-order ineligibility check
+ * (`cash-assembly-period-loop-v1.ts:161-178`), replicated pre-invocation so
+ * gate 5 can persist a completed-`unavailable` outcome instead of ever
+ * invoking the loop on a doomed input. `OPENING_STATE_INELIGIBLE_FIELDS_V1`
+ * (the contract's read-only mirror of the loop's own list) pins the order.
+ */
+function firstNonzeroOpeningBalanceField(
+  observation: FundAccountingStateObservationV1_1
+): {
+  readonly field: (typeof OPENING_STATE_INELIGIBLE_FIELDS_V1)[number];
+  readonly valueUsd: string;
+} | null {
+  for (const field of OPENING_STATE_INELIGIBLE_FIELDS_V1) {
+    const value = observation[field];
+    if (!new Decimal(value).isZero()) {
+      return { field, valueUsd: value };
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Section 8 eligibility gates (registry order). Each gate returns a reason
+// on a hit, or `null` to continue. Gate 5 (opening state) is handled by its
+// own dedicated step in the transaction body because a hit there can come
+// from two independent sources (contract ineligibility vs value
+// ineligibility) and a miss produces the resolved observation the loop
+// needs.
+// ---------------------------------------------------------------------------
+
+/** Gate 1: vehicle roster (G6/R3 amendment — re-checked against the PINNED
+ * facts snapshot roster, never a live `vehicles` read). */
+function gateVehicleRoster(
+  envelope: EnvelopeRow,
+  facts: PersistedFinancialFactsSnapshotV1 & { readonly id: number }
+): LpEconomicsRunUnavailabilityReasonV1 | null {
+  const roster = facts.payload.vehicleRoster;
+  const pinned = roster.find((entry) => entry.vehicleId === envelope.mainFundVehicleId);
+  if (pinned === undefined || pinned.vehicleType !== 'main_fund') {
+    return {
+      code: 'MAIN_FUND_VEHICLE_ABSENT',
+      detail: `Pinned main_fund_vehicle_id ${envelope.mainFundVehicleId} is absent or reclassified on the facts snapshot roster.`,
+    };
+  }
+  if (pinned.currency !== 'USD') {
+    return {
+      code: 'MAIN_FUND_CURRENCY_UNSUPPORTED',
+      detail: `Main fund vehicle currency ${pinned.currency} is not supported.`,
+    };
+  }
+  const otherEntries = roster.filter((entry) => entry.vehicleId !== envelope.mainFundVehicleId);
+  if (otherEntries.length > 0) {
+    // D7: "V1 runs ONLY when the roster contains EXACTLY ONE VEHICLE TOTAL
+    // (the main fund)." Any spv/co_invest roster entry disqualifies the run.
+    return {
+      code: 'MAIN_FUND_SCOPED_FORECAST_UNAVAILABLE',
+      detail: 'The facts snapshot roster carries vehicles beyond the main fund (Brief 4 vNext).',
+    };
+  }
+  // MAIN_FUND_COMMITMENT_ABSENT (D8: "main_fund committedCapital null") is
+  // structurally unreachable via this run service: the envelope's
+  // `total_commitment_usd`/`lp_commitment_usd` columns are migration-0045
+  // NOT NULL with a `total_commitment_usd > 0` CHECK, and this service never
+  // reads the live, mutable `vehicles.committedCapital` field (that would
+  // reintroduce the exact mutable-basis dependency the R3 gate-1 amendment
+  // forbids). No trigger condition exists for this code on this path.
+  return null;
+}
+
+/** Gate 2: config lineage — policy and plan must descend from the same
+ * source config version. */
+function gateConfigLineage(
+  policy: PolicyRow,
+  plan: PlanRow
+): LpEconomicsRunUnavailabilityReasonV1 | null {
+  if (
+    policy.sourceConfigId !== plan.sourceConfigId ||
+    policy.sourceConfigVersion !== plan.sourceConfigVersion
+  ) {
+    return {
+      code: 'CONFIG_LINEAGE_MISMATCH',
+      detail: `Policy config (${policy.sourceConfigId}/${policy.sourceConfigVersion}) and plan config (${plan.sourceConfigId}/${plan.sourceConfigVersion}) diverge.`,
+    };
+  }
+  return null;
+}
+
+/** Gate 3: forecast basis state. */
+function gateForecastBasisState(
+  forecast: CurrentForecastV2
+): LpEconomicsRunUnavailabilityReasonV1 | null {
+  if (forecast.status === 'unavailable') {
+    return { code: 'FORECAST_UNAVAILABLE', detail: 'The pinned forecast is unavailable.' };
+  }
+  if (forecast.status === 'failed') {
+    return { code: 'FORECAST_FAILED', detail: 'The pinned forecast failed.' };
+  }
+  if (forecast.status === 'held') {
+    return {
+      code: 'FORECAST_HELD_UNSUPPORTED',
+      detail: 'The pinned forecast is serving-plane held.',
+    };
+  }
+  return null;
+}
+
+/** Gate 4: facts consumer evaluation for the 'economics' consumer
+ * (EXTERNAL-REVIEW AMENDED / L3-Q7 — missing or duplicate entries fail
+ * closed under the same code). */
+function gateFactsConsumerEvaluation(
+  facts: PersistedFinancialFactsSnapshotV1 & { readonly id: number }
+): LpEconomicsRunUnavailabilityReasonV1 | null {
+  const economicsEvaluations = facts.consumerEvaluations.filter(
+    (evaluation) => evaluation.consumer === 'economics'
+  );
+  if (economicsEvaluations.length !== 1 || economicsEvaluations[0]?.status === 'blocked') {
+    return {
+      code: 'FACTS_ECONOMICS_EVALUATION_BLOCKED',
+      detail: 'The financial-facts snapshot blocks internal LP economics.',
+    };
+  }
+  return null;
+}
+
+/** Gate 6: GP commitment must be zero (D9: structural zeros by refusal). */
+function gateGpCommitment(envelope: EnvelopeRow): LpEconomicsRunUnavailabilityReasonV1 | null {
+  if (!new Decimal(envelope.gpCommitmentUsd).isZero()) {
+    return {
+      code: 'GP_COMMITMENT_UNSUPPORTED',
+      detail: `Envelope GP commitment ${envelope.gpCommitmentUsd} is nonzero.`,
+    };
+  }
+  return null;
+}
+
+/** Gate 7: zero-fee bridge (Brief 2), via the frozen
+ * `buildEffectiveFeeExpenseBridgeV1` helper. */
+function gateZeroFeeBridge(input: {
+  readonly config: unknown;
+  readonly plan: PlanRow;
+  readonly forecast: CurrentForecastV2;
+  readonly envelope: EnvelopeRow;
+}): LpEconomicsRunUnavailabilityReasonV1 | null {
+  const parsedConfig = FundDraftWriteV1Schema.safeParse(input.config);
+  if (!parsedConfig.success) {
+    return {
+      code: 'FORECAST_FEE_BASIS_INCOMPATIBLE',
+      detail: 'The source fund config does not parse as a valid draft-write shape.',
+    };
+  }
+  const bridge = buildEffectiveFeeExpenseBridgeV1({
+    config: parsedConfig.data,
+    currentPlan: planV1FromRow(input.plan),
+    forecast: input.forecast,
+    totalCommitmentUsd: input.envelope.totalCommitmentUsd,
+  });
+  if (!bridge.ok) {
+    return {
+      code: 'FORECAST_FEE_BASIS_INCOMPATIBLE',
+      detail: `Zero-fee bridge incompatible: ${bridge.reasons.join(', ')}`,
+    };
+  }
+  return null;
+}
+
+/** Gate 8: terminal pair readback via the G11 validators (ADR-065 item 8 —
+ * no raw date arithmetic anywhere in this file). `persistedTerminalResolution`
+ * is the raw candidate (unvalidated methodology-version literal) — the
+ * validator itself performs the candidate-schema parse and the literal
+ * check, converting a mismatch into a typed `TerminalPolicyV1Error` this
+ * gate maps to `TERMINAL_RESOLUTION_METHODOLOGY_UNSUPPORTED` rather than an
+ * uncaught crash. */
+function gateTerminalResolution(input: {
+  readonly persistedTerminalResolution: unknown;
+  readonly termStartDate: string;
+  readonly fundLifeYears: string;
+  readonly forecast: CurrentForecastV2;
+  readonly openingCutoverInstant: string;
+}): LpEconomicsRunUnavailabilityReasonV1 | null {
+  try {
+    // Frozen precedence order (this gate's registry code list, methodology
+    // -> mismatch -> cutover -> horizon -> representability): the match
+    // assert re-parses the candidate first (methodology-unsupported surfaces
+    // here too) then compares it against a policy-time recomputation from
+    // the policy body's OWN term anchor inputs (integrity check on the
+    // dedicated columns, never used to compute the value fed to the loop --
+    // that stays `policy.terminalPeriodEnd`/`terminalResolutionMethodologyVersion`
+    // read verbatim, per ADR-065 item 8's "never re-resolve at run time").
+    assertPersistedTerminalResolutionMatchesPolicyV1({
+      termStartDate: input.termStartDate,
+      fundLifeYears: input.fundLifeYears,
+      persisted: input.persistedTerminalResolution,
+    });
+    validatePersistedTerminalResolutionV1({
+      persisted: input.persistedTerminalResolution,
+      forecastPeriodEnds: input.forecast.series.map((point) => point.periodEnd),
+      openingCutoverInstant: input.openingCutoverInstant,
+    });
+  } catch (error) {
+    if (error instanceof TerminalPolicyV1Error) {
+      return {
+        code: error.code as LpEconomicsRunUnavailabilityReasonV1['code'],
+        detail: error.message,
+      };
+    }
+    throw error;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Admission control (P-D7 R5/R6/R7 amendments), evaluated after all nine
+// eligibility gates (section 8) have passed. Period count and the
+// forecast-point term of the event count both measure the ASSEMBLED,
+// terminal-truncated grid (via the frozen module's own exported
+// `buildCashAssemblyPeriodGridV1` filter, computed by the caller) rather
+// than the raw pre-truncation forecast series, so a legitimately small
+// post-truncation workload is never falsely rejected; event count sums the
+// four named categories across that same assembled input.
+// ---------------------------------------------------------------------------
+
+interface AdmissionCounts {
+  readonly periodCount: number;
+  readonly totalEventCount: number;
+}
+
+function countAdmission(input: {
+  readonly periodCount: number;
+  readonly factsEvents: readonly FactsCashAssemblyEventV1[];
+  readonly factsNavMarks: readonly FactsCashAssemblyNavMarkV1[];
+  readonly factsPeriodNav: readonly FactsCashAssemblyPeriodNavV1[];
+}): AdmissionCounts {
+  return {
+    periodCount: input.periodCount,
+    totalEventCount:
+      input.factsEvents.length +
+      input.factsNavMarks.length +
+      input.factsPeriodNav.length +
+      input.periodCount,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Loop-input assembly: converts pinned basis rows into the frozen loop's
+// exact input shape (G10). No re-derivation of financial results anywhere
+// in this section.
+// ---------------------------------------------------------------------------
+
+function buildFactsEventsFromPayload(
+  facts: PersistedFinancialFactsSnapshotV1 & { readonly id: number }
+): FactsCashAssemblyEventV1[] {
+  return facts.payload.cashFlowSeries.series.flatMap((series) =>
+    series.points.map((point): FactsCashAssemblyEventV1 => ({
+      eventId: point.eventId,
+      eventType: series.eventType,
+      effectiveAt: point.effectiveAt,
+      amountUsd: point.amount,
+    }))
+  );
+}
+
+function buildFactsNavMarksFromPayload(
+  facts: PersistedFinancialFactsSnapshotV1 & { readonly id: number }
+): FactsCashAssemblyNavMarkV1[] {
+  return facts.payload.marksSeries.marks.map((mark) => ({
+    markId: mark.markId,
+    effectiveAt: mark.effectiveAt,
+    fairValueUsd: mark.fairValue,
+  }));
+}
+
+function buildFactsPeriodNavFromPayload(
+  facts: PersistedFinancialFactsSnapshotV1 & { readonly id: number }
+): FactsCashAssemblyPeriodNavV1[] {
+  return facts.payload.marksSeries.periodNav.map((entry) => ({
+    periodEnd: entry.periodEnd,
+    navUsd: entry.nav,
+  }));
+}
+
+function compareForecastPointsForAssembly(
+  left: CurrentForecastSeriesPointV1,
+  right: CurrentForecastSeriesPointV1
+): number {
+  return (
+    left.periodEnd.localeCompare(right.periodEnd) ||
+    left.periodStart.localeCompare(right.periodStart) ||
+    left.source.localeCompare(right.source)
+  );
+}
+
+/**
+ * Mirrors the frozen loop's own `buildDeploymentDeltaMap`
+ * (`cash-assembly-period-loop-v1.ts:389-407`) exactly: this is basis-to-
+ * input ASSEMBLY (constructing one of the loop's required inputs from the
+ * pinned forecast basis), not a re-derivation of a financial RESULT — the
+ * loop re-validates this exact match via `assertScheduledDeploymentsMatchForecast`
+ * and throws `SCHEDULE_GRID_MISMATCH` if this service ever drifts from it.
+ * Fees/expenses are fixed at zero (Brief 2 zero-fee bridge; gate 7 already
+ * proved the pinned basis is zero-fee-compatible before this is called).
+ */
+function buildScheduledNeedsFromForecast(
+  forecastSeries: readonly CurrentForecastSeriesPointV1[]
+): CallSizingQuarterNeedInputV1[] {
+  const sorted = [...forecastSeries].sort(compareForecastPointsForAssembly);
+  const needs: CallSizingQuarterNeedInputV1[] = [];
+  let previousCumulativeDeployment = new Decimal(0);
+
+  for (const point of sorted) {
+    const cumulativeDeployment = new Decimal(point.deployedUsd);
+    if (point.source === 'projected') {
+      needs.push({
+        period: {
+          periodStart: point.periodStart,
+          periodEnd: point.periodEnd,
+          source: point.source,
+        },
+        scheduledDeploymentUsd: cumulativeDeployment.minus(previousCumulativeDeployment),
+        scheduledFeeUsd: new Decimal(0),
+        scheduledExpenseUsd: new Decimal(0),
+      });
+    }
+    previousCumulativeDeployment = cumulativeDeployment;
+  }
+  return needs;
+}
+
+function deriveIrrBasis(
+  terminalMode: LoadedBasis['policyBody']['terminalMode']
+): LpEconomicsIrrBasisV1 {
+  // The loop injects the terminal NAV as a synthetic XIRR flow only on the
+  // hold_unrealized path (`cash-assembly-period-loop-v1.ts:956-965`); on
+  // liquidate_at_horizon every flow, including the terminal liquidation, is
+  // an actual distribution event. terminalMode is pinned basis, so this
+  // derivation is purity-preserving, not a re-derivation of a result.
+  return terminalMode === 'hold_unrealized' ? 'cash_plus_terminal_nav' : 'cash_only';
+}
+
+// ---------------------------------------------------------------------------
+// Section 6: event enrichment + totals assembly (the one named exception to
+// the no-arithmetic pass-through rule — Decimal-safe aggregation only).
+// ---------------------------------------------------------------------------
+
+function enrichWaterfallEvents(
+  loopEvents: readonly CashAssemblyWaterfallEventV1[]
+): LpEconomicsWaterfallEventV1[] {
+  return loopEvents.map((event, index): LpEconomicsWaterfallEventV1 => {
+    // The terminal-liquidation allocation, if present, is always the last
+    // element the loop emits (`cash-assembly-period-loop-v1.ts:763,770-773`
+    // appends it after every ordinary core distribution). Position alone is
+    // not sufficient, though: a run with no terminal event still has an
+    // ordinary distribution at the last index, so eventKind is a two-part
+    // discriminant — last position AND the frozen loop's own literal
+    // `:terminal_liquidation` sourceId suffix (`cash-assembly-period-loop-v1.ts:445`)
+    // — never derived by parsing any OTHER part of the opaque sourceId
+    // string (section 6 R3(b); the suffix check is a structural read of a
+    // literal the frozen module itself appends, not string interpretation).
+    const isTerminal =
+      index === loopEvents.length - 1 && event.sourceId.endsWith(':terminal_liquidation');
+    return {
+      ...event,
+      eventSequence: index,
+      eventId: buildLpEconomicsEventIdV1({
+        sourceId: event.sourceId,
+        periodEnd: event.periodEnd,
+        eventSequence: index,
+      }),
+      sourceRefs: [{ sourceId: event.sourceId }],
+      eventKind: isTerminal ? 'terminal_realization' : 'forecast_quarterly_distribution',
+    };
+  });
+}
+
+function sumMoney(values: readonly string[]): string {
+  return values.reduce((total, value) => total.plus(value), new Decimal(0)).toFixed(6);
+}
+
+/**
+ * Section 6(c) three-way split: (i) Decimal-safe summation over QUARTER rows
+ * for flow fields beyond the LP capital/profit split; (ii) Decimal-safe
+ * summation over EVENT rows for the LP-capital-return/profit split
+ * specifically (quarter rows only carry the aggregate `lpDistributionUsd`);
+ * (iii) verbatim terminal-quarter-row pass-through for stock/ratio fields —
+ * never re-derived, never a reimplementation of `calculateGuardedRatios`.
+ */
+function assembleTotals(
+  quarters: readonly CashAssemblyQuarterRowV1[],
+  enrichedEvents: readonly LpEconomicsWaterfallEventV1[]
+): LpEconomicsTotalsV1 {
+  const terminalQuarter = quarters.at(-1);
+  if (terminalQuarter === undefined) {
+    throw new Error('assembleTotals requires at least one quarter row.');
+  }
+  return {
+    lpCapitalCallUsd: sumMoney(quarters.map((quarter) => quarter.lpCapitalCallUsd)),
+    gpCommitmentCallUsd: sumMoney(quarters.map((quarter) => quarter.gpCommitmentCallUsd)),
+    portfolioDeploymentUsd: sumMoney(quarters.map((quarter) => quarter.portfolioDeploymentUsd)),
+    managementFeesUsd: sumMoney(quarters.map((quarter) => quarter.managementFeesUsd)),
+    fundExpensesUsd: sumMoney(quarters.map((quarter) => quarter.fundExpensesUsd)),
+    grossRealizedProceedsUsd: sumMoney(quarters.map((quarter) => quarter.grossRealizedProceedsUsd)),
+    lpCapitalReturnUsd: sumMoney(enrichedEvents.map((event) => event.lpCapitalReturnUsd)),
+    lpProfitUsd: sumMoney(enrichedEvents.map((event) => event.lpProfitUsd)),
+    lpDistributionUsd: sumMoney(quarters.map((quarter) => quarter.lpDistributionUsd)),
+    gpInvestmentDistributionUsd: sumMoney(
+      quarters.map((quarter) => quarter.gpInvestmentDistributionUsd)
+    ),
+    gpCarryDistributedUsd: sumMoney(quarters.map((quarter) => quarter.gpCarryDistributedUsd)),
+    endingCashUsd: terminalQuarter.endingCashUsd,
+    grossNavUsd: terminalQuarter.grossNavUsd,
+    lpNetNavUsd: terminalQuarter.lpNetNavUsd,
+    dpi: terminalQuarter.dpi,
+    rvpi: terminalQuarter.rvpi,
+    tvpi: terminalQuarter.tvpi,
+  };
+}
+
+function buildIndicativeReasons(
+  resultStatusReasons: readonly string[]
+): LpEconomicsIndicativeReasonV1[] {
+  const reasons = resultStatusReasons.map((code) => ({
+    code: code as LpEconomicsIndicativeReasonV1['code'],
+  }));
+  return [...sortAndDedupeLpEconomicsReasonsV1(reasons)];
+}
+
+// ---------------------------------------------------------------------------
+// Persistence (P-D4/P-D5 mapping). Common lineage fields are identical
+// across all three outcomes; only the state-coupled fields differ.
+// ---------------------------------------------------------------------------
+
+interface CommonRunFields {
+  readonly fundId: number;
+  readonly policyVersionId: number;
+  readonly factsSnapshotId: number;
+  readonly planVersionId: number;
+  readonly forecastSnapshotId: number;
+  readonly evaluationClock: Date;
+  readonly terminalMode: LpEconomicsRunRequestV1['terminalMode'];
+  readonly engineVersion: string;
+  readonly methodologyVersion: string;
+  readonly inputHash: string;
+  readonly createdBy: number | null;
+  readonly idempotencyKey: string;
+  readonly preimagePlain: Record<string, unknown>;
+}
+
+/**
+ * `input_hash`: a content-identity hash of the resolved basis-pin set
+ * (request basis IDs plus the envelope ID transitively pinned by policy,
+ * plus the deployed-code engine/methodology identity) — distinct from
+ * `request_hash` (the client-authoritative idempotency preimage, which
+ * intentionally excludes the envelope ID since it is resolved, not
+ * client-supplied). Computable immediately after basis reads complete,
+ * before any gate or admission-control check.
+ */
+function buildInputHash(input: {
+  readonly fundId: number;
+  readonly policyVersionId: number;
+  readonly envelopeVersionId: number;
+  readonly factsSnapshotId: number;
+  readonly planVersionId: number;
+  readonly forecastSnapshotId: number;
+  readonly terminalMode: string;
+  readonly clock: string;
+  readonly engineVersion: string;
+  readonly methodologyVersion: string;
+}): string {
+  return canonicalSha256(input);
+}
+
+async function insertRunRow(
+  database: RunDatabase,
+  common: CommonRunFields,
+  stateFields: {
+    readonly runState: 'completed' | 'failed';
+    readonly resultSnapshotId: number | null;
+    readonly resultSnapshotType: 'INTERNAL_LP_ECONOMICS' | null;
+    readonly resultStatus: 'indicative' | 'unavailable' | null;
+    readonly resultHash: string | null;
+    readonly failureCode: string | null;
+    readonly failureContext: Record<string, unknown> | null;
+  }
+): Promise<InternalLpEconomicsRunRow> {
+  const loadExistingRun = async (): Promise<{
+    row: InternalLpEconomicsRunRow;
+    requestHash: string;
+  } | null> => {
+    const [existing] = await database
+      .select()
+      .from(internalLpEconomicsRuns)
+      .where(
+        and(
+          eq(internalLpEconomicsRuns.fundId, common.fundId),
+          eq(internalLpEconomicsRuns.idempotencyKey, common.idempotencyKey)
+        )
+      )
+      .limit(1);
+    return existing ? { row: existing, requestHash: existing.requestHash } : null;
+  };
+
+  const result = await runIdempotentCommand<InternalLpEconomicsRunRow>({
+    db: database,
+    fundId: common.fundId,
+    idempotencyKey: common.idempotencyKey,
+    contractVersion: LP_ECONOMICS_RUN_CONTRACT_VERSION,
+    request: common.preimagePlain,
+    loadExisting: loadExistingRun,
+    insert: async (requestHash) => {
+      const [inserted] = await database
+        .insert(internalLpEconomicsRuns)
+        .values({
+          fundId: common.fundId,
+          policyVersionId: common.policyVersionId,
+          factsSnapshotId: common.factsSnapshotId,
+          planVersionId: common.planVersionId,
+          forecastSnapshotId: common.forecastSnapshotId,
+          forecastSnapshotType: 'CURRENT_FORECAST_V2',
+          resultSnapshotId: stateFields.resultSnapshotId,
+          resultSnapshotType: stateFields.resultSnapshotType,
+          runState: stateFields.runState,
+          resultStatus: stateFields.resultStatus,
+          failureCode: stateFields.failureCode,
+          failureContext: stateFields.failureContext,
+          evaluationClock: common.evaluationClock,
+          terminalMode: common.terminalMode,
+          engineVersion: common.engineVersion,
+          methodologyVersion: common.methodologyVersion,
+          inputHash: common.inputHash,
+          resultHash: stateFields.resultHash,
+          createdBy: common.createdBy,
+          idempotencyKey: common.idempotencyKey,
+          requestHash,
+        })
+        .onConflictDoNothing({
+          target: [internalLpEconomicsRuns.fundId, internalLpEconomicsRuns.idempotencyKey],
+        })
+        .returning();
+      return inserted ?? null;
+    },
+  });
+  return result.row;
+}
+
+async function insertResultSnapshot(
+  database: RunDatabase,
+  input: {
+    readonly fundId: number;
+    readonly clock: string;
+    readonly payload: LpEconomicsResultV1;
+  }
+): Promise<number> {
+  const [inserted] = await database
+    .insert(fundSnapshots)
+    .values({
+      fundId: input.fundId,
+      type: 'INTERNAL_LP_ECONOMICS',
+      payload: input.payload,
+      state: null,
+      scenarioSetId: null,
+      snapshotTime: new Date(input.clock),
+      calcVersion: LP_ECONOMICS_RESULT_CALC_VERSION,
+      correlationId: randomUUID(),
+    })
+    .returning({ id: fundSnapshots.id });
+  if (inserted === undefined || !Number.isSafeInteger(inserted.id) || inserted.id <= 0) {
+    throw new Error('Internal LP economics result snapshot insert did not return a persisted id.');
+  }
+  return inserted.id;
+}
+
+async function persistFailedRun(
+  database: RunDatabase,
+  common: CommonRunFields,
+  failureCode: string,
+  failureContext: Record<string, unknown>
+): Promise<LpEconomicsRunReceipt> {
+  const run = await insertRunRow(database, common, {
+    runState: 'failed',
+    resultSnapshotId: null,
+    resultSnapshotType: null,
+    resultStatus: null,
+    resultHash: null,
+    failureCode,
+    failureContext,
+  });
+  return { run, result: null };
+}
+
+// `resultHash` (below and in `persistCompletedRun`) hashes the persisted
+// value payload only (value + reasons); it deliberately excludes basis IDs.
+// Basis-identity coverage for the row lives in `common.inputHash` (built by
+// `buildInputHash` from the pinned policy/envelope/facts/plan/forecast IDs
+// + terminalMode + clock + engine/methodology version), a separate column
+// on the same run row (section 4). Together the two columns satisfy section
+// 6's "covers basis, value, provenance, exclusions, and reasons" clause
+// without duplicating basis identity into the value hash.
+async function persistUnavailableRun(
+  database: RunDatabase,
+  common: CommonRunFields,
+  clock: string,
+  reasons: readonly LpEconomicsRunUnavailabilityReasonV1[]
+): Promise<LpEconomicsRunReceipt> {
+  const sortedReasons = sortAndDedupeLpEconomicsReasonsV1(reasons);
+  const payload = LpEconomicsResultV1Schema.parse({
+    waterfallTemplate: 'deal_by_deal',
+    resultStatus: 'unavailable',
+    clock,
+    currency: 'USD',
+    perspective: 'lp_net',
+    precisionMode: 'decimal_native_with_float64_xirr',
+    reasons: sortedReasons,
+  });
+  const resultSnapshotId = await insertResultSnapshot(database, {
+    fundId: common.fundId,
+    clock,
+    payload,
+  });
+  const run = await insertRunRow(database, common, {
+    runState: 'completed',
+    resultSnapshotId,
+    resultSnapshotType: 'INTERNAL_LP_ECONOMICS',
+    resultStatus: 'unavailable',
+    resultHash: canonicalSha256(payload),
+    failureCode: null,
+    failureContext: null,
+  });
+  return { run, result: payload };
+}
+
+async function persistCompletedRun(
+  database: RunDatabase,
+  common: CommonRunFields,
+  clock: string,
+  payload: LpEconomicsResultV1
+): Promise<LpEconomicsRunReceipt> {
+  const resultSnapshotId = await insertResultSnapshot(database, {
+    fundId: common.fundId,
+    clock,
+    payload,
+  });
+  const run = await insertRunRow(database, common, {
+    runState: 'completed',
+    resultSnapshotId,
+    resultSnapshotType: 'INTERNAL_LP_ECONOMICS',
+    resultStatus: 'indicative',
+    resultHash: canonicalSha256(payload),
+    failureCode: null,
+    failureContext: null,
+  });
+  return { run, result: payload };
+}
+
+async function buildReceiptFromRunRow(
+  run: InternalLpEconomicsRunRow,
+  database: RunDatabase
+): Promise<LpEconomicsRunReceipt> {
+  if (run.runState === 'failed' || run.resultSnapshotId === null) {
+    return { run, result: null };
+  }
+  const [snapshotRow] = await database
+    .select()
+    .from(fundSnapshots)
+    .where(
+      and(
+        eq(fundSnapshots.id, run.resultSnapshotId),
+        eq(fundSnapshots.fundId, run.fundId),
+        eq(fundSnapshots.type, 'INTERNAL_LP_ECONOMICS')
+      )
+    )
+    .limit(1);
+  if (snapshotRow === undefined) {
+    throw new LpEconomicsRunServiceError(
+      500,
+      'RUN_RESULT_SNAPSHOT_MISSING',
+      'The run result snapshot could not be read back by (id, fund, type).'
+    );
+  }
+  return { run, result: LpEconomicsResultV1Schema.parse(snapshotRow.payload) };
+}
+
+// ---------------------------------------------------------------------------
+// Main orchestrator: P-D7 steps 1-10, executed once per transaction attempt.
+// ---------------------------------------------------------------------------
+
+async function executeLpEconomicsRunInTransaction(params: {
+  readonly opts: ExecuteLpEconomicsRunOptions;
+  readonly database: RunDatabase;
+}): Promise<LpEconomicsRunReceipt> {
+  const { opts, database } = params;
+  const { fundId, request } = opts;
+
+  // Step 1: fund-scoped advisory lock (G4 namespace convention).
+  await lockRunGeneration(database, fundId);
+
+  // Step 2: early idempotent replay, before ANY basis read (G16 fail-closed
+  // lesson). The preimage already carries fundId + contractVersion at its
+  // top level (P-D8), so it doubles directly as the replay request.
+  const preimage = buildLpEconomicsRunIdempotencyPreimageV1({
+    fundId,
+    request,
+    engineVersion: LP_ECONOMICS_RUN_ENGINE_VERSION,
+    methodologyVersion: LP_ECONOMICS_RUN_METHODOLOGY_VERSION,
+  });
+  const preimagePlain: Record<string, unknown> = { ...preimage };
+
+  const replay = await replayIdempotentCommandIfPresent<InternalLpEconomicsRunRow>({
+    db: database,
+    fundId,
+    idempotencyKey: opts.idempotencyKey,
+    contractVersion: LP_ECONOMICS_RUN_CONTRACT_VERSION,
+    request: preimagePlain,
+    loadExisting: async () => {
+      const [existing] = await database
+        .select()
+        .from(internalLpEconomicsRuns)
+        .where(
+          and(
+            eq(internalLpEconomicsRuns.fundId, fundId),
+            eq(internalLpEconomicsRuns.idempotencyKey, opts.idempotencyKey)
+          )
+        )
+        .limit(1);
+      return existing ? { row: existing, requestHash: existing.requestHash } : null;
+    },
+  });
+  if (replay !== null) {
+    return buildReceiptFromRunRow(replay.row, database);
+  }
+
+  // Step 3: basis reads by explicit IDs only (ADR-065 item 1) with
+  // ownership asserts (P-D9). Terminal-mode match is validated immediately
+  // after the policy read.
+  const policy = await loadPolicyRow(database, fundId, request.policyVersionId);
+  const policyBody = EconomicsPolicyBodyV1Schema.parse(policy.policyBody);
+  if (request.terminalMode !== policyBody.terminalMode) {
+    throw new LpEconomicsRunServiceError(
+      422,
+      'TERMINAL_MODE_MISMATCH',
+      `Request terminalMode "${request.terminalMode}" does not match the pinned policy's terminalMode "${policyBody.terminalMode}".`
+    );
+  }
+  const envelope = await loadEnvelopeRow(database, fundId, policy.capitalEnvelopeVersionId);
+  const facts = await loadFactsRow(database, fundId, request.factsSnapshotId);
+  const plan = await loadPlanRow(database, fundId, request.planVersionId);
+  const { forecast } = await loadForecastRow(database, fundId, request.forecastSnapshotId);
+
+  // Raw candidate (unvalidated methodology-version literal) — gate 8 is the
+  // sole validation point (G11); the branded `PersistedTerminalResolutionV1`
+  // is derived via `terminalResolutionHashPreimageV1` only after gate 8
+  // passes, immediately before loop-input assembly.
+  const persistedTerminalResolutionCandidate: unknown = {
+    terminalPeriodEnd: policy.terminalPeriodEnd,
+    terminalResolutionMethodologyVersion: policy.terminalResolutionMethodologyVersion,
+  };
+
+  const common: CommonRunFields = {
+    fundId,
+    policyVersionId: policy.id,
+    factsSnapshotId: facts.id,
+    planVersionId: plan.id,
+    forecastSnapshotId: request.forecastSnapshotId,
+    evaluationClock: new Date(request.clock),
+    terminalMode: request.terminalMode,
+    engineVersion: LP_ECONOMICS_RUN_ENGINE_VERSION,
+    methodologyVersion: LP_ECONOMICS_RUN_METHODOLOGY_VERSION,
+    inputHash: buildInputHash({
+      fundId,
+      policyVersionId: policy.id,
+      envelopeVersionId: envelope.id,
+      factsSnapshotId: facts.id,
+      planVersionId: plan.id,
+      forecastSnapshotId: request.forecastSnapshotId,
+      terminalMode: request.terminalMode,
+      clock: request.clock,
+      engineVersion: LP_ECONOMICS_RUN_ENGINE_VERSION,
+      methodologyVersion: LP_ECONOMICS_RUN_METHODOLOGY_VERSION,
+    }),
+    createdBy: opts.actorId,
+    idempotencyKey: opts.idempotencyKey,
+    preimagePlain,
+  };
+
+  // Step 4: section 8's nine eligibility gates, in registry order, BEFORE
+  // the admission-control guards below — a basis that is both
+  // gate-ineligible and operationally oversized must resolve as the
+  // ratified completed-`unavailable` gate outcome, never a `failed` guard
+  // rejection (P-D7 step ordering: gates are step 4, guards are folded
+  // into step 5's pre-invocation preparation). A hit is a COMPLETED run
+  // (D9 unavailable envelope).
+  const gate1 = gateVehicleRoster(envelope, facts);
+  if (gate1 !== null) return persistUnavailableRun(database, common, request.clock, [gate1]);
+
+  const gate2 = gateConfigLineage(policy, plan);
+  if (gate2 !== null) return persistUnavailableRun(database, common, request.clock, [gate2]);
+
+  const gate3 = gateForecastBasisState(forecast);
+  if (gate3 !== null) return persistUnavailableRun(database, common, request.clock, [gate3]);
+
+  const gate4 = gateFactsConsumerEvaluation(facts);
+  if (gate4 !== null) return persistUnavailableRun(database, common, request.clock, [gate4]);
+
+  // Gate 5: opening state (P-D10). Distinct from gate 6's envelope check.
+  const openingStateOutcome = readOpeningStateFromFacts(facts);
+  if (openingStateOutcome.kind === 'absent') {
+    return persistUnavailableRun(database, common, request.clock, [
+      { code: 'OPENING_CASH_UNAVAILABLE', detail: 'No authoritative opening cash in facts.' },
+    ]);
+  }
+  if (openingStateOutcome.kind === 'contract_ineligible') {
+    return persistUnavailableRun(database, common, request.clock, [
+      {
+        code: 'OPENING_STATE_CONTRACT_INELIGIBLE',
+        context: { detail: OPENING_STATE_CONTRACT_V1_INELIGIBLE_DETAIL },
+      },
+    ]);
+  }
+  const openingState = openingStateOutcome.observation;
+  const nonzeroField = firstNonzeroOpeningBalanceField(openingState);
+  if (nonzeroField !== null) {
+    return persistUnavailableRun(database, common, request.clock, [
+      {
+        code: 'OPENING_STATE_INELIGIBLE',
+        detail: `${nonzeroField.field} must be zero for the V1 period loop.`,
+        context: { field: nonzeroField.field, valueUsd: nonzeroField.valueUsd },
+      },
+    ]);
+  }
+
+  const gate6 = gateGpCommitment(envelope);
+  if (gate6 !== null) return persistUnavailableRun(database, common, request.clock, [gate6]);
+
+  const fundConfigRow = await loadFundConfigRow(database, fundId, policy.sourceConfigId);
+  // fundConfigs rows are mutable in place (fund-persistence-service.ts's
+  // draft-sync path updates `config` without bumping `version`); a stale
+  // read here would silently break ADR-065 item 1's basis-purity contract
+  // for gate 7. Fail closed on drift, mirroring the version-match check
+  // economics-policy-service.ts already performs at policy-seed time.
+  if (fundConfigRow !== undefined && fundConfigRow.version !== policy.sourceConfigVersion) {
+    throw new LpEconomicsRunServiceError(
+      409,
+      'SOURCE_CONFIG_VERSION_DRIFTED',
+      `fundConfigs row ${policy.sourceConfigId} is at version ${fundConfigRow.version}, but the pinned policy expects version ${policy.sourceConfigVersion}.`
+    );
+  }
+  const gate7 = gateZeroFeeBridge({
+    config: fundConfigRow?.config,
+    plan,
+    forecast,
+    envelope,
+  });
+  if (gate7 !== null) return persistUnavailableRun(database, common, request.clock, [gate7]);
+
+  const gate8 = gateTerminalResolution({
+    persistedTerminalResolution: persistedTerminalResolutionCandidate,
+    termStartDate: policyBody.termStartDate,
+    fundLifeYears: policyBody.fundLifeYears,
+    forecast,
+    openingCutoverInstant: openingState.cutoverInstant,
+  });
+  if (gate8 !== null) return persistUnavailableRun(database, common, request.clock, [gate8]);
+
+  // Gate 8 already proved the candidate's methodology-version literal
+  // matches; this call is now guaranteed not to throw.
+  const persistedTerminalResolution: PersistedTerminalResolutionV1 =
+    terminalResolutionHashPreimageV1(persistedTerminalResolutionCandidate);
+
+  // Step 5: two pre-invocation admission-control guards (P-D7 R5/R6/R7),
+  // now that every gate has passed. Period count measures the ASSEMBLED
+  // grid via the frozen module's own exported filter (never the raw,
+  // pre-terminal-truncation forecast series length), so a legitimately
+  // small post-truncation workload is never falsely rejected. A violation
+  // persists a FAILED run row: no snapshot, key consumed.
+  const factsEvents = buildFactsEventsFromPayload(facts);
+  const factsNavMarks = buildFactsNavMarksFromPayload(facts);
+  const factsPeriodNav = buildFactsPeriodNavFromPayload(facts);
+  const assembledGrid = buildCashAssemblyPeriodGridV1({
+    forecastSeries: forecast.series,
+    persistedTerminalResolution,
+  });
+  const admission = countAdmission({
+    periodCount: assembledGrid.length,
+    factsEvents,
+    factsNavMarks,
+    factsPeriodNav,
+  });
+  if (admission.periodCount > MAX_CASH_ASSEMBLY_PERIOD_COUNT) {
+    return persistFailedRun(database, common, 'CASH_ASSEMBLY_PERIOD_COUNT_EXCEEDED', {
+      bound: MAX_CASH_ASSEMBLY_PERIOD_COUNT,
+      observed: admission.periodCount,
+    });
+  }
+  if (admission.totalEventCount > MAX_CASH_ASSEMBLY_TOTAL_EVENT_COUNT) {
+    return persistFailedRun(database, common, 'CASH_ASSEMBLY_TOTAL_EVENT_COUNT_EXCEEDED', {
+      bound: MAX_CASH_ASSEMBLY_TOTAL_EVENT_COUNT,
+      observed: admission.totalEventCount,
+    });
+  }
+
+  // Step 6 (P-D7 4b): valid only because gate 6 already proved zero GP
+  // commitment.
+  const unfundedEnvelopeRemainingUsd = new Decimal(envelope.lpCommitmentUsd).minus(
+    openingState.cumulativeLpPaidInUsd
+  );
+
+  // Step 7: assemble the frozen loop's exact input shape and invoke it
+  // exactly once.
+  const loopInput: ExecuteCashAssemblyPeriodLoopV1Input = {
+    factsSnapshotId: facts.id,
+    forecastSnapshotId: request.forecastSnapshotId,
+    economicsPolicyVersion: policy.policySchemaVersion,
+    engineVersion: LP_ECONOMICS_RUN_ENGINE_VERSION,
+    methodologyVersion: LP_ECONOMICS_RUN_METHODOLOGY_VERSION,
+    factsEvents,
+    factsNavMarks,
+    factsPeriodNav,
+    openingState,
+    forecastSeries: forecast.series,
+    scheduledNeeds: buildScheduledNeedsFromForecast(forecast.series),
+    cashBufferQuarters: policyBody.cashBufferQuarters,
+    unfundedEnvelopeRemainingUsd,
+    persistedTerminalResolution,
+    terminalMode: request.terminalMode,
+    carryPct: policyBody.carryPct,
+  };
+
+  const loopStartedAtMs = Date.now();
+  let loopResult;
+  try {
+    loopResult = executeCashAssemblyPeriodLoopV1(loopInput);
+  } catch (error) {
+    logStructuredWarning('lp_economics_run_loop_duration_ms', {
+      durationMs: Date.now() - loopStartedAtMs,
+      outcome: 'error',
+    });
+    // Step 9: typed engine failure -> P-D7 step 6's table dispatch.
+    const classified = classifyLoopError(error);
+    if (classified === null) {
+      // Step 10: unexpected exception -> full rollback (rethrow out of the
+      // transaction), nothing persisted, key not consumed.
+      throw error;
+    }
+    if (classified.disposition === 'unavailable') {
+      return persistUnavailableRun(database, common, request.clock, [
+        unavailabilityReasonFromLoopError(classified),
+      ]);
+    }
+    return persistFailedRun(database, common, classified.code, {
+      errorClass: classified.errorClass,
+      message: classified.message,
+      ...classified.context,
+    });
+  }
+  logStructuredWarning('lp_economics_run_loop_duration_ms', {
+    durationMs: Date.now() - loopStartedAtMs,
+    outcome: 'success',
+  });
+
+  // Step 8: success -- event enrichment, totals assembly, reason
+  // sort/dedupe (exactly once), persist result snapshot + run row.
+  const enrichedEvents = enrichWaterfallEvents(loopResult.waterfallEvents);
+  const totals = assembleTotals(loopResult.quarters, enrichedEvents);
+  const reasons = buildIndicativeReasons(loopResult.resultStatusReasons);
+  const resultEnvelope = LpEconomicsResultV1Schema.parse({
+    waterfallTemplate: 'deal_by_deal',
+    resultStatus: 'indicative',
+    clock: request.clock,
+    currency: 'USD',
+    perspective: 'lp_net',
+    precisionMode: 'decimal_native_with_float64_xirr',
+    quarters: loopResult.quarters,
+    waterfallEvents: enrichedEvents,
+    totals,
+    terminalNavBeforeRealizationUsd: loopResult.terminalNavBeforeRealizationUsd,
+    lpNetIrr: loopResult.lpNetIrr,
+    lpNetIrrBasis: deriveIrrBasis(request.terminalMode),
+    lpNetIrrDiagnostic: loopResult.xirrDiagnostic,
+    reasons,
+  });
+
+  return persistCompletedRun(database, common, request.clock, resultEnvelope);
+}

--- a/server/services/reserves/dynamic-reserve-intelligence-service.ts
+++ b/server/services/reserves/dynamic-reserve-intelligence-service.ts
@@ -121,7 +121,8 @@ function snapshotFromRow(row: FinancialFactsSnapshot): PersistedFinancialFactsSn
   return PersistedFinancialFactsSnapshotV1Schema.parse({
     policyVersion: row.policyVersion,
     ...(row.policyVersion === 'financial-facts-policy/1.1.0' ||
-    row.policyVersion === 'financial-facts-policy/1.2.0'
+    row.policyVersion === 'financial-facts-policy/1.2.0' ||
+    row.policyVersion === 'financial-facts-policy/1.3.0'
       ? { payloadSchemaId: row.payloadSchemaId }
       : {}),
     fundId: row.fundId,

--- a/shared/contracts/financial-facts-snapshot-v1.contract.ts
+++ b/shared/contracts/financial-facts-snapshot-v1.contract.ts
@@ -14,19 +14,22 @@ import {
 } from './financial-facts-consumer-policies';
 import { FinancialProvenanceSchema } from './financial-provenance.contract';
 import { FundAccountingStateSnapshotRefV1Schema } from './internal-economics/fund-accounting-state-observation-v1.contract';
+import { FundAccountingStateSnapshotRefV1_1Schema } from './internal-economics/fund-accounting-state-observation-v1.1.contract';
 import { ProvenanceEnvelopeSchema } from './provenance-envelope.contract';
 import { canonicalSha256 } from '../lib/canonical-hash';
-import { canonicalizeDecimalLeaves, MoneyDecimalStringSchema } from '../lib/decimal-string';
+import { MoneyDecimalStringSchema } from '../lib/decimal-string';
 
 export const FINANCIAL_FACTS_POLICY_VERSION_1_0_0 = 'financial-facts-policy/1.0.0' as const;
 export const FINANCIAL_FACTS_POLICY_VERSION_1_0_1 = 'financial-facts-policy/1.0.1' as const;
 export const FINANCIAL_FACTS_POLICY_VERSION_1_1_0 = 'financial-facts-policy/1.1.0' as const;
 export const FINANCIAL_FACTS_POLICY_VERSION_1_2_0 = 'financial-facts-policy/1.2.0' as const;
-export const FINANCIAL_FACTS_POLICY_VERSION = FINANCIAL_FACTS_POLICY_VERSION_1_2_0;
+export const FINANCIAL_FACTS_POLICY_VERSION_1_3_0 = 'financial-facts-policy/1.3.0' as const;
+export const FINANCIAL_FACTS_POLICY_VERSION = FINANCIAL_FACTS_POLICY_VERSION_1_3_0;
 export const FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID_1 = 'financial-facts-payload/1' as const;
 export const FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID_2 = 'financial-facts-payload/2' as const;
 export const FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID_3 = 'financial-facts-payload/3' as const;
-export const FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID = FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID_3;
+export const FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID_4 = 'financial-facts-payload/4' as const;
+export const FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID = FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID_4;
 
 const SelectionIdSchema = z.union([z.number().int().positive(), z.string().min(1)]);
 
@@ -277,10 +280,96 @@ export const FinancialFactsPayloadV3Schema = FinancialFactsPayloadV2Schema.exten
   openingAccountingState: FundAccountingStateSnapshotRefV1Schema.nullable(),
 }).strict();
 
+const EMBEDDED_OPENING_STATE_DERIVED_FIELD = 'lpUnreturnedContributedCapitalUsd' as const;
+
+type FundAccountingStateSnapshotRefV1_1Resolved = z.infer<
+  typeof FundAccountingStateSnapshotRefV1_1Schema
+>;
+
+/**
+ * V4-only idempotent embedded-ref adapter (WP-L3 section 7, R10 amendment).
+ *
+ * The frozen v1.1 observation contract is intentionally asymmetric: its strict
+ * raw input omits `lpUnreturnedContributedCapitalUsd` and its transform derives
+ * that field into the output, so parsing a resolved output a second time is
+ * rejected by the frozen schema. This adapter is the resolved/persisted
+ * embedding boundary ONLY (payload, hash preimage, persisted envelope, and
+ * readback validation). It delegates all authoritative validation and
+ * derivation to the frozen `FundAccountingStateSnapshotRefV1_1Schema`:
+ *
+ * - Raw-shape input (no derived field): parsed once via the frozen schema.
+ * - Already-resolved input (derived field present): the derived field alone is
+ *   stripped to reconstruct the frozen input shape, the frozen schema reparses
+ *   it, and the supplied value must equal the frozen recomputation
+ *   byte-for-byte. A mismatch is rejected, never silently healed.
+ *
+ * Therefore `adapter.parse(adapter.parse(rawRef))` is byte-stable. The producer
+ * must keep applying the frozen observation schema DIRECTLY to source-artifact
+ * bytes; this adapter never parses source-artifact JSON, so a human-supplied
+ * derived field remains invalid at the artifact boundary.
+ */
+export const EmbeddedFundAccountingStateSnapshotRefV1_1Schema = z
+  .unknown()
+  .transform((value, ctx): FundAccountingStateSnapshotRefV1_1Resolved => {
+    const observation =
+      typeof value === 'object' && value !== null && !Array.isArray(value)
+        ? (value as { observation?: unknown }).observation
+        : undefined;
+    const suppliedDerived =
+      typeof observation === 'object' &&
+      observation !== null &&
+      !Array.isArray(observation) &&
+      EMBEDDED_OPENING_STATE_DERIVED_FIELD in observation
+        ? {
+            present: true as const,
+            value: (observation as Record<string, unknown>)[EMBEDDED_OPENING_STATE_DERIVED_FIELD],
+          }
+        : { present: false as const };
+
+    const candidate = suppliedDerived.present
+      ? {
+          ...(value as Record<string, unknown>),
+          observation: Object.fromEntries(
+            Object.entries(observation as Record<string, unknown>).filter(
+              ([key]) => key !== EMBEDDED_OPENING_STATE_DERIVED_FIELD
+            )
+          ),
+        }
+      : value;
+
+    const reparsed = FundAccountingStateSnapshotRefV1_1Schema.safeParse(candidate);
+    if (!reparsed.success) {
+      for (const issue of reparsed.error.issues) {
+        ctx.addIssue(issue);
+      }
+      return z.NEVER;
+    }
+
+    if (
+      suppliedDerived.present &&
+      suppliedDerived.value !== reparsed.data.observation[EMBEDDED_OPENING_STATE_DERIVED_FIELD]
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['observation', EMBEDDED_OPENING_STATE_DERIVED_FIELD],
+        message:
+          'Supplied lpUnreturnedContributedCapitalUsd must equal the frozen v1.1 recomputation byte-for-byte.',
+      });
+      return z.NEVER;
+    }
+
+    return reparsed.data;
+  });
+
+export const FinancialFactsPayloadV4Schema = FinancialFactsPayloadV3Schema.extend({
+  openingAccountingState: EmbeddedFundAccountingStateSnapshotRefV1_1Schema.nullable(),
+}).strict();
+
 export type FinancialFactsPayloadV1_0_0 = z.infer<typeof FinancialFactsPayloadV1_0_0Schema>;
 export type FinancialFactsPayloadV1 = z.infer<typeof FinancialFactsPayloadV1Schema>;
 export type FinancialFactsPayloadV2 = z.infer<typeof FinancialFactsPayloadV2Schema>;
 export type FinancialFactsPayloadV3 = z.infer<typeof FinancialFactsPayloadV3Schema>;
+export type FinancialFactsPayloadV4 = z.infer<typeof FinancialFactsPayloadV4Schema>;
 
 const Sha256Schema = z.string().regex(/^[a-f0-9]{64}$/);
 
@@ -336,6 +425,19 @@ export const FinancialFactsSnapshotInputHashPreimageV3Schema = z
   })
   .strict();
 
+export const FinancialFactsSnapshotInputHashPreimageV4Schema = z
+  .object({
+    fundId: z.number().int().positive(),
+    vehicleIds: z.array(z.number().int().positive()),
+    asOfDate: z.string().date(),
+    knowledgeCutoff: z.string().datetime(),
+    policyVersion: z.literal(FINANCIAL_FACTS_POLICY_VERSION_1_3_0),
+    payloadSchemaId: z.literal(FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID_4),
+    selectionSetHash: Sha256Schema,
+    payload: FinancialFactsPayloadV4Schema,
+  })
+  .strict();
+
 export const PersistedFinancialFactsSnapshotInputHashPreimageSchema = z.discriminatedUnion(
   'policyVersion',
   [
@@ -343,6 +445,7 @@ export const PersistedFinancialFactsSnapshotInputHashPreimageSchema = z.discrimi
     FinancialFactsSnapshotInputHashPreimageSchema,
     FinancialFactsSnapshotInputHashPreimageV2Schema,
     FinancialFactsSnapshotInputHashPreimageV3Schema,
+    FinancialFactsSnapshotInputHashPreimageV4Schema,
   ]
 );
 
@@ -358,15 +461,28 @@ export type FinancialFactsSnapshotInputHashPreimageV2 = z.infer<
 export type FinancialFactsSnapshotInputHashPreimageV3 = z.infer<
   typeof FinancialFactsSnapshotInputHashPreimageV3Schema
 >;
+export type FinancialFactsSnapshotInputHashPreimageV4 = z.infer<
+  typeof FinancialFactsSnapshotInputHashPreimageV4Schema
+>;
 export type PersistedFinancialFactsSnapshotInputHashPreimage = z.infer<
   typeof PersistedFinancialFactsSnapshotInputHashPreimageSchema
 >;
 
+/**
+ * Total for every schema-valid persisted preimage (WP-L3 section 7, R9
+ * amendment): the discriminated preimage/payload Zod schemas are the
+ * validation boundary for decimal strings, so the redundant decimal-leaf scan
+ * (whose unanchored scientific-notation guard also matched ordinary SHA-256
+ * substrings such as `EMPTY_SELECTION_SET_HASH`) is not reapplied here.
+ * Canonical bytes are unchanged: both canonicalizers recursively sort object
+ * keys and preserve array order.
+ */
 export function buildSnapshotInputHash(
   input: PersistedFinancialFactsSnapshotInputHashPreimage
 ): string {
   const parsed = PersistedFinancialFactsSnapshotInputHashPreimageSchema.parse(input);
-  const preimage = canonicalizeDecimalLeaves({
+
+  return canonicalSha256({
     fundId: parsed.fundId,
     vehicleIds: [...parsed.vehicleIds].sort((left, right) => left - right),
     asOfDate: parsed.asOfDate,
@@ -379,8 +495,6 @@ export function buildSnapshotInputHash(
         : FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID_1,
     payload: parsed.payload,
   });
-
-  return canonicalSha256(preimage);
 }
 
 export const FinancialFactsSnapshotV1_0_0Schema = z
@@ -459,17 +573,38 @@ export const FinancialFactsSnapshotV3Schema = z
   })
   .strict();
 
+export const FinancialFactsSnapshotV4Schema = z
+  .object({
+    policyVersion: z.literal(FINANCIAL_FACTS_POLICY_VERSION_1_3_0),
+    payloadSchemaId: z.literal(FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID_4),
+    fundId: z.number().int().positive(),
+    asOfDate: z.string().date(),
+    knowledgeCutoff: z.string().datetime(),
+    vehicleScope: z.literal('fund_all'),
+    vehicleIds: z.array(z.number().int().positive()),
+    selectionSetHash: Sha256Schema,
+    sourceFactsInputHash: Sha256Schema,
+    snapshotInputHash: Sha256Schema,
+    consumerEvaluations: z.array(ConsumerEvaluationV2Schema),
+    payload: FinancialFactsPayloadV4Schema,
+    actorId: z.number().int().positive().nullable(),
+    createdAt: z.string().datetime(),
+  })
+  .strict();
+
 export const PersistedFinancialFactsSnapshotV1Schema = z.discriminatedUnion('policyVersion', [
   FinancialFactsSnapshotV1_0_0Schema,
   FinancialFactsSnapshotV1Schema,
   FinancialFactsSnapshotV2Schema,
   FinancialFactsSnapshotV3Schema,
+  FinancialFactsSnapshotV4Schema,
 ]);
 
 export type FinancialFactsSnapshotV1_0_0 = z.infer<typeof FinancialFactsSnapshotV1_0_0Schema>;
 export type FinancialFactsSnapshotV1 = z.infer<typeof FinancialFactsSnapshotV1Schema>;
 export type FinancialFactsSnapshotV2 = z.infer<typeof FinancialFactsSnapshotV2Schema>;
 export type FinancialFactsSnapshotV3 = z.infer<typeof FinancialFactsSnapshotV3Schema>;
+export type FinancialFactsSnapshotV4 = z.infer<typeof FinancialFactsSnapshotV4Schema>;
 export type PersistedFinancialFactsSnapshotV1 = z.infer<
   typeof PersistedFinancialFactsSnapshotV1Schema
 >;

--- a/shared/contracts/internal-economics/capital-envelope-v1.contract.ts
+++ b/shared/contracts/internal-economics/capital-envelope-v1.contract.ts
@@ -1,0 +1,180 @@
+/**
+ * Immutable Legal Capital Envelope contract (`capital-envelope/1.0.0`).
+ *
+ * Brief 3 (docs/superpowers/specs/2026-07-30-task163-go-readiness-briefs.md,
+ * lines 376-433) defines the operator-attested legal capital envelope for
+ * internal LP economics: an append-only, versioned record of LP/GP/total
+ * commitments for a fund's single `main_fund` vehicle. This module carries
+ * the schema-only surface for WP-L3's envelope service:
+ *
+ *  - `CapitalEnvelopeCreateRequestV1Schema` — the client-authoritative
+ *    creation request (Brief 3 field list verbatim). The four arithmetic
+ *    invariants (lp >= 0, gp >= 0, total > 0, lp + gp = total exactly) are
+ *    enforced in-schema; each violation surfaces its seed-refusal code as
+ *    the zod issue message so callers can map 422 payloads without string
+ *    invention.
+ *  - `CapitalEnvelopeSeedRefusalCodeV1Schema` — the Brief 3 invariant
+ *    refusal registry (HTTP 422, nothing persisted). The two vehicle codes
+ *    (`ENVELOPE_VEHICLE_NOT_IN_FUND`, `ENVELOPE_VEHICLE_NOT_MAIN_FUND`)
+ *    are DB-state checks the envelope service performs at creation time;
+ *    they cannot be schema-enforced here.
+ *  - `CapitalEnvelopeHashPreimageV1Schema` and
+ *    `buildCapitalEnvelopeHashPreimageV1` — the `envelope_hash` preimage
+ *    shape: contract version + fundId + the attested legal content fields,
+ *    and nothing else. Lineage fields (row id, version, parent version,
+ *    idempotency key, request hash, created-at) are excluded so the hash is
+ *    a pure content identity.
+ *
+ * Money is canonical 6dp decimal strings (`MoneyDecimalStringSchema`);
+ * never `number` round-trips. This module is schema-only: no hashing, no
+ * Node crypto — services compute `envelope_hash` from the preimage object
+ * via the canonical hash helper server-side.
+ *
+ * Governing plan: docs/superpowers/plans/
+ * 2026-07-31-task163-wp-l3-service-persistence-plan.md (section 1 scope,
+ * P-D6/P-D11, section 11 T-B1).
+ *
+ * @module shared/contracts/internal-economics/capital-envelope-v1.contract
+ */
+import { z } from 'zod';
+
+import { Decimal } from '../../lib/decimal-config';
+import { MoneyDecimalStringSchema } from '../../lib/decimal-string';
+
+export const CAPITAL_ENVELOPE_CONTRACT_VERSION = 'capital-envelope/1.0.0' as const;
+
+const Sha256HexSchema = z.string().regex(/^[a-f0-9]{64}$/);
+
+/**
+ * Brief 3 invariant refusal registry (envelope-seed phase, HTTP 422, no row
+ * created). Codes are minted here 1:1 against Brief 3's invariant list
+ * (briefs lines 410-422); the `ENVELOPE_` prefix keeps the one-definitions
+ * registry unambiguous across phases.
+ */
+export const CAPITAL_ENVELOPE_SEED_REFUSAL_CODES_V1 = [
+  'ENVELOPE_LP_COMMITMENT_NEGATIVE',
+  'ENVELOPE_GP_COMMITMENT_NEGATIVE',
+  'ENVELOPE_TOTAL_COMMITMENT_NOT_POSITIVE',
+  'ENVELOPE_COMMITMENT_SUM_MISMATCH',
+  'ENVELOPE_CURRENCY_UNSUPPORTED',
+  'ENVELOPE_VEHICLE_NOT_IN_FUND',
+  'ENVELOPE_VEHICLE_NOT_MAIN_FUND',
+] as const;
+
+export const CapitalEnvelopeSeedRefusalCodeV1Schema = z.enum(
+  CAPITAL_ENVELOPE_SEED_REFUSAL_CODES_V1
+);
+export type CapitalEnvelopeSeedRefusalCodeV1 = z.infer<
+  typeof CapitalEnvelopeSeedRefusalCodeV1Schema
+>;
+
+const CapitalEnvelopeContentFieldsV1 = {
+  mainFundVehicleId: z.number().int().positive(),
+  lpCommitmentUsd: MoneyDecimalStringSchema,
+  gpCommitmentUsd: MoneyDecimalStringSchema,
+  totalCommitmentUsd: MoneyDecimalStringSchema,
+  currency: z.literal('USD'),
+  effectiveAt: z.string().datetime(),
+  sourceArtifactId: z.number().int().positive(),
+  sourceConfigId: z.number().int().positive(),
+  sourceConfigVersion: z.number().int().positive(),
+  sourceConfigHash: Sha256HexSchema,
+  attestedBy: z.number().int().positive(),
+  attestedAt: z.string().datetime(),
+} as const;
+
+function enforceCommitmentInvariants(
+  value: {
+    lpCommitmentUsd: string;
+    gpCommitmentUsd: string;
+    totalCommitmentUsd: string;
+  },
+  ctx: z.RefinementCtx
+): void {
+  const lp = new Decimal(value.lpCommitmentUsd);
+  const gp = new Decimal(value.gpCommitmentUsd);
+  const total = new Decimal(value.totalCommitmentUsd);
+
+  if (lp.lt(0)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['lpCommitmentUsd'],
+      message: 'ENVELOPE_LP_COMMITMENT_NEGATIVE',
+    });
+  }
+  if (gp.lt(0)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['gpCommitmentUsd'],
+      message: 'ENVELOPE_GP_COMMITMENT_NEGATIVE',
+    });
+  }
+  if (!total.gt(0)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['totalCommitmentUsd'],
+      message: 'ENVELOPE_TOTAL_COMMITMENT_NOT_POSITIVE',
+    });
+  }
+  if (!lp.plus(gp).eq(total)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['totalCommitmentUsd'],
+      message: 'ENVELOPE_COMMITMENT_SUM_MISMATCH',
+    });
+  }
+}
+
+/**
+ * Client-authoritative envelope creation request (Brief 3 fields). Version
+ * allocation, parent-version lineage, and the vehicle checks are service
+ * concerns (P-D11 advisory-lock protocol); they never travel in the request.
+ */
+export const CapitalEnvelopeCreateRequestV1Schema = z
+  .object(CapitalEnvelopeContentFieldsV1)
+  .strict()
+  .superRefine(enforceCommitmentInvariants);
+export type CapitalEnvelopeCreateRequestV1 = Readonly<
+  z.infer<typeof CapitalEnvelopeCreateRequestV1Schema>
+>;
+
+/**
+ * `envelope_hash` preimage: contract version + fund + attested legal
+ * content. Excludes row id, version, parent lineage, idempotency key,
+ * request hash, and created-at, so identical legal content always hashes
+ * identically across correction chains.
+ */
+export const CapitalEnvelopeHashPreimageV1Schema = z
+  .object({
+    contractVersion: z.literal(CAPITAL_ENVELOPE_CONTRACT_VERSION),
+    fundId: z.number().int().positive(),
+    ...CapitalEnvelopeContentFieldsV1,
+  })
+  .strict()
+  .superRefine(enforceCommitmentInvariants);
+export type CapitalEnvelopeHashPreimageV1 = Readonly<
+  z.infer<typeof CapitalEnvelopeHashPreimageV1Schema>
+>;
+
+/** Pure projection from a validated request to the hash preimage shape. */
+export function buildCapitalEnvelopeHashPreimageV1(input: {
+  readonly fundId: number;
+  readonly request: CapitalEnvelopeCreateRequestV1;
+}): CapitalEnvelopeHashPreimageV1 {
+  return CapitalEnvelopeHashPreimageV1Schema.parse({
+    contractVersion: CAPITAL_ENVELOPE_CONTRACT_VERSION,
+    fundId: input.fundId,
+    mainFundVehicleId: input.request.mainFundVehicleId,
+    lpCommitmentUsd: input.request.lpCommitmentUsd,
+    gpCommitmentUsd: input.request.gpCommitmentUsd,
+    totalCommitmentUsd: input.request.totalCommitmentUsd,
+    currency: input.request.currency,
+    effectiveAt: input.request.effectiveAt,
+    sourceArtifactId: input.request.sourceArtifactId,
+    sourceConfigId: input.request.sourceConfigId,
+    sourceConfigVersion: input.request.sourceConfigVersion,
+    sourceConfigHash: input.request.sourceConfigHash,
+    attestedBy: input.request.attestedBy,
+    attestedAt: input.request.attestedAt,
+  });
+}

--- a/shared/contracts/internal-economics/economics-policy-v1.contract.ts
+++ b/shared/contracts/internal-economics/economics-policy-v1.contract.ts
@@ -1,0 +1,148 @@
+/**
+ * Internal economics policy contract (`internal-economics-policy/1.0.0`).
+ *
+ * WP-L3 P-D6: policy rows persist AUTHORED configuration only. The
+ * `policy_body` JSONB column carries exactly the contract-versioned
+ * assumptions modeled by `EconomicsPolicyBodyV1Schema`:
+ *
+ *  - waterfall template pinned to the `deal_by_deal` literal (whole_fund is
+ *    a V2 publish, never silent V1 widening — D9);
+ *  - `carryPct` as a finite number in [0, 1], matching the frozen period
+ *    loop's own input contract;
+ *  - hurdle `{ basis: 'none' }` — schema V1 admits no pref-bearing basis
+ *    (`HURDLE_BASIS_UNSUPPORTED` refuses pref-bearing source configs);
+ *  - explicit zero fees / empty expenses (Brief 2 zero-fee bridge posture;
+ *    the call-sizing seam separately throws
+ *    `NONZERO_FEE_EXPENSE_UNSUPPORTED_V1` on any nonzero schedule);
+ *  - `cashBufferQuarters` as a nonnegative integer;
+ *  - terminal mode plus the term anchor inputs (`termStartDate`,
+ *    `fundLifeYears`) that feed `resolveTerminalPeriodEndV1`. The terminal
+ *    pair itself is persisted in dedicated columns written exclusively via
+ *    the exported terminal-policy projection helpers (G11/ADR-065 item 8);
+ *    this module performs no date arithmetic of its own.
+ *
+ * Also here:
+ *  - `EconomicsPolicyCreateRequestV1Schema` — source-config ref + pinned
+ *    capital-envelope version + authored body (section 5 service surface);
+ *  - the policy-seed refusal registry (HTTP 422, no policy created;
+ *    scoping-design lines 774-797, section 5 list verbatim);
+ *  - `EconomicsPolicyNormalizationWarningV1Schema` — the persisted
+ *    provenance shape for dormant-but-disabled parameter normalization.
+ *    Warnings persist in `normalization_warnings` JSONB and participate in
+ *    `assumptions_hash` (D4 review-added requirement; G14's explicit
+ *    clawback active/dormant determination records `provenance:
+ *    'explicit' | 'defaulted'` per resolved parameter).
+ *
+ * Schema-only module: no hashing, no Node crypto.
+ *
+ * Governing plan: docs/superpowers/plans/
+ * 2026-07-31-task163-wp-l3-service-persistence-plan.md (P-D6, section 5,
+ * section 11 T-B2).
+ *
+ * @module shared/contracts/internal-economics/economics-policy-v1.contract
+ */
+import { z } from 'zod';
+
+import { TerminalModeV1Schema } from './terminal-policy-v1.contract';
+
+export const ECONOMICS_POLICY_CONTRACT_VERSION = 'internal-economics-policy/1.0.0' as const;
+
+/**
+ * Policy-seed refusal registry (HTTP 422, nothing persisted). Order and
+ * literals are the ratified registry's policy-seed phase verbatim
+ * (scoping-design lines 774-797). `CREDIT_FACILITY_UNSUPPORTED` is
+ * issue-mandated and reserved (structurally unreachable in V1 seeds).
+ */
+export const ECONOMICS_POLICY_SEED_REFUSAL_CODES_V1 = [
+  'CATCH_UP_UNSUPPORTED',
+  'CLAWBACK_UNSUPPORTED',
+  'ESCROW_UNSUPPORTED',
+  'RECYCLING_UNSUPPORTED',
+  'HURDLE_BASIS_UNSUPPORTED',
+  'FUND_LIFE_ABSENT',
+  'FUND_LIFE_GRID_UNREPRESENTABLE',
+  'FUND_TERM_START_ABSENT',
+  'EVERGREEN_STATUS_ABSENT',
+  'EVERGREEN_UNSUPPORTED',
+  'CREDIT_FACILITY_UNSUPPORTED',
+] as const;
+
+export const EconomicsPolicySeedRefusalCodeV1Schema = z.enum(
+  ECONOMICS_POLICY_SEED_REFUSAL_CODES_V1
+);
+export type EconomicsPolicySeedRefusalCodeV1 = z.infer<
+  typeof EconomicsPolicySeedRefusalCodeV1Schema
+>;
+
+const ZERO_MONEY_LITERAL = '0.000000' as const;
+
+/**
+ * Positive decimal-string years (e.g. '10', '10.25'). Grid representability
+ * (`fundLifeYears * 4` must be a positive integer quarter count) is enforced
+ * by the terminal-policy helpers at seed time, not by this shape.
+ */
+const PositiveDecimalStringSchema = z
+  .string()
+  .regex(/^(?:0|[1-9]\d*)(?:\.\d+)?$/)
+  // Canonical unsigned decimal strings are positive exactly when they carry a
+  // nonzero digit (pure string check; zod string checks are non-fatal, so a
+  // numeric-parse refinement here could run on non-matching input).
+  .refine((value) => /[1-9]/.test(value), 'fundLifeYears must be positive.');
+
+/** Authored V1 policy assumptions persisted verbatim in `policy_body`. */
+export const EconomicsPolicyBodyV1Schema = z
+  .object({
+    waterfallTemplate: z.literal('deal_by_deal'),
+    carryPct: z.number().finite().min(0).max(1),
+    hurdle: z.object({ basis: z.literal('none') }).strict(),
+    managementFeesUsd: z.literal(ZERO_MONEY_LITERAL),
+    fundExpenses: z.tuple([]),
+    cashBufferQuarters: z.number().int().nonnegative(),
+    terminalMode: TerminalModeV1Schema,
+    termStartDate: z.string().date(),
+    fundLifeYears: PositiveDecimalStringSchema,
+  })
+  .strict();
+export type EconomicsPolicyBodyV1 = Readonly<z.infer<typeof EconomicsPolicyBodyV1Schema>>;
+
+/**
+ * Policy creation request: the pinned capital-envelope version (P-D6 — the
+ * policy pins the envelope; runs never re-select it), the seed source-config
+ * lineage, and the authored body. Version allocation is the service's
+ * advisory-lock protocol (P-D11) and never travels in the request.
+ */
+export const EconomicsPolicyCreateRequestV1Schema = z
+  .object({
+    capitalEnvelopeVersionId: z.number().int().positive(),
+    sourceConfigId: z.number().int().positive(),
+    sourceConfigVersion: z.number().int().positive(),
+    body: EconomicsPolicyBodyV1Schema,
+  })
+  .strict();
+export type EconomicsPolicyCreateRequestV1 = Readonly<
+  z.infer<typeof EconomicsPolicyCreateRequestV1Schema>
+>;
+
+export const ECONOMICS_POLICY_NORMALIZATION_PROVENANCE_V1 = ['explicit', 'defaulted'] as const;
+
+/**
+ * Persisted normalization-warning provenance (dormant-but-disabled
+ * parameters normalize with warnings, never silently). Rows persist in
+ * `normalization_warnings` and participate in `assumptions_hash`, so two
+ * policies differing only in dormant parameters hash differently.
+ */
+export const EconomicsPolicyNormalizationWarningV1Schema = z
+  .object({
+    /** Normalized parameter name, e.g. 'clawbackEnabled'. */
+    parameter: z.string().min(1),
+    /** Whether the resolved value came from the source config or a default. */
+    provenance: z.enum(ECONOMICS_POLICY_NORMALIZATION_PROVENANCE_V1),
+    /** Resolved value, string-encoded for deterministic JSONB/hash content. */
+    resolvedValue: z.string(),
+    /** Human-readable normalization outcome. */
+    detail: z.string().min(1),
+  })
+  .strict();
+export type EconomicsPolicyNormalizationWarningV1 = Readonly<
+  z.infer<typeof EconomicsPolicyNormalizationWarningV1Schema>
+>;

--- a/shared/contracts/internal-economics/lp-economics-run-v1.contract.ts
+++ b/shared/contracts/internal-economics/lp-economics-run-v1.contract.ts
@@ -1,0 +1,497 @@
+/**
+ * Internal LP economics run contract (D8 request/idempotency surface + D9
+ * result envelope), contract version `lp-economics/1.0.0`.
+ *
+ * WP-L3's run service is an assembler/persister around the frozen
+ * `executeCashAssemblyPeriodLoopV1` seam. This module carries every
+ * schema-shaped piece of that surface:
+ *
+ *  - `LpEconomicsRunRequestV1Schema` — explicit basis IDs only (ADR-065
+ *    item 1: no latest-resolution anywhere): policy version, facts
+ *    snapshot, plan version, forecast snapshot, terminal mode, and the
+ *    pinned evaluation `clock` (D9: clock is BASIS — it participates in the
+ *    idempotency preimage and the result hash and replays byte-identical).
+ *  - `LpEconomicsRunIdempotencyPreimageV1Schema` — P-D8 (R1 amendment):
+ *    route-injected `fundId` + `contractVersion` + the normalized request
+ *    body + `engineVersion` + `methodologyVersion`. Nothing resolved from
+ *    the DB participates (basis IDs already pin immutable rows); the
+ *    engine/methodology axis is a deployed-code property and must change
+ *    the preimage so upgrades never silently replay stale results.
+ *  - The run-unavailability reason registry (persisted `unavailable`,
+ *    HTTP 200) in section 8 gate order, including the three gate-ratified
+ *    additions `FACTS_ECONOMICS_EVALUATION_BLOCKED` (L3-Q7),
+ *    `OPENING_STATE_CONTRACT_INELIGIBLE` (L3-Q6/P-D10 R5), and
+ *    `OPENING_STATE_INELIGIBLE` (P-D7 R10), plus the indicative-phase
+ *    registry (the D-11 pair and `FLOAT64_WATERFALL_PATH`).
+ *  - Reason shape `{ code, detail?, context? }` with typed context
+ *    obligations: `OPENING_STATE_INELIGIBLE` carries `{ field, valueUsd }`
+ *    (the four frozen-loop opening-balance fields, canonical 6dp value);
+ *    `OPENING_STATE_CONTRACT_INELIGIBLE` carries
+ *    `context.detail = 'OPENING_STATE_CONTRACT_V1_INELIGIBLE'` as the
+ *    version discriminant.
+ *  - The D9 result envelope: waterfall template pinned to the single
+ *    `deal_by_deal` member (whole_fund arrives only as a V2 publish, so the
+ *    template axis is expressed as a pinned literal on every member and the
+ *    operative runtime discrimination is the nested `resultStatus` union);
+ *    `indicative` carries quarters/events/totals plus nonempty reasons,
+ *    `unavailable` carries nonempty reasons only. Quarter rows are exactly
+ *    the frozen loop's emitted rows; event rows are the loop's rows PLUS
+ *    the section 6 enrichment fields (`eventSequence`, `eventId`,
+ *    `sourceRefs`, `eventKind`). The E1-resolved unreturned-capital fields
+ *    are deliberately absent from event rows (legacy ledger must never
+ *    populate them). Totals follow section 6(c)'s three-way split; the IRR
+ *    block reuses the ADR-010 XIRR diagnostic taxonomy. Money passes
+ *    through as canonical 6dp decimal strings, ratios as 12dp; never
+ *    `number` round-trips.
+ *  - `sortAndDedupeLpEconomicsReasonsV1` — the registry's binding
+ *    sort/dedupe rule, applied exactly once at payload construction: sort
+ *    key is `code` (ties broken by `detail`, with the dedupe hash as a
+ *    final deterministic tiebreak); dedupe identity is the EXPORTED
+ *    `canonicalSha256` of the full `{ code, detail, context }` tuple
+ *    (section 6 R7 — key-order-insensitive, and context discriminants are
+ *    never collapsed by a code-only dedupe).
+ *
+ * NOTE: this module is crypto-bearing — `canonicalSha256` pulls
+ * `node:crypto` (used by the event-id builder and the reason dedupe
+ * helper). Client code must import this module TYPE-ONLY (plan section
+ * 10(j)); the schema-only sibling contracts stay crypto-free.
+ *
+ * Governing docs: docs/superpowers/plans/
+ * 2026-07-31-task163-wp-l3-service-persistence-plan.md (sections 5, 6, 8;
+ * P-D8/P-D10) and docs/superpowers/specs/
+ * 2026-07-30-task163-deal-by-deal-scoping-design.md (D8 lines 478-549, D9
+ * lines 551-677, registry lines 766-846).
+ *
+ * @module shared/contracts/internal-economics/lp-economics-run-v1.contract
+ */
+import { z } from 'zod';
+
+import { canonicalSha256 } from '../../lib/canonical-hash';
+import { MoneyDecimalStringSchema, RatioDecimalStringSchema } from '../../lib/decimal-string';
+import type { CashAssemblyWaterfallEventV1 } from '../../lib/internal-economics/cash-assembly-period-loop-v1';
+import type { CashAssemblyQuarterRowV1 } from '../../lib/internal-economics/cash-assembly-types-v1';
+import { XirrDiagnosticSchema } from '../lp-reporting/lp-metric-run.contract';
+import { TerminalModeV1Schema } from './terminal-policy-v1.contract';
+
+export const LP_ECONOMICS_RUN_CONTRACT_VERSION = 'lp-economics/1.0.0' as const;
+
+// ---------------------------------------------------------------------------
+// Run request (explicit basis IDs only) + idempotency preimage (P-D8).
+// ---------------------------------------------------------------------------
+
+export const LpEconomicsRunRequestV1Schema = z
+  .object({
+    policyVersionId: z.number().int().positive(),
+    factsSnapshotId: z.number().int().positive(),
+    planVersionId: z.number().int().positive(),
+    forecastSnapshotId: z.number().int().positive(),
+    /**
+     * Must exactly match the pinned policy's terminal mode (section 5:
+     * mismatch is a typed request-validation rejection, never a run
+     * outcome). Duplicated in the request for explicitness, not override.
+     */
+    terminalMode: TerminalModeV1Schema,
+    /** Pinned evaluation clock (BASIS — replays byte-identical). */
+    clock: z.string().datetime(),
+  })
+  .strict();
+export type LpEconomicsRunRequestV1 = Readonly<z.infer<typeof LpEconomicsRunRequestV1Schema>>;
+
+export const LpEconomicsRunIdempotencyPreimageV1Schema = z
+  .object({
+    fundId: z.number().int().positive(),
+    contractVersion: z.literal(LP_ECONOMICS_RUN_CONTRACT_VERSION),
+    request: LpEconomicsRunRequestV1Schema,
+    engineVersion: z.string().min(1),
+    methodologyVersion: z.string().min(1),
+  })
+  .strict();
+export type LpEconomicsRunIdempotencyPreimageV1 = Readonly<
+  z.infer<typeof LpEconomicsRunIdempotencyPreimageV1Schema>
+>;
+
+/** Pure preimage assembly; the service hashes the returned object. */
+export function buildLpEconomicsRunIdempotencyPreimageV1(input: {
+  readonly fundId: number;
+  readonly request: LpEconomicsRunRequestV1;
+  readonly engineVersion: string;
+  readonly methodologyVersion: string;
+}): LpEconomicsRunIdempotencyPreimageV1 {
+  return LpEconomicsRunIdempotencyPreimageV1Schema.parse({
+    fundId: input.fundId,
+    contractVersion: LP_ECONOMICS_RUN_CONTRACT_VERSION,
+    request: input.request,
+    engineVersion: input.engineVersion,
+    methodologyVersion: input.methodologyVersion,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Reason registries (run-unavailability phase + indicative phase).
+// ---------------------------------------------------------------------------
+
+/**
+ * Persisted run-unavailability registry in section 8 gate order (ratified
+ * registry, scoping-design lines 803-834, plus the three gate-ratified
+ * additions named in the module docstring).
+ */
+export const LP_ECONOMICS_RUN_UNAVAILABILITY_REASON_CODES_V1 = [
+  'MAIN_FUND_VEHICLE_ABSENT',
+  'MAIN_FUND_SCOPED_FORECAST_UNAVAILABLE',
+  'MAIN_FUND_COMMITMENT_ABSENT',
+  'MAIN_FUND_CURRENCY_UNSUPPORTED',
+  'CONFIG_LINEAGE_MISMATCH',
+  'FORECAST_UNAVAILABLE',
+  'FORECAST_FAILED',
+  'FORECAST_HELD_UNSUPPORTED',
+  'FACTS_ECONOMICS_EVALUATION_BLOCKED',
+  'OPENING_CASH_UNAVAILABLE',
+  'OPENING_STATE_CONTRACT_INELIGIBLE',
+  'OPENING_STATE_INELIGIBLE',
+  'GP_COMMITMENT_UNSUPPORTED',
+  'FORECAST_FEE_BASIS_INCOMPATIBLE',
+  'TERMINAL_RESOLUTION_METHODOLOGY_UNSUPPORTED',
+  'TERMINAL_RESOLUTION_MISMATCH',
+  'TERMINAL_BEFORE_CUTOVER',
+  'FORECAST_HORIZON_SHORT',
+  'FORECAST_TERMINAL_PERIOD_UNREPRESENTABLE',
+  'POST_TERM_ACTIVITY',
+  'NEGATIVE_SOURCE_MONEY',
+  'FORECAST_DEPLOYMENT_CUMULATIVE_DECREASE',
+  'COMMITTED_CAPITAL_EXCEEDED',
+] as const;
+
+export const LpEconomicsRunUnavailabilityReasonCodeV1Schema = z.enum(
+  LP_ECONOMICS_RUN_UNAVAILABILITY_REASON_CODES_V1
+);
+export type LpEconomicsRunUnavailabilityReasonCodeV1 = z.infer<
+  typeof LpEconomicsRunUnavailabilityReasonCodeV1Schema
+>;
+
+/**
+ * Indicative-phase registry: the D-11 pair the frozen loop emits plus the
+ * ratified `FLOAT64_WATERFALL_PATH` cap for any float64 waterfall path.
+ */
+export const LP_ECONOMICS_INDICATIVE_REASON_CODES_V1 = [
+  'DECIMAL_CORE_UNCERTIFIED',
+  'FLOAT64_WATERFALL_PATH',
+  'LP_NET_NAV_FLAT_SHARE_APPROXIMATION',
+] as const;
+
+export const LpEconomicsIndicativeReasonCodeV1Schema = z.enum(
+  LP_ECONOMICS_INDICATIVE_REASON_CODES_V1
+);
+export type LpEconomicsIndicativeReasonCodeV1 = z.infer<
+  typeof LpEconomicsIndicativeReasonCodeV1Schema
+>;
+
+// ---------------------------------------------------------------------------
+// Reason shape { code, detail?, context? } + typed context obligations.
+// ---------------------------------------------------------------------------
+
+const LpEconomicsReasonContextV1Schema = z.record(z.string(), z.string());
+
+export const OPENING_STATE_CONTRACT_V1_INELIGIBLE_DETAIL =
+  'OPENING_STATE_CONTRACT_V1_INELIGIBLE' as const;
+
+/**
+ * The four opening-balance fields the frozen loop checks, in its exact
+ * fixed order (read-only mirror of the loop's own ineligibility list; the
+ * service checks them in this order pre-invocation per P-D10 R10).
+ */
+export const OPENING_STATE_INELIGIBLE_FIELDS_V1 = [
+  'cumulativeGpPaidInUsd',
+  'gpUnreturnedContributedCapitalUsd',
+  'gpInvestmentDistributionsPaidUsd',
+  'accruedPreferredReturnUsd',
+] as const;
+
+export const OpeningStateIneligibleContextV1Schema = z
+  .object({
+    field: z.enum(OPENING_STATE_INELIGIBLE_FIELDS_V1),
+    valueUsd: MoneyDecimalStringSchema,
+  })
+  .strict();
+export type OpeningStateIneligibleContextV1 = Readonly<
+  z.infer<typeof OpeningStateIneligibleContextV1Schema>
+>;
+
+export const LpEconomicsRunUnavailabilityReasonV1Schema = z
+  .object({
+    code: LpEconomicsRunUnavailabilityReasonCodeV1Schema,
+    detail: z.string().min(1).optional(),
+    context: LpEconomicsReasonContextV1Schema.optional(),
+  })
+  .strict()
+  .superRefine((reason, ctx) => {
+    if (reason.code === 'OPENING_STATE_INELIGIBLE') {
+      const parsedContext = OpeningStateIneligibleContextV1Schema.safeParse(reason.context);
+      if (!parsedContext.success) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['context'],
+          message:
+            'OPENING_STATE_INELIGIBLE requires context {field, valueUsd} with a frozen-loop field name and canonical 6dp value.',
+        });
+      }
+    }
+    if (
+      reason.code === 'OPENING_STATE_CONTRACT_INELIGIBLE' &&
+      reason.context?.['detail'] !== OPENING_STATE_CONTRACT_V1_INELIGIBLE_DETAIL
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['context'],
+        message:
+          'OPENING_STATE_CONTRACT_INELIGIBLE requires the OPENING_STATE_CONTRACT_V1_INELIGIBLE context.detail discriminant.',
+      });
+    }
+  });
+export type LpEconomicsRunUnavailabilityReasonV1 = Readonly<
+  z.infer<typeof LpEconomicsRunUnavailabilityReasonV1Schema>
+>;
+
+export const LpEconomicsIndicativeReasonV1Schema = z
+  .object({
+    code: LpEconomicsIndicativeReasonCodeV1Schema,
+    detail: z.string().min(1).optional(),
+    context: LpEconomicsReasonContextV1Schema.optional(),
+  })
+  .strict();
+export type LpEconomicsIndicativeReasonV1 = Readonly<
+  z.infer<typeof LpEconomicsIndicativeReasonV1Schema>
+>;
+
+// ---------------------------------------------------------------------------
+// Reason sort/dedupe (registry rule: exactly once, at payload construction).
+// ---------------------------------------------------------------------------
+
+export interface LpEconomicsReasonTupleV1 {
+  readonly code: string;
+  readonly detail?: string | undefined;
+  readonly context?: Readonly<Record<string, string>> | undefined;
+}
+
+function compareStrings(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+/**
+ * Sorts by `code` (ties broken by `detail`, then by the dedupe hash as a
+ * final deterministic tiebreak) and dedupes on the `canonicalSha256` of the
+ * full `{ code, detail, context }` tuple — key-order-insensitive, so
+ * semantically identical contexts collapse while context discriminants
+ * (e.g. distinct `OPENING_STATE_INELIGIBLE` fields) always survive.
+ */
+export function sortAndDedupeLpEconomicsReasonsV1<T extends LpEconomicsReasonTupleV1>(
+  reasons: readonly T[]
+): readonly T[] {
+  const seen = new Set<string>();
+  const entries: Array<{ reason: T; dedupeKey: string }> = [];
+  for (const reason of reasons) {
+    const dedupeKey = canonicalSha256({
+      code: reason.code,
+      detail: reason.detail,
+      context: reason.context,
+    });
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+    entries.push({ reason, dedupeKey });
+  }
+
+  return entries
+    .sort(
+      (left, right) =>
+        compareStrings(left.reason.code, right.reason.code) ||
+        compareStrings(left.reason.detail ?? '', right.reason.detail ?? '') ||
+        compareStrings(left.dedupeKey, right.dedupeKey)
+    )
+    .map((entry) => entry.reason);
+}
+
+// ---------------------------------------------------------------------------
+// D9 value rows: frozen-loop quarter rows verbatim; events + enrichment.
+// ---------------------------------------------------------------------------
+
+export const LpEconomicsQuarterRowV1Schema = z
+  .object({
+    periodStart: z.string().date(),
+    periodEnd: z.string().date(),
+    source: z.enum(['actual', 'projected']),
+    openingCashUsd: MoneyDecimalStringSchema,
+    lpCapitalCallUsd: MoneyDecimalStringSchema,
+    gpCommitmentCallUsd: MoneyDecimalStringSchema,
+    portfolioDeploymentUsd: MoneyDecimalStringSchema,
+    managementFeesUsd: MoneyDecimalStringSchema,
+    fundExpensesUsd: MoneyDecimalStringSchema,
+    grossRealizedProceedsUsd: MoneyDecimalStringSchema,
+    lpDistributionUsd: MoneyDecimalStringSchema,
+    gpInvestmentDistributionUsd: MoneyDecimalStringSchema,
+    gpCarryDistributedUsd: MoneyDecimalStringSchema,
+    endingCashUsd: MoneyDecimalStringSchema,
+    grossNavUsd: MoneyDecimalStringSchema,
+    lpNetNavUsd: MoneyDecimalStringSchema,
+    cumulativeLpPaidInUsd: MoneyDecimalStringSchema,
+    cumulativeLpDistributedUsd: MoneyDecimalStringSchema,
+    dpi: RatioDecimalStringSchema.nullable(),
+    rvpi: RatioDecimalStringSchema.nullable(),
+    tvpi: RatioDecimalStringSchema.nullable(),
+  })
+  .strict();
+export type LpEconomicsQuarterRowV1 = Readonly<z.infer<typeof LpEconomicsQuarterRowV1Schema>>;
+
+export const LpEconomicsEventKindV1Schema = z.enum([
+  'forecast_quarterly_distribution',
+  'terminal_realization',
+]);
+export type LpEconomicsEventKindV1 = z.infer<typeof LpEconomicsEventKindV1Schema>;
+
+/** Typed wrapper around the frozen loop's bare `sourceId` string. */
+export const LpEconomicsEventSourceRefV1Schema = z.object({ sourceId: z.string().min(1) }).strict();
+export type LpEconomicsEventSourceRefV1 = Readonly<
+  z.infer<typeof LpEconomicsEventSourceRefV1Schema>
+>;
+
+/**
+ * Frozen-loop event fields verbatim PLUS the section 6 enrichment fields.
+ * `eventId` is basis-derived only (never run-derived — D9 excludes run IDs
+ * from the result hash); see `buildLpEconomicsEventIdV1`.
+ */
+export const LpEconomicsWaterfallEventV1Schema = z
+  .object({
+    periodEnd: z.string().date(),
+    sourceId: z.string().min(1),
+    grossDistributionUsd: MoneyDecimalStringSchema,
+    lpCapitalReturnUsd: MoneyDecimalStringSchema,
+    lpProfitUsd: MoneyDecimalStringSchema,
+    gpInvestmentDistributionUsd: MoneyDecimalStringSchema,
+    gpCarryUsd: MoneyDecimalStringSchema,
+    eventSequence: z.number().int().nonnegative(),
+    eventId: z.string().regex(/^[a-f0-9]{64}$/),
+    sourceRefs: z.array(LpEconomicsEventSourceRefV1Schema).min(1),
+    eventKind: LpEconomicsEventKindV1Schema,
+  })
+  .strict();
+export type LpEconomicsWaterfallEventV1 = Readonly<
+  z.infer<typeof LpEconomicsWaterfallEventV1Schema>
+>;
+
+/**
+ * Deterministic, basis-only event identity (section 6 R3(a)): a hash of
+ * the loop's stable `sourceId`, the event's `periodEnd`, and its array
+ * position — identical basis replays produce identical `eventId` values.
+ */
+export function buildLpEconomicsEventIdV1(input: {
+  readonly sourceId: string;
+  readonly periodEnd: string;
+  readonly eventSequence: number;
+}): string {
+  return canonicalSha256({
+    sourceId: input.sourceId,
+    periodEnd: input.periodEnd,
+    eventSequence: input.eventSequence,
+  });
+}
+
+/**
+ * Section 6(c) totals: (i) quarter-summed flow fields, (ii) the
+ * event-summed LP capital-return/profit split, (iii) terminal-quarter-row
+ * pass-through for the stock/ratio fields (never re-derived).
+ */
+export const LpEconomicsTotalsV1Schema = z
+  .object({
+    lpCapitalCallUsd: MoneyDecimalStringSchema,
+    gpCommitmentCallUsd: MoneyDecimalStringSchema,
+    portfolioDeploymentUsd: MoneyDecimalStringSchema,
+    managementFeesUsd: MoneyDecimalStringSchema,
+    fundExpensesUsd: MoneyDecimalStringSchema,
+    grossRealizedProceedsUsd: MoneyDecimalStringSchema,
+    lpCapitalReturnUsd: MoneyDecimalStringSchema,
+    lpProfitUsd: MoneyDecimalStringSchema,
+    lpDistributionUsd: MoneyDecimalStringSchema,
+    gpInvestmentDistributionUsd: MoneyDecimalStringSchema,
+    gpCarryDistributedUsd: MoneyDecimalStringSchema,
+    endingCashUsd: MoneyDecimalStringSchema,
+    grossNavUsd: MoneyDecimalStringSchema,
+    lpNetNavUsd: MoneyDecimalStringSchema,
+    dpi: RatioDecimalStringSchema.nullable(),
+    rvpi: RatioDecimalStringSchema.nullable(),
+    tvpi: RatioDecimalStringSchema.nullable(),
+  })
+  .strict();
+export type LpEconomicsTotalsV1 = Readonly<z.infer<typeof LpEconomicsTotalsV1Schema>>;
+
+// ---------------------------------------------------------------------------
+// D9 result envelope.
+// ---------------------------------------------------------------------------
+
+export const LpEconomicsIrrBasisV1Schema = z.enum(['cash_only', 'cash_plus_terminal_nav']);
+export type LpEconomicsIrrBasisV1 = z.infer<typeof LpEconomicsIrrBasisV1Schema>;
+
+const LpEconomicsResultEnvelopeCommonV1 = {
+  waterfallTemplate: z.literal('deal_by_deal'),
+  clock: z.string().datetime(),
+  currency: z.literal('USD'),
+  perspective: z.literal('lp_net'),
+  precisionMode: z.literal('decimal_native_with_float64_xirr'),
+} as const;
+
+export const LpEconomicsIndicativeResultV1Schema = z
+  .object({
+    ...LpEconomicsResultEnvelopeCommonV1,
+    resultStatus: z.literal('indicative'),
+    quarters: z.array(LpEconomicsQuarterRowV1Schema),
+    waterfallEvents: z.array(LpEconomicsWaterfallEventV1Schema),
+    totals: LpEconomicsTotalsV1Schema,
+    terminalNavBeforeRealizationUsd: MoneyDecimalStringSchema,
+    lpNetIrr: RatioDecimalStringSchema.nullable(),
+    lpNetIrrBasis: LpEconomicsIrrBasisV1Schema,
+    lpNetIrrDiagnostic: XirrDiagnosticSchema,
+    reasons: z.array(LpEconomicsIndicativeReasonV1Schema).min(1),
+  })
+  .strict();
+export type LpEconomicsIndicativeResultV1 = Readonly<
+  z.infer<typeof LpEconomicsIndicativeResultV1Schema>
+>;
+
+export const LpEconomicsUnavailableResultV1Schema = z
+  .object({
+    ...LpEconomicsResultEnvelopeCommonV1,
+    resultStatus: z.literal('unavailable'),
+    reasons: z.array(LpEconomicsRunUnavailabilityReasonV1Schema).min(1),
+  })
+  .strict();
+export type LpEconomicsUnavailableResultV1 = Readonly<
+  z.infer<typeof LpEconomicsUnavailableResultV1Schema>
+>;
+
+/**
+ * D9 envelope. `available` is typed nowhere in V1 (D-11 addendum:
+ * `resultStatus` stays `indicative` end to end until the certification
+ * path lands as its own later act; the schema admits only the
+ * `indicative`/`unavailable` pair, so an `available` payload cannot parse).
+ */
+export const LpEconomicsResultV1Schema = z.discriminatedUnion('resultStatus', [
+  LpEconomicsIndicativeResultV1Schema,
+  LpEconomicsUnavailableResultV1Schema,
+]);
+export type LpEconomicsResultV1 = Readonly<z.infer<typeof LpEconomicsResultV1Schema>>;
+
+// ---------------------------------------------------------------------------
+// Compile-time parity pins against the frozen loop's emitted types
+// (pass-through discipline; type-only imports — the frozen modules are
+// never executed or edited by this contract).
+// ---------------------------------------------------------------------------
+
+type _StaticAssert<T extends true> = T;
+type _LoopQuarterRowParsesVerbatim = _StaticAssert<
+  CashAssemblyQuarterRowV1 extends LpEconomicsQuarterRowV1 ? true : false
+>;
+type _ContractQuarterRowAddsNothing = _StaticAssert<
+  LpEconomicsQuarterRowV1 extends CashAssemblyQuarterRowV1 ? true : false
+>;
+type _EnrichedEventCarriesEveryLoopField = _StaticAssert<
+  LpEconomicsWaterfallEventV1 extends CashAssemblyWaterfallEventV1 ? true : false
+>;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -54,6 +54,7 @@ export * from './schema/investment-ledger';
 export * from './schema/investment-positions';
 export * from './schema/vehicle-financing-participations';
 export * from './schema/internal-analysis';
+export * from './schema/internal-economics';
 export * from './schemas/flags';
 export * from './schemas/reserve-approvals';
 

--- a/shared/schema/financial-facts-snapshots.ts
+++ b/shared/schema/financial-facts-snapshots.ts
@@ -23,6 +23,7 @@ import type {
   FinancialFactsPayloadV1,
   FinancialFactsPayloadV2,
   FinancialFactsPayloadV3,
+  FinancialFactsPayloadV4,
 } from '../contracts/financial-facts-snapshot-v1.contract';
 import { funds } from './fund';
 
@@ -44,7 +45,12 @@ export const financialFactsSnapshots = pgTable(
     snapshotInputHash: text('snapshot_input_hash').notNull(),
     payload: jsonb('payload')
       .notNull()
-      .$type<FinancialFactsPayloadV1 | FinancialFactsPayloadV2 | FinancialFactsPayloadV3>(),
+      .$type<
+        | FinancialFactsPayloadV1
+        | FinancialFactsPayloadV2
+        | FinancialFactsPayloadV3
+        | FinancialFactsPayloadV4
+      >(),
     consumerEvaluations: jsonb('consumer_evaluations')
       .notNull()
       .$type<ConsumerEvaluation[] | ConsumerEvaluationV2[]>(),

--- a/shared/schema/fund.ts
+++ b/shared/schema/fund.ts
@@ -145,7 +145,11 @@ export const calcRuns = pgTable(
 
 // Fund snapshots for CQRS pattern
 // Phase 2A Item 8: runId/configId/configVersion nullable for attribution
-export const NON_TIMELINE_SNAPSHOT_TYPES = ['CURRENT_FORECAST_V2', 'RESERVE_INTELLIGENCE'] as const;
+export const NON_TIMELINE_SNAPSHOT_TYPES = [
+  'CURRENT_FORECAST_V2',
+  'RESERVE_INTELLIGENCE',
+  'INTERNAL_LP_ECONOMICS',
+] as const;
 
 export const fundSnapshots = pgTable(
   'fund_snapshots',
@@ -186,6 +190,10 @@ export const fundSnapshots = pgTable(
       table.type,
       table.createdAt.desc()
     ),
+    /** WP-L3 P-D3: DB-enforced snapshot TYPE for typed composite FKs
+     * (`internal_lp_economics_runs`). Declared as `unique()`, never
+     * `uniqueIndex` — composite FKs must target a constraint (42830). */
+    idTypeUnique: unique('fund_snapshots_id_type_unique').on(table.id, table.type),
     scenarioDedupeIdx: uniqueIndex('fund_snapshots_scenarios_dedup_idx').on(
       table.fundId,
       table.scenarioSetId,

--- a/shared/schema/internal-economics.ts
+++ b/shared/schema/internal-economics.ts
@@ -1,0 +1,360 @@
+import { sql } from 'drizzle-orm';
+import {
+  check,
+  date,
+  decimal,
+  foreignKey,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  serial,
+  text,
+  timestamp,
+  unique,
+  uniqueIndex,
+  varchar,
+} from 'drizzle-orm/pg-core';
+
+import { currentPlanVersions } from './current-plans';
+import { financialFactsSnapshots } from './financial-facts-snapshots';
+import { sourceArtifacts } from './financial-observations';
+import { funds, fundSnapshots } from './fund';
+import { users } from './user';
+import { vehicles } from './vehicles';
+
+/**
+ * Internal LP economics persistence tier (Task 16.3 WP-L3 Phase A; ADR-065
+ * items 2/3/6). Three append-only tables landing dormant ahead of their
+ * services, mirroring how 0038 and 0044 landed:
+ *
+ * - `internal_capital_envelope_versions` — the immutable legal capital
+ *   envelope (Brief 3). Corrections insert child versions via
+ *   `parent_envelope_version_id`; rows are never updated.
+ * - `internal_economics_policy_versions` — immutable authored economics
+ *   policy (D3/P-D6). The terminal pair (`terminal_period_end`,
+ *   `terminal_resolution_methodology_version`) lives in dedicated columns,
+ *   written exclusively through the exported terminal-policy helpers
+ *   (ADR-065 item 8), never raw date arithmetic.
+ * - `internal_lp_economics_runs` — pure lineage (P-D4): FKs + hashes + state,
+ *   never result values. Result payloads persist as `fund_snapshots` rows
+ *   with `type = 'INTERNAL_LP_ECONOMICS'`, pinned here through typed
+ *   composite FKs onto the new `fund_snapshots (id, type)` unique (P-D3).
+ *
+ * Immutability is DB-enforced by migration 0045's BEFORE UPDATE trigger web
+ * (`internal_economics_forbid_update()` on all three tables plus a
+ * type-scoped `fund_snapshots` trigger); triggers are not expressible in
+ * Drizzle, so the migration and manifest 22's `triggerDefinitions` audit are
+ * the authorities there.
+ *
+ * FK posture (L3-Q2 ruling, D8): every basis-version FK is
+ * `ON DELETE restrict`; version-lineage self-FKs (`parent_*_version_id`) are
+ * correction-chain references, not basis pins, and stay NO ACTION. `fund_id`
+ * FKs cascade, matching the 0044 idiom.
+ *
+ * Every composite-FK target is a plain `unique()` constraint, never
+ * `uniqueIndex` (drizzle-kit 42830 lesson). The ONE partial unique —
+ * `internal_lp_economics_runs_result_snapshot_unique`, "exactly one run per
+ * result snapshot" — is correctly a `uniqueIndex().where(...)` because PG
+ * cannot express a partial UNIQUE constraint and nothing FKs it (precedent:
+ * `fund_snapshots_scenarios_dedup_idx`).
+ *
+ * FK names are declared explicitly so the journaled migration (0045) and a
+ * Drizzle push produce byte-identical catalog constraint names (G5).
+ */
+export const internalCapitalEnvelopeVersions = pgTable(
+  'internal_capital_envelope_versions',
+  {
+    id: serial('id').primaryKey(),
+    fundId: integer('fund_id').notNull(),
+    version: integer('version').notNull(),
+    mainFundVehicleId: integer('main_fund_vehicle_id').notNull(),
+    lpCommitmentUsd: decimal('lp_commitment_usd', { precision: 20, scale: 6 }).notNull(),
+    gpCommitmentUsd: decimal('gp_commitment_usd', { precision: 20, scale: 6 }).notNull(),
+    totalCommitmentUsd: decimal('total_commitment_usd', { precision: 20, scale: 6 }).notNull(),
+    currency: varchar('currency', { length: 3 }).notNull().$type<'USD'>(),
+    effectiveAt: timestamp('effective_at', { withTimezone: true }).notNull(),
+    sourceArtifactId: integer('source_artifact_id').notNull(),
+    sourceConfigId: integer('source_config_id').notNull(),
+    sourceConfigVersion: integer('source_config_version').notNull(),
+    sourceConfigHash: varchar('source_config_hash', { length: 64 }).notNull(),
+    attestedBy: integer('attested_by').notNull(),
+    attestedAt: timestamp('attested_at', { withTimezone: true }).notNull(),
+    envelopeHash: varchar('envelope_hash', { length: 64 }).notNull(),
+    parentEnvelopeVersionId: integer('parent_envelope_version_id'),
+    idempotencyKey: varchar('idempotency_key', { length: 128 }).notNull(),
+    requestHash: varchar('request_hash', { length: 64 }).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    fundFk: foreignKey({
+      columns: [table.fundId],
+      foreignColumns: [funds.id],
+      name: 'internal_capital_envelope_versions_fund_id_funds_id_fk',
+    }).onDelete('cascade'),
+    vehicleFundFk: foreignKey({
+      columns: [table.mainFundVehicleId, table.fundId],
+      foreignColumns: [vehicles.id, vehicles.fundId],
+      name: 'internal_capital_envelope_versions_vehicle_fund_fk',
+    }).onDelete('restrict'),
+    sourceArtifactFundFk: foreignKey({
+      columns: [table.sourceArtifactId, table.fundId],
+      foreignColumns: [sourceArtifacts.id, sourceArtifacts.fundId],
+      name: 'internal_capital_envelope_versions_source_artifact_fund_fk',
+    }).onDelete('restrict'),
+    attestedByFk: foreignKey({
+      columns: [table.attestedBy],
+      foreignColumns: [users.id],
+      name: 'internal_capital_envelope_versions_attested_by_fk',
+    }),
+    parentFundFk: foreignKey({
+      columns: [table.parentEnvelopeVersionId, table.fundId],
+      foreignColumns: [table.id, table.fundId],
+      name: 'internal_capital_envelope_versions_parent_fund_fk',
+    }),
+    idFundUnique: unique('internal_capital_envelope_versions_id_fund_unique').on(
+      table.id,
+      table.fundId
+    ),
+    fundVersionUnique: unique('internal_capital_envelope_versions_fund_version_unique').on(
+      table.fundId,
+      table.version
+    ),
+    fundIdempotencyUnique: unique('internal_capital_envelope_versions_fund_idempotency_unique').on(
+      table.fundId,
+      table.idempotencyKey
+    ),
+    currencyCheck: check(
+      'internal_capital_envelope_versions_currency_check',
+      sql`${table.currency} = 'USD'`
+    ),
+    lpNonnegativeCheck: check(
+      'internal_capital_envelope_versions_lp_nonnegative_check',
+      sql`${table.lpCommitmentUsd} >= 0`
+    ),
+    gpNonnegativeCheck: check(
+      'internal_capital_envelope_versions_gp_nonnegative_check',
+      sql`${table.gpCommitmentUsd} >= 0`
+    ),
+    totalPositiveCheck: check(
+      'internal_capital_envelope_versions_total_positive_check',
+      sql`${table.totalCommitmentUsd} > 0`
+    ),
+    /** Brief 3 invariant: exact numeric equality, DB-checkable on `numeric`. */
+    commitmentSumCheck: check(
+      'internal_capital_envelope_versions_commitment_sum_check',
+      sql`${table.lpCommitmentUsd} + ${table.gpCommitmentUsd} = ${table.totalCommitmentUsd}`
+    ),
+    noSelfParentCheck: check(
+      'internal_capital_envelope_versions_no_self_parent_check',
+      sql`${table.parentEnvelopeVersionId} IS NULL OR ${table.parentEnvelopeVersionId} <> ${table.id}`
+    ),
+  })
+);
+
+export const internalEconomicsPolicyVersions = pgTable(
+  'internal_economics_policy_versions',
+  {
+    id: serial('id').primaryKey(),
+    fundId: integer('fund_id').notNull(),
+    version: integer('version').notNull(),
+    /** Contract literal `internal-economics-policy/1.0.0` (P-D6). */
+    policySchemaVersion: text('policy_schema_version').notNull(),
+    policyBody: jsonb('policy_body').notNull().$type<Record<string, unknown>>(),
+    /** D4: persisted provenance; participates in `assumptions_hash`. */
+    normalizationWarnings: jsonb('normalization_warnings').notNull().default([]).$type<unknown[]>(),
+    terminalPeriodEnd: date('terminal_period_end').notNull(),
+    terminalResolutionMethodologyVersion: text('terminal_resolution_methodology_version').notNull(),
+    capitalEnvelopeVersionId: integer('capital_envelope_version_id').notNull(),
+    assumptionsHash: text('assumptions_hash').notNull(),
+    sourceConfigId: integer('source_config_id').notNull(),
+    sourceConfigVersion: integer('source_config_version').notNull(),
+    parentPolicyVersionId: integer('parent_policy_version_id'),
+    createdBy: integer('created_by'),
+    idempotencyKey: varchar('idempotency_key', { length: 128 }).notNull(),
+    requestHash: varchar('request_hash', { length: 64 }).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    fundFk: foreignKey({
+      columns: [table.fundId],
+      foreignColumns: [funds.id],
+      name: 'internal_economics_policy_versions_fund_id_funds_id_fk',
+    }).onDelete('cascade'),
+    envelopeFundFk: foreignKey({
+      columns: [table.capitalEnvelopeVersionId, table.fundId],
+      foreignColumns: [internalCapitalEnvelopeVersions.id, internalCapitalEnvelopeVersions.fundId],
+      name: 'internal_economics_policy_versions_envelope_fund_fk',
+    }).onDelete('restrict'),
+    parentFundFk: foreignKey({
+      columns: [table.parentPolicyVersionId, table.fundId],
+      foreignColumns: [table.id, table.fundId],
+      name: 'internal_economics_policy_versions_parent_fund_fk',
+    }),
+    createdByFk: foreignKey({
+      columns: [table.createdBy],
+      foreignColumns: [users.id],
+      name: 'internal_economics_policy_versions_created_by_fk',
+    }),
+    idFundUnique: unique('internal_economics_policy_versions_id_fund_unique').on(
+      table.id,
+      table.fundId
+    ),
+    fundVersionUnique: unique('internal_economics_policy_versions_fund_version_unique').on(
+      table.fundId,
+      table.version
+    ),
+    fundIdempotencyUnique: unique('internal_economics_policy_versions_fund_idempotency_unique').on(
+      table.fundId,
+      table.idempotencyKey
+    ),
+    noSelfParentCheck: check(
+      'internal_economics_policy_versions_no_self_parent_check',
+      sql`${table.parentPolicyVersionId} IS NULL OR ${table.parentPolicyVersionId} <> ${table.id}`
+    ),
+  })
+);
+
+export const internalLpEconomicsRuns = pgTable(
+  'internal_lp_economics_runs',
+  {
+    id: serial('id').primaryKey(),
+    fundId: integer('fund_id').notNull(),
+    policyVersionId: integer('policy_version_id').notNull(),
+    factsSnapshotId: integer('facts_snapshot_id').notNull(),
+    planVersionId: integer('plan_version_id').notNull(),
+    forecastSnapshotId: integer('forecast_snapshot_id').notNull(),
+    forecastSnapshotType: varchar('forecast_snapshot_type', { length: 50 })
+      .notNull()
+      .$type<'CURRENT_FORECAST_V2'>(),
+    resultSnapshotId: integer('result_snapshot_id'),
+    resultSnapshotType: varchar('result_snapshot_type', {
+      length: 50,
+    }).$type<'INTERNAL_LP_ECONOMICS'>(),
+    runState: varchar('run_state', { length: 16 }).notNull().$type<'completed' | 'failed'>(),
+    /** P-D5: `available` is DB-unreachable until the certification act. */
+    resultStatus: varchar('result_status', { length: 16 }).$type<'indicative' | 'unavailable'>(),
+    failureCode: text('failure_code'),
+    failureContext: jsonb('failure_context').$type<Record<string, unknown>>(),
+    /** Pinned basis clock (D9): evaluation time is basis, never now(). */
+    evaluationClock: timestamp('evaluation_clock', { withTimezone: true }).notNull(),
+    terminalMode: varchar('terminal_mode', { length: 24 })
+      .notNull()
+      .$type<'liquidate_at_horizon' | 'hold_unrealized'>(),
+    engineVersion: text('engine_version').notNull(),
+    methodologyVersion: text('methodology_version').notNull(),
+    inputHash: varchar('input_hash', { length: 64 }).notNull(),
+    resultHash: varchar('result_hash', { length: 64 }),
+    createdBy: integer('created_by'),
+    idempotencyKey: varchar('idempotency_key', { length: 128 }).notNull(),
+    requestHash: varchar('request_hash', { length: 64 }).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    fundFk: foreignKey({
+      columns: [table.fundId],
+      foreignColumns: [funds.id],
+      name: 'internal_lp_economics_runs_fund_id_funds_id_fk',
+    }).onDelete('cascade'),
+    policyVersionFundFk: foreignKey({
+      columns: [table.policyVersionId, table.fundId],
+      foreignColumns: [internalEconomicsPolicyVersions.id, internalEconomicsPolicyVersions.fundId],
+      name: 'internal_lp_economics_runs_policy_version_fund_fk',
+    }).onDelete('restrict'),
+    factsSnapshotFundFk: foreignKey({
+      columns: [table.factsSnapshotId, table.fundId],
+      foreignColumns: [financialFactsSnapshots.id, financialFactsSnapshots.fundId],
+      name: 'internal_lp_economics_runs_facts_snapshot_fund_fk',
+    }).onDelete('restrict'),
+    /** Plain FK by design (G7): `current_plan_versions` has no `(id, fund_id)`
+     * unique; ownership is code-enforced via the existing
+     * `current_plan_version` ownership kind. */
+    planVersionFk: foreignKey({
+      columns: [table.planVersionId],
+      foreignColumns: [currentPlanVersions.id],
+      name: 'internal_lp_economics_runs_plan_version_fk',
+    }).onDelete('restrict'),
+    forecastSnapshotTypeFk: foreignKey({
+      columns: [table.forecastSnapshotId, table.forecastSnapshotType],
+      foreignColumns: [fundSnapshots.id, fundSnapshots.type],
+      name: 'internal_lp_economics_runs_forecast_snapshot_type_fk',
+    }).onDelete('restrict'),
+    resultSnapshotTypeFk: foreignKey({
+      columns: [table.resultSnapshotId, table.resultSnapshotType],
+      foreignColumns: [fundSnapshots.id, fundSnapshots.type],
+      name: 'internal_lp_economics_runs_result_snapshot_type_fk',
+    }).onDelete('restrict'),
+    createdByFk: foreignKey({
+      columns: [table.createdBy],
+      foreignColumns: [users.id],
+      name: 'internal_lp_economics_runs_created_by_fk',
+    }),
+    idFundUnique: unique('internal_lp_economics_runs_id_fund_unique').on(table.id, table.fundId),
+    fundIdempotencyUnique: unique('internal_lp_economics_runs_fund_idempotency_unique').on(
+      table.fundId,
+      table.idempotencyKey
+    ),
+    runStateCheck: check(
+      'internal_lp_economics_runs_run_state_check',
+      sql`${table.runState} IN ('completed','failed')`
+    ),
+    resultStatusCheck: check(
+      'internal_lp_economics_runs_result_status_check',
+      sql`${table.resultStatus} IS NULL OR ${table.resultStatus} IN ('indicative','unavailable')`
+    ),
+    terminalModeCheck: check(
+      'internal_lp_economics_runs_terminal_mode_check',
+      sql`${table.terminalMode} IN ('liquidate_at_horizon','hold_unrealized')`
+    ),
+    forecastSnapshotTypeCheck: check(
+      'internal_lp_economics_runs_forecast_snapshot_type_check',
+      sql`${table.forecastSnapshotType} = 'CURRENT_FORECAST_V2'`
+    ),
+    resultSnapshotTypeCheck: check(
+      'internal_lp_economics_runs_result_snapshot_type_check',
+      sql`${table.resultSnapshotType} IS NULL OR ${table.resultSnapshotType} = 'INTERNAL_LP_ECONOMICS'`
+    ),
+    /** P-D5 state coupling: a completed run is structurally inseparable from
+     * exactly one result snapshot; a failed run structurally cannot carry one. */
+    stateCouplingCheck: check(
+      'internal_lp_economics_runs_state_coupling_check',
+      sql`(
+        ${table.runState} = 'completed'
+        AND ${table.resultSnapshotId} IS NOT NULL
+        AND ${table.resultSnapshotType} IS NOT NULL
+        AND ${table.resultStatus} IS NOT NULL
+        AND ${table.resultHash} IS NOT NULL
+        AND ${table.failureCode} IS NULL
+        AND ${table.failureContext} IS NULL
+      )
+      OR (
+        ${table.runState} = 'failed'
+        AND ${table.resultSnapshotId} IS NULL
+        AND ${table.resultSnapshotType} IS NULL
+        AND ${table.resultStatus} IS NULL
+        AND ${table.resultHash} IS NULL
+        AND ${table.failureCode} IS NOT NULL
+        AND ${table.failureContext} IS NOT NULL
+      )`
+    ),
+    /** P-D4 one-to-one linkage: exactly one run may pin a result snapshot.
+     * Partial uniques cannot be UNIQUE constraints in PG and nothing FKs this
+     * index, so the 42830 unique()-not-uniqueIndex lesson does not apply. */
+    resultSnapshotUnique: uniqueIndex('internal_lp_economics_runs_result_snapshot_unique')
+      .on(table.resultSnapshotId)
+      .where(sql`${table.resultSnapshotId} IS NOT NULL`),
+    fundCreatedIdx: index('idx_internal_lp_economics_runs_fund_created').on(
+      table.fundId,
+      table.createdAt.desc()
+    ),
+  })
+);
+
+export type InternalCapitalEnvelopeVersionRow = typeof internalCapitalEnvelopeVersions.$inferSelect;
+export type InsertInternalCapitalEnvelopeVersionRow =
+  typeof internalCapitalEnvelopeVersions.$inferInsert;
+export type InternalEconomicsPolicyVersionRow = typeof internalEconomicsPolicyVersions.$inferSelect;
+export type InsertInternalEconomicsPolicyVersionRow =
+  typeof internalEconomicsPolicyVersions.$inferInsert;
+export type InternalLpEconomicsRunRow = typeof internalLpEconomicsRuns.$inferSelect;
+export type InsertInternalLpEconomicsRunRow = typeof internalLpEconomicsRuns.$inferInsert;

--- a/tests/config/testcontainers-test-paths.mjs
+++ b/tests/config/testcontainers-test-paths.mjs
@@ -14,4 +14,5 @@ export const TESTCONTAINERS_TEST_PATHS = Object.freeze([
   'tests/integration/scenarios/scenario-case-seed-persistence.test.ts',
   'tests/integration/scenarios/company-scenario-create-persistence.test.ts',
   'tests/integration/internal-analysis/analysis-checkpoint.pg.test.ts',
+  'tests/integration/internal-economics/economics-schema.pg.test.ts',
 ]);

--- a/tests/integration/internal-economics/economics-schema.pg.test.ts
+++ b/tests/integration/internal-economics/economics-schema.pg.test.ts
@@ -1,0 +1,787 @@
+/**
+ * PostgreSQL proofs for migration 0045 (WP-L3 Phase A, T-A1/T-A2/T-A3/T-A5).
+ *
+ * These assert the invariants only a real database can demonstrate:
+ * - T-A1: the migration applies clean through the drizzle migrator (journal
+ *   entry asserted by its OWN tag) and the raw file replays without error.
+ * - T-A2: the internal_economics_forbid_update() trigger web forbids every
+ *   UPDATE on the three new tables, forbids UPDATE of INTERNAL_LP_ECONOMICS
+ *   fund_snapshots rows in BOTH directions (including laundering another
+ *   row INTO the protected type), leaves other snapshot types mutable,
+ *   admits child-version corrections, and `DELETE FROM funds` fails on the
+ *   FK web (L3-Q2: RESTRICT posture, no live fund-deletion cascade exists).
+ * - T-A3: envelope arithmetic CHECKs (exact numeric equality incl. the
+ *   trailing-zeros pre-mortem case), runs state-coupling CHECKs
+ *   ('available' DB-unreachable), typed snapshot composite FKs, wrong-fund
+ *   composite FK rejection, and the one-result-snapshot-per-run partial
+ *   unique.
+ * - T-A5: manifest 22 audits ACTION_REFUSE_FOR_HUMAN before manual
+ *   reconciliation (trigger DDL cannot ride the additive-safe apply path)
+ *   and ACTION_SKIP only once the live tgenabled/pg_get_triggerdef wiring
+ *   and pg_proc function body match the manifest pins exactly.
+ */
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  ACTION_REFUSE_FOR_HUMAN,
+  ACTION_SKIP,
+  auditManifest,
+  loadManifests,
+} from '../../../scripts/reconcile-prod-schema.mjs';
+import {
+  cleanupTestContainers,
+  getPostgresConnectionString,
+  setupTestContainers,
+} from '../../helpers/testcontainers';
+import { runMigrationsWithConnectionString } from '../../helpers/testcontainers-migration';
+
+const skipIfNoDocker =
+  !process.env.TEST_DATABASE_URL && !process.env.CI && process.platform === 'win32';
+const createdDatabases: string[] = [];
+
+const MIGRATION_TAG = '0045_internal_economics_policy_runs';
+const MIGRATION_FILE = path.join(process.cwd(), 'migrations', `${MIGRATION_TAG}.sql`);
+const TRIGGER_NAMES = [
+  'internal_capital_envelope_versions_forbid_update_trigger',
+  'internal_economics_policy_versions_forbid_update_trigger',
+  'internal_lp_economics_runs_forbid_update_trigger',
+  'fund_snapshots_internal_economics_forbid_update_trigger',
+] as const;
+
+let adminPool: Pool | undefined;
+let fundIdCounter = 163_450_000;
+let startedTestContainers = false;
+
+describe.skipIf(skipIfNoDocker)('internal economics schema PostgreSQL proof', () => {
+  beforeAll(async () => {
+    if (!process.env.TEST_DATABASE_URL) {
+      await setupTestContainers();
+      startedTestContainers = true;
+    }
+    adminPool = new Pool({ connectionString: testDatabaseConnectionString(), max: 1 });
+  });
+
+  afterAll(async () => {
+    if (adminPool) {
+      for (const databaseName of createdDatabases.reverse()) {
+        await adminPool.query(`DROP DATABASE IF EXISTS ${quoteIdentifier(databaseName)}`);
+      }
+      await adminPool.end();
+    }
+    if (startedTestContainers) {
+      await cleanupTestContainers();
+    }
+  });
+
+  it('applies migration 0045 through the migrator and replays the raw file (T-A1)', async () => {
+    const { connectionString, state } = await createMigratedDatabase('replay');
+
+    // Journal entry asserted by its OWN tag, never entries.at(-1).
+    expect(state.applied.map((entry) => entry.name)).toContain(MIGRATION_TAG);
+
+    await withPool(connectionString, async (pool) => {
+      // Raw replay: every statement is replay-safe by construction.
+      const migrationSql = await readFile(MIGRATION_FILE, 'utf8');
+      await pool.query(migrationSql);
+
+      const triggers = await pool.query<{ tgname: string; tgenabled: string }>(
+        `
+          SELECT t.tgname, t.tgenabled
+          FROM pg_trigger t
+          JOIN pg_class c ON c.oid = t.tgrelid
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+          WHERE n.nspname = 'public'
+            AND NOT t.tgisinternal
+            AND t.tgname = ANY($1::text[])
+        `,
+        [[...TRIGGER_NAMES]]
+      );
+      expect(triggers.rows.map((row) => row.tgname).sort()).toEqual([...TRIGGER_NAMES].sort());
+      expect(triggers.rows.every((row) => row.tgenabled === 'O')).toBe(true);
+
+      const constraint = await pool.query(
+        `
+          SELECT conname
+          FROM pg_constraint
+          WHERE conname = 'fund_snapshots_id_type_unique'
+            AND conrelid = 'public.fund_snapshots'::regclass
+        `
+      );
+      expect(constraint.rowCount).toBe(1);
+
+      const functions = await pool.query(
+        `
+          SELECT p.proname
+          FROM pg_proc p
+          JOIN pg_namespace n ON n.oid = p.pronamespace
+          WHERE n.nspname = 'public' AND p.proname = 'internal_economics_forbid_update'
+        `
+      );
+      expect(functions.rowCount).toBe(1);
+    });
+  });
+
+  it('forbids every UPDATE on the three tables and type-scoped fund_snapshots rows (T-A2)', async () => {
+    const { connectionString } = await createMigratedDatabase('immutability');
+
+    await withPool(connectionString, async (pool) => {
+      const basis = await seedRunBasis(pool);
+      const envelopeId = basis.envelopeId;
+      const policyId = basis.policyId;
+      const runId = await insertCompletedRun(pool, basis, 'immutable-run');
+
+      await expect(
+        pool.query(
+          `UPDATE internal_capital_envelope_versions SET lp_commitment_usd = '1.000000' WHERE id = $1`,
+          [envelopeId]
+        )
+      ).rejects.toThrow(/immutable_row_update_forbidden: internal_capital_envelope_versions/);
+
+      await expect(
+        pool.query(`UPDATE internal_economics_policy_versions SET version = 99 WHERE id = $1`, [
+          policyId,
+        ])
+      ).rejects.toThrow(/immutable_row_update_forbidden: internal_economics_policy_versions/);
+
+      await expect(
+        pool.query(`UPDATE internal_lp_economics_runs SET result_hash = $2 WHERE id = $1`, [
+          runId,
+          hex64('tampered'),
+        ])
+      ).rejects.toThrow(/immutable_row_update_forbidden: internal_lp_economics_runs/);
+
+      // Type-scoped fund_snapshots trigger: protected row cannot be updated...
+      await expect(
+        pool.query(`UPDATE fund_snapshots SET payload = '{"tampered":true}'::jsonb WHERE id = $1`, [
+          basis.resultSnapshotId,
+        ])
+      ).rejects.toThrow(/immutable_row_update_forbidden: fund_snapshots/);
+
+      // ...a row of another type cannot be laundered INTO the protected type...
+      const reserveSnapshotId = await seedFundSnapshot(pool, basis.fundId, 'RESERVE');
+      await expect(
+        pool.query(`UPDATE fund_snapshots SET type = 'INTERNAL_LP_ECONOMICS' WHERE id = $1`, [
+          reserveSnapshotId,
+        ])
+      ).rejects.toThrow(/immutable_row_update_forbidden: fund_snapshots/);
+
+      // ...and every other snapshot type keeps its existing mutability.
+      await expect(
+        pool.query(`UPDATE fund_snapshots SET payload = '{"updated":true}'::jsonb WHERE id = $1`, [
+          reserveSnapshotId,
+        ])
+      ).resolves.toMatchObject({ rowCount: 1 });
+
+      // Corrections are child-version INSERTs, never UPDATEs.
+      const childEnvelopeId = await insertEnvelope(pool, {
+        fundId: basis.fundId,
+        vehicleId: basis.vehicleId,
+        sourceArtifactId: basis.sourceArtifactId,
+        attestedBy: basis.userId,
+        version: 2,
+        parentEnvelopeVersionId: envelopeId,
+        idempotencyKey: 'envelope-v2',
+      });
+      expect(childEnvelopeId).toEqual(expect.any(Number));
+
+      // L3-Q2 posture: no live fund-deletion cascade exists to preserve; the
+      // FK web (restrict basis pins + fund_snapshots NO ACTION) rejects it.
+      await expect(pool.query(`DELETE FROM funds WHERE id = $1`, [basis.fundId])).rejects.toThrow(
+        /violates foreign key constraint/
+      );
+    });
+  });
+
+  it('enforces envelope arithmetic, state coupling, typed and fund-scoped FKs (T-A3)', async () => {
+    const { connectionString } = await createMigratedDatabase('constraints');
+
+    await withPool(connectionString, async (pool) => {
+      const basis = await seedRunBasis(pool);
+      const envelopeDefaults = {
+        fundId: basis.fundId,
+        vehicleId: basis.vehicleId,
+        sourceArtifactId: basis.sourceArtifactId,
+        attestedBy: basis.userId,
+      };
+
+      // lp + gp = total must hold with exact numeric equality.
+      await expect(
+        insertEnvelope(pool, {
+          ...envelopeDefaults,
+          version: 11,
+          idempotencyKey: 'sum-violation',
+          lp: '600000.000000',
+          gp: '300000.000000',
+          total: '1000000.000000',
+        })
+      ).rejects.toThrow(/internal_capital_envelope_versions_commitment_sum_check/);
+
+      // numeric compares by value, not representation (pre-mortem row):
+      // trailing zeros and mixed scales still satisfy the equality CHECK.
+      await expect(
+        insertEnvelope(pool, {
+          ...envelopeDefaults,
+          version: 12,
+          idempotencyKey: 'trailing-zeros',
+          lp: '600000.10',
+          gp: '399999.9',
+          total: '1000000.000000',
+        })
+      ).resolves.toEqual(expect.any(Number));
+
+      await expect(
+        insertEnvelope(pool, {
+          ...envelopeDefaults,
+          version: 13,
+          idempotencyKey: 'negative-lp',
+          lp: '-1.000000',
+          gp: '1000001.000000',
+          total: '1000000.000000',
+        })
+      ).rejects.toThrow(/internal_capital_envelope_versions_lp_nonnegative_check/);
+
+      await expect(
+        insertEnvelope(pool, {
+          ...envelopeDefaults,
+          version: 14,
+          idempotencyKey: 'negative-gp',
+          lp: '1000001.000000',
+          gp: '-1.000000',
+          total: '1000000.000000',
+        })
+      ).rejects.toThrow(/internal_capital_envelope_versions_gp_nonnegative_check/);
+
+      await expect(
+        insertEnvelope(pool, {
+          ...envelopeDefaults,
+          version: 15,
+          idempotencyKey: 'zero-total',
+          lp: '0.000000',
+          gp: '0.000000',
+          total: '0.000000',
+        })
+      ).rejects.toThrow(/internal_capital_envelope_versions_total_positive_check/);
+
+      await expect(
+        insertEnvelope(pool, {
+          ...envelopeDefaults,
+          version: 16,
+          idempotencyKey: 'non-usd',
+          currency: 'EUR',
+        })
+      ).rejects.toThrow(/internal_capital_envelope_versions_currency_check/);
+
+      await expect(
+        insertEnvelope(pool, {
+          ...envelopeDefaults,
+          version: 17,
+          idempotencyKey: 'self-parent',
+          explicitId: 900001,
+          parentEnvelopeVersionId: 900001,
+        })
+      ).rejects.toThrow(/internal_capital_envelope_versions_no_self_parent_check/);
+
+      // Version sequence uniqueness per fund.
+      await expect(
+        insertEnvelope(pool, {
+          ...envelopeDefaults,
+          version: 1,
+          idempotencyKey: 'duplicate-version',
+        })
+      ).rejects.toThrow(/internal_capital_envelope_versions_fund_version_unique/);
+
+      // State coupling: completed run without a result snapshot is
+      // unrepresentable...
+      await expect(
+        insertRun(pool, basis, {
+          idempotencyKey: 'completed-without-snapshot',
+          runState: 'completed',
+          resultSnapshotId: null,
+          resultSnapshotType: null,
+          resultStatus: 'indicative',
+          resultHash: hex64('r'),
+          failureCode: null,
+          failureContext: null,
+        })
+      ).rejects.toThrow(/internal_lp_economics_runs_state_coupling_check/);
+
+      // ...as is a failed run carrying one...
+      await expect(
+        insertRun(pool, basis, {
+          idempotencyKey: 'failed-with-snapshot',
+          runState: 'failed',
+          resultSnapshotId: basis.resultSnapshotId,
+          resultSnapshotType: 'INTERNAL_LP_ECONOMICS',
+          resultStatus: null,
+          resultHash: null,
+          failureCode: 'CORE_ROW_MAPPING_MISMATCH',
+          failureContext: '{}',
+        })
+      ).rejects.toThrow(/internal_lp_economics_runs_state_coupling_check/);
+
+      // ...and 'available' is DB-unreachable until the certification act.
+      await expect(
+        insertRun(pool, basis, {
+          idempotencyKey: 'available-unreachable',
+          runState: 'completed',
+          resultSnapshotId: basis.resultSnapshotId,
+          resultSnapshotType: 'INTERNAL_LP_ECONOMICS',
+          resultStatus: 'available',
+          resultHash: hex64('r'),
+          failureCode: null,
+          failureContext: null,
+        })
+      ).rejects.toThrow(/internal_lp_economics_runs_result_status_check/);
+
+      // Typed snapshot composite FK: a RESERVE row cannot satisfy the
+      // CURRENT_FORECAST_V2 pin even when the type literal is asserted.
+      const reserveSnapshotId = await seedFundSnapshot(pool, basis.fundId, 'RESERVE');
+      await expect(
+        insertRun(pool, basis, {
+          idempotencyKey: 'wrong-forecast-type',
+          forecastSnapshotId: reserveSnapshotId,
+        })
+      ).rejects.toThrow(/internal_lp_economics_runs_forecast_snapshot_type_fk/);
+
+      // Wrong-type result snapshot pin rejected the same way.
+      await expect(
+        insertRun(pool, basis, {
+          idempotencyKey: 'wrong-result-type',
+          resultSnapshotId: basis.forecastSnapshotId,
+        })
+      ).rejects.toThrow(/internal_lp_economics_runs_result_snapshot_type_fk/);
+
+      // Wrong-fund composite FK: another fund's policy is unrepresentable.
+      const otherBasis = await seedRunBasis(pool);
+      await expect(
+        insertRun(pool, basis, {
+          idempotencyKey: 'cross-fund-policy',
+          policyVersionId: otherBasis.policyId,
+        })
+      ).rejects.toThrow(/internal_lp_economics_runs_policy_version_fund_fk/);
+
+      // Exactly one run may pin a result snapshot (partial unique).
+      await insertCompletedRun(pool, basis, 'first-result-pin');
+      await expect(insertCompletedRun(pool, basis, 'second-result-pin')).rejects.toThrow(
+        /internal_lp_economics_runs_result_snapshot_unique/
+      );
+
+      // Idempotency-key uniqueness is fund-scoped.
+      await expect(
+        insertRun(pool, otherBasis, {
+          idempotencyKey: 'first-result-pin',
+          runState: 'failed',
+          resultSnapshotId: null,
+          resultSnapshotType: null,
+          resultStatus: null,
+          resultHash: null,
+          failureCode: 'CORE_ROW_MAPPING_MISMATCH',
+          failureContext: '{}',
+        })
+      ).resolves.toEqual(expect.any(Number));
+      await expect(
+        insertRun(pool, basis, {
+          idempotencyKey: 'first-result-pin',
+          runState: 'failed',
+          resultSnapshotId: null,
+          resultSnapshotType: null,
+          resultStatus: null,
+          resultHash: null,
+          failureCode: 'CORE_ROW_MAPPING_MISMATCH',
+          failureContext: '{}',
+        })
+      ).rejects.toThrow(/internal_lp_economics_runs_fund_idempotency_unique/);
+    });
+  });
+
+  it('manifest 22 REFUSES-FOR-HUMAN pre-reconciliation and SKIPs once live definitions match (T-A5)', async () => {
+    const { connectionString } = await createMigratedDatabase('manifest', '0044_internal_analysis');
+    const manifests = await loadManifests();
+    const manifest = manifests.find(
+      (candidate: { name: string }) => candidate.name === 'internal-economics-policy-runs'
+    );
+    expect(manifest).toBeDefined();
+
+    await withPool(connectionString, async (pool) => {
+      // Pre-reconciliation: tables and triggers absent -> REFUSE-FOR-HUMAN,
+      // never an automated apply (trigger DDL cannot ride the additive path).
+      const before = await auditManifest(pool, manifest);
+      expect(before.action).toBe(ACTION_REFUSE_FOR_HUMAN);
+      const beforeKinds = before.objects.flatMap((object: { deltas: Array<{ kind: string }> }) =>
+        object.deltas.map((delta) => delta.kind)
+      );
+      expect(beforeKinds).toContain('missing-trigger');
+      expect(beforeKinds).toContain('missing-function');
+
+      // Manual reconciliation: the operator applies the journaled migration.
+      const migrationSql = await readFile(MIGRATION_FILE, 'utf8');
+      await pool.query(migrationSql);
+
+      const after = await auditManifest(pool, manifest);
+      expect(after.action).toBe(ACTION_SKIP);
+      for (const object of after.objects) {
+        expect(object.deltas, `${object.table} deltas`).toEqual([]);
+        expect(object.action, `${object.table} action`).toBe(ACTION_SKIP);
+      }
+
+      // Dropped trigger drift -> REFUSE until restored.
+      await pool.query(
+        `DROP TRIGGER "fund_snapshots_internal_economics_forbid_update_trigger" ON "fund_snapshots"`
+      );
+      const dropped = await auditManifest(pool, manifest);
+      expect(dropped.action).toBe(ACTION_REFUSE_FOR_HUMAN);
+      await pool.query(migrationSql);
+      expect((await auditManifest(pool, manifest)).action).toBe(ACTION_SKIP);
+
+      // Disabled trigger drift -> REFUSE until re-enabled.
+      await pool.query(
+        `ALTER TABLE "internal_lp_economics_runs" DISABLE TRIGGER "internal_lp_economics_runs_forbid_update_trigger"`
+      );
+      const disabled = await auditManifest(pool, manifest);
+      expect(disabled.action).toBe(ACTION_REFUSE_FOR_HUMAN);
+      expect(
+        disabled.objects.some((object: { deltas: Array<{ kind: string }> }) =>
+          object.deltas.some((delta) => delta.kind === 'trigger-disabled')
+        )
+      ).toBe(true);
+      await pool.query(
+        `ALTER TABLE "internal_lp_economics_runs" ENABLE TRIGGER "internal_lp_economics_runs_forbid_update_trigger"`
+      );
+      expect((await auditManifest(pool, manifest)).action).toBe(ACTION_SKIP);
+
+      // Function-body drift -> REFUSE until the pinned body is restored.
+      await pool.query(`
+        CREATE OR REPLACE FUNCTION "internal_economics_forbid_update"() RETURNS trigger
+        LANGUAGE plpgsql
+        AS $$
+        BEGIN
+          RETURN NEW;
+        END;
+        $$;
+      `);
+      const redefined = await auditManifest(pool, manifest);
+      expect(redefined.action).toBe(ACTION_REFUSE_FOR_HUMAN);
+      expect(
+        redefined.objects.some((object: { deltas: Array<{ kind: string }> }) =>
+          object.deltas.some((delta) => delta.kind === 'function-definition-mismatch')
+        )
+      ).toBe(true);
+      await pool.query(migrationSql);
+      expect((await auditManifest(pool, manifest)).action).toBe(ACTION_SKIP);
+    });
+  }, 120_000);
+});
+
+interface RunBasis {
+  fundId: number;
+  userId: number;
+  vehicleId: number;
+  sourceArtifactId: number;
+  factsSnapshotId: number;
+  planVersionId: number;
+  forecastSnapshotId: number;
+  resultSnapshotId: number;
+  envelopeId: number;
+  policyId: number;
+}
+
+interface EnvelopeInput {
+  fundId: number;
+  vehicleId: number;
+  sourceArtifactId: number;
+  attestedBy: number;
+  version: number;
+  idempotencyKey: string;
+  lp?: string;
+  gp?: string;
+  total?: string;
+  currency?: string;
+  parentEnvelopeVersionId?: number;
+  explicitId?: number;
+}
+
+interface RunOverrides {
+  idempotencyKey: string;
+  policyVersionId?: number;
+  forecastSnapshotId?: number;
+  runState?: 'completed' | 'failed';
+  resultSnapshotId?: number | null;
+  resultSnapshotType?: string | null;
+  resultStatus?: string | null;
+  resultHash?: string | null;
+  failureCode?: string | null;
+  failureContext?: string | null;
+}
+
+async function seedRunBasis(pool: Pool): Promise<RunBasis> {
+  const fundId = nextFundId();
+  await pool.query(
+    `
+      INSERT INTO funds (id, name, size, management_fee, carry_percentage, vintage_year)
+      VALUES ($1, $2, 10000000, '0.0200', '0.2000', 2026)
+    `,
+    [fundId, `WP-L3 Fund ${fundId}`]
+  );
+  const userId = await insertedId(
+    pool,
+    `INSERT INTO users (username, password) VALUES ($1, 'x') RETURNING id`,
+    [`wp-l3-${fundId}`]
+  );
+  const vehicleId = await insertedId(
+    pool,
+    `
+      INSERT INTO vehicles (fund_id, vehicle_slug, vehicle_type, name)
+      VALUES ($1, $2, 'main_fund', $3)
+      RETURNING id
+    `,
+    [fundId, `main-${fundId}`, `Main Fund ${fundId}`]
+  );
+  const sourceArtifactId = await insertedId(
+    pool,
+    `
+      INSERT INTO source_artifacts (
+        fund_id, source_type, media_type, byte_count, payload_sha256, payload,
+        purge_after, idempotency_key, request_hash
+      ) VALUES ($1, 'manual', 'text/csv', 1, $2, $3, NOW() + INTERVAL '30 days', $4, $5)
+      RETURNING id
+    `,
+    [fundId, hex64(`artifact-${fundId}`), Buffer.from('a'), `artifact-${fundId}`, hex64('req')]
+  );
+  const factsSnapshotId = await insertedId(
+    pool,
+    `
+      INSERT INTO financial_facts_snapshots (
+        fund_id, policy_version, payload_schema_id, as_of_date, knowledge_cutoff,
+        vehicle_scope, vehicle_ids, selection_set_hash, source_facts_input_hash,
+        snapshot_input_hash, payload, consumer_evaluations, idempotency_key, request_hash
+      ) VALUES (
+        $1, 'financial-facts-policy/1.2.0', 'financial-facts-payload/3', '2026-06-30', NOW(),
+        'fund_all', '[]'::jsonb, $2, $3, $4, '{}'::jsonb, '[]'::jsonb, $5, $6
+      )
+      RETURNING id
+    `,
+    [
+      fundId,
+      hex64(`selection-${fundId}`),
+      hex64(`source-${fundId}`),
+      hex64(`snapshot-${fundId}`),
+      `facts-${fundId}`,
+      hex64(`request-${fundId}`),
+    ]
+  );
+  const planVersionId = await insertedId(
+    pool,
+    `
+      INSERT INTO current_plan_versions (
+        fund_id, version, source_config_id, source_config_version,
+        source_facts_snapshot_id, deployable_capital_usd, plan_transformation_version,
+        allocations, pacing_assumptions, cohort_assumptions, reserve_policy_version,
+        assumptions_hash, idempotency_key, request_hash
+      ) VALUES (
+        $1, 1, 1, 1, $2, '10000000.000000', 'plan-transformation/1.0.0',
+        '[]'::jsonb, '{}'::jsonb, '{}'::jsonb, 'reserve-policy/1.0.0',
+        $3, $4, $5
+      )
+      RETURNING id
+    `,
+    [fundId, factsSnapshotId, hex64(`plan-${fundId}`), `plan-${fundId}`, hex64('plan-req')]
+  );
+  const forecastSnapshotId = await seedFundSnapshot(pool, fundId, 'CURRENT_FORECAST_V2');
+  const resultSnapshotId = await seedFundSnapshot(pool, fundId, 'INTERNAL_LP_ECONOMICS');
+  const envelopeId = await insertEnvelope(pool, {
+    fundId,
+    vehicleId,
+    sourceArtifactId,
+    attestedBy: userId,
+    version: 1,
+    idempotencyKey: 'envelope-v1',
+  });
+  const policyId = await insertedId(
+    pool,
+    `
+      INSERT INTO internal_economics_policy_versions (
+        fund_id, version, policy_schema_version, policy_body, terminal_period_end,
+        terminal_resolution_methodology_version, capital_envelope_version_id,
+        assumptions_hash, source_config_id, source_config_version, created_by,
+        idempotency_key, request_hash
+      ) VALUES (
+        $1, 1, 'internal-economics-policy/1.0.0', '{}'::jsonb, '2036-12-31',
+        'terminal-resolution/1.0.0', $2, $3, 1, 1, $4, $5, $6
+      )
+      RETURNING id
+    `,
+    [fundId, envelopeId, hex64(`assumptions-${fundId}`), userId, 'policy-v1', hex64('policy-req')]
+  );
+
+  return {
+    fundId,
+    userId,
+    vehicleId,
+    sourceArtifactId,
+    factsSnapshotId,
+    planVersionId,
+    forecastSnapshotId,
+    resultSnapshotId,
+    envelopeId,
+    policyId,
+  };
+}
+
+function insertEnvelope(pool: Pool, input: EnvelopeInput): Promise<number> {
+  const columns = input.explicitId === undefined ? '' : 'id,';
+  const idValue = input.explicitId === undefined ? '' : `${input.explicitId},`;
+  return insertedId(
+    pool,
+    `
+      INSERT INTO internal_capital_envelope_versions (
+        ${columns}
+        fund_id, version, main_fund_vehicle_id, lp_commitment_usd, gp_commitment_usd,
+        total_commitment_usd, currency, effective_at, source_artifact_id,
+        source_config_id, source_config_version, source_config_hash, attested_by,
+        attested_at, envelope_hash, parent_envelope_version_id, idempotency_key,
+        request_hash
+      ) VALUES (
+        ${idValue}
+        $1, $2, $3, $4, $5, $6, $7, NOW(), $8, 1, 1, $9, $10, NOW(), $11, $12, $13, $14
+      )
+      RETURNING id
+    `,
+    [
+      input.fundId,
+      input.version,
+      input.vehicleId,
+      input.lp ?? '10000000.000000',
+      input.gp ?? '0.000000',
+      input.total ?? '10000000.000000',
+      input.currency ?? 'USD',
+      input.sourceArtifactId,
+      hex64('config'),
+      input.attestedBy,
+      hex64('envelope'),
+      input.parentEnvelopeVersionId ?? null,
+      input.idempotencyKey,
+      hex64(input.idempotencyKey),
+    ]
+  );
+}
+
+function insertRun(pool: Pool, basis: RunBasis, overrides: RunOverrides): Promise<number> {
+  const runState = overrides.runState ?? 'completed';
+  return insertedId(
+    pool,
+    `
+      INSERT INTO internal_lp_economics_runs (
+        fund_id, policy_version_id, facts_snapshot_id, plan_version_id,
+        forecast_snapshot_id, forecast_snapshot_type, result_snapshot_id,
+        result_snapshot_type, run_state, result_status, failure_code,
+        failure_context, evaluation_clock, terminal_mode, engine_version,
+        methodology_version, input_hash, result_hash, created_by,
+        idempotency_key, request_hash
+      ) VALUES (
+        $1, $2, $3, $4, $5, 'CURRENT_FORECAST_V2', $6, $7, $8, $9, $10,
+        $11::jsonb, NOW(), 'liquidate_at_horizon', 'cash-assembly-period-loop/1.0.0',
+        'lp-economics/1.0.0', $12, $13, $14, $15, $16
+      )
+      RETURNING id
+    `,
+    [
+      basis.fundId,
+      overrides.policyVersionId ?? basis.policyId,
+      basis.factsSnapshotId,
+      basis.planVersionId,
+      overrides.forecastSnapshotId ?? basis.forecastSnapshotId,
+      'resultSnapshotId' in overrides ? overrides.resultSnapshotId : basis.resultSnapshotId,
+      'resultSnapshotType' in overrides ? overrides.resultSnapshotType : 'INTERNAL_LP_ECONOMICS',
+      runState,
+      'resultStatus' in overrides ? overrides.resultStatus : 'indicative',
+      overrides.failureCode ?? null,
+      overrides.failureContext ?? null,
+      hex64(`input-${overrides.idempotencyKey}`),
+      'resultHash' in overrides ? overrides.resultHash : hex64('result'),
+      basis.userId,
+      overrides.idempotencyKey,
+      hex64(overrides.idempotencyKey),
+    ]
+  );
+}
+
+function insertCompletedRun(pool: Pool, basis: RunBasis, idempotencyKey: string): Promise<number> {
+  return insertRun(pool, basis, { idempotencyKey });
+}
+
+async function seedFundSnapshot(pool: Pool, fundId: number, type: string): Promise<number> {
+  return insertedId(
+    pool,
+    `
+      INSERT INTO fund_snapshots (
+        fund_id, type, payload, calc_version, correlation_id, snapshot_time
+      ) VALUES ($1, $2, '{}'::jsonb, 'lp-economics/1.0.0', $3, NOW())
+      RETURNING id
+    `,
+    [fundId, type, `00000000-0000-4000-8000-${String(fundId).padStart(12, '0')}`]
+  );
+}
+
+async function createMigratedDatabase(
+  suffix: string,
+  targetVersion: string = MIGRATION_TAG
+): Promise<{ connectionString: string; state: { applied: Array<{ name: string }> } }> {
+  if (!adminPool) throw new Error('Admin pool not initialized.');
+  const databaseName = `wp_l3_${suffix}_${process.pid}_${Date.now()}`.toLowerCase();
+  createdDatabases.push(databaseName);
+  await adminPool.query(`CREATE DATABASE ${quoteIdentifier(databaseName)}`);
+  const connectionString = databaseConnectionString(databaseName);
+  const state = await runMigrationsWithConnectionString(connectionString, targetVersion);
+  return { connectionString, state };
+}
+
+function databaseConnectionString(databaseName: string): string {
+  const base = new URL(testDatabaseConnectionString());
+  base.pathname = `/${databaseName}`;
+  return base.toString();
+}
+
+function testDatabaseConnectionString(): string {
+  return process.env.TEST_DATABASE_URL ?? getPostgresConnectionString();
+}
+
+async function insertedId(pool: Pool, sql: string, values: unknown[]): Promise<number> {
+  const result = await pool.query(sql, values);
+  const id = result.rows[0]?.id;
+  if (typeof id !== 'number') throw new Error('Expected an inserted id.');
+  return id;
+}
+
+async function withPool<T>(
+  connectionString: string,
+  callback: (pool: Pool) => Promise<T>
+): Promise<T> {
+  const pool = new Pool({ connectionString, max: 4 });
+  try {
+    return await callback(pool);
+  } finally {
+    await pool.end();
+  }
+}
+
+function quoteIdentifier(identifier: string): string {
+  return `"${identifier.replace(/"/g, '""')}"`;
+}
+
+/** Deterministic 64-char hex filler for the provenance hash columns. */
+function hex64(seed: string): string {
+  let value = '';
+  for (let index = 0; value.length < 64; index += 1) {
+    value += (seed.charCodeAt(index % seed.length) + index).toString(16).padStart(2, '0');
+  }
+  return value.slice(0, 64);
+}
+
+function nextFundId(): number {
+  fundIdCounter += 1;
+  return fundIdCounter;
+}

--- a/tests/integration/prod-schema-clone.test.ts
+++ b/tests/integration/prod-schema-clone.test.ts
@@ -150,6 +150,15 @@ const BUSINESS_TIME_COMPARISON_LINEAGE_MANIFEST_TABLES = [
   'calc_runs',
   'fund_scenario_calculation_runs',
 ] as const;
+// M22 (22-internal-economics-policy-runs): WP-L3 Phase A envelope/policy/run
+// tables (journal 0045) plus the shared fund_snapshots entry carrying the new
+// (id, type) unique and the type-scoped immutability trigger pin.
+const INTERNAL_ECONOMICS_MANIFEST_TABLES = [
+  'internal_capital_envelope_versions',
+  'internal_economics_policy_versions',
+  'internal_lp_economics_runs',
+  'fund_snapshots',
+] as const;
 const EXPECTED_PRODUCTION_MANIFEST_NAMES = [
   'M1-cohort',
   'M2-fund-moic',
@@ -172,6 +181,7 @@ const EXPECTED_PRODUCTION_MANIFEST_NAMES = [
   'user-identity-grants-revocation',
   'company-scenario-create-requests',
   'business-time-comparison-lineage',
+  'internal-economics-policy-runs',
 ] as const;
 const SHAPE_ONLY_NOT_JOURNALED = [
   'flag_changes',
@@ -811,6 +821,7 @@ describe.skipIf(skipIfNoDocker)('prod schema synthetic clone', () => {
         ...USER_IDENTITY_GRANTS_REVOCATION_MANIFEST_TABLES,
         ...COMPANY_SCENARIO_CREATE_REQUEST_MANIFEST_TABLES,
         ...BUSINESS_TIME_COMPARISON_LINEAGE_MANIFEST_TABLES,
+        ...INTERNAL_ECONOMICS_MANIFEST_TABLES,
       ])
     );
 

--- a/tests/integration/prod-schema-reconcile-partial-drift.test.ts
+++ b/tests/integration/prod-schema-reconcile-partial-drift.test.ts
@@ -29,6 +29,7 @@ interface ManifestTable {
 
 interface Manifest {
   readonly name: string;
+  readonly order: number;
   readonly sqlFiles: readonly string[];
   readonly expectedTables?: readonly ManifestTable[];
 }
@@ -414,7 +415,9 @@ describe.skipIf(skipIfNoDocker)('prod schema partial-drift reconciliation', () =
           '0035_substrate_shadow_reconciliations'
         );
         isolatedPool = new Pool({ connectionString: databaseConnectionString, max: 1 });
-        const manifests = (await loadManifests()) as Manifest[];
+        const manifests = ((await loadManifests()) as Manifest[]).filter(
+          (manifest) => manifest.order <= 21
+        );
 
         await isolatedPool.query(`
           WITH inserted_fund AS (

--- a/tests/unit/components/fund-results/reserve-intelligence-panel.test.tsx
+++ b/tests/unit/components/fund-results/reserve-intelligence-panel.test.tsx
@@ -180,6 +180,7 @@ describe('ReserveIntelligencePanel', () => {
     'financial-facts-policy/1.0.1' as const,
     'financial-facts-policy/1.1.0' as const,
     'financial-facts-policy/1.2.0' as const,
+    'financial-facts-policy/1.3.0' as const,
   ])('renders policy version %s without assuming details exist', async (policyVersion) => {
     const user = userEvent.setup();
     const run = makeReserveIntelligenceRun(policyVersion);
@@ -197,6 +198,25 @@ describe('ReserveIntelligencePanel', () => {
     } else {
       expect(within(drawer).getByText(/valuation basis.*derived 1/i)).toBeInTheDocument();
     }
+  });
+
+  it('renders the policy 1.3.0 effective-terms and evaluation-detail branches, never the fallback', async () => {
+    const user = userEvent.setup();
+    const run = makeReserveIntelligenceRun('financial-facts-policy/1.3.0');
+    mockHook({ data: { kind: 'ready', run }, error: null, isLoading: false });
+
+    render(<ReserveIntelligencePanel fundId={7} />);
+
+    expect(screen.queryByText(/does not disclose effective-terms refs/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/reserve selection differs from the default/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Open reserve facts for Alpha' }));
+    const drawer = screen.getByRole('dialog', { name: 'Alpha reserve evidence' });
+    expect(within(drawer).getByText(/participation refs: 1/i)).toBeInTheDocument();
+    expect(within(drawer).getByText(/valuation basis.*derived 1/i)).toBeInTheDocument();
+    expect(
+      within(drawer).queryByText(/does not disclose effective-terms refs/i)
+    ).not.toBeInTheDocument();
   });
 
   it('keeps recompute disabled with reason and exposes no apply or write-back action', () => {

--- a/tests/unit/contract/financial-facts-snapshot-v1.contract.test.ts
+++ b/tests/unit/contract/financial-facts-snapshot-v1.contract.test.ts
@@ -7,6 +7,7 @@ import {
   FINANCIAL_FACTS_POLICY_VERSION_1_0_1,
   FINANCIAL_FACTS_POLICY_VERSION_1_1_0,
   FINANCIAL_FACTS_POLICY_VERSION_1_2_0,
+  FINANCIAL_FACTS_POLICY_VERSION_1_3_0,
   FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID_1,
   FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID_2,
   FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID_3,
@@ -215,7 +216,7 @@ describe('canonical decimal-string primitives', () => {
 
 describe('financial facts snapshot hashes', () => {
   it('pins the byte-identical policy 1.0.0 empty selection-set hash under current policy', () => {
-    expect(FINANCIAL_FACTS_POLICY_VERSION).toBe(FINANCIAL_FACTS_POLICY_VERSION_1_2_0);
+    expect(FINANCIAL_FACTS_POLICY_VERSION).toBe(FINANCIAL_FACTS_POLICY_VERSION_1_3_0);
     expect(EMPTY_SELECTION_SET_HASH).toBe(
       'be150e55440d5748ad85f67b7c5a1ace54bbd847880a4ec7aa10bc85b6777230'
     );

--- a/tests/unit/contract/financial-facts-snapshot-v4.contract.test.ts
+++ b/tests/unit/contract/financial-facts-snapshot-v4.contract.test.ts
@@ -1,0 +1,378 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  EMPTY_SELECTION_SET_HASH,
+  EmbeddedFundAccountingStateSnapshotRefV1_1Schema,
+  FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID_2,
+  FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID_3,
+  FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID_4,
+  FINANCIAL_FACTS_POLICY_VERSION_1_0_0,
+  FINANCIAL_FACTS_POLICY_VERSION_1_0_1,
+  FINANCIAL_FACTS_POLICY_VERSION_1_1_0,
+  FINANCIAL_FACTS_POLICY_VERSION_1_2_0,
+  FINANCIAL_FACTS_POLICY_VERSION_1_3_0,
+  FinancialFactsPayloadV1Schema,
+  FinancialFactsPayloadV1_0_0Schema,
+  FinancialFactsPayloadV2Schema,
+  FinancialFactsPayloadV3Schema,
+  FinancialFactsPayloadV4Schema,
+  FinancialFactsSnapshotInputHashPreimageSchema,
+  FinancialFactsSnapshotInputHashPreimageV1_0_0Schema,
+  FinancialFactsSnapshotInputHashPreimageV4Schema,
+  FinancialFactsSnapshotV4Schema,
+  PersistedFinancialFactsSnapshotV1Schema,
+  buildSnapshotInputHash,
+  type FinancialFactsPayloadV1,
+  type FinancialFactsPayloadV2,
+  type FinancialFactsPayloadV3,
+  type FinancialFactsPayloadV4,
+  type FinancialFactsSnapshotInputHashPreimageV4,
+  type FinancialFactsSnapshotV4,
+  type PersistedFinancialFactsSnapshotInputHashPreimage,
+} from '../../../shared/contracts/financial-facts-snapshot-v1.contract';
+import { canonicalSha256 } from '../../../shared/lib/canonical-hash';
+
+/**
+ * Raw (frozen-input-shape) v1.1 embedded ref: no derived
+ * lpUnreturnedContributedCapitalUsd. Uses the G20 founding fixture numbers
+ * (paidIn 10,000,000 / ROC 3,500,000 -> derived 6,500,000).
+ */
+function rawEmbeddedRef() {
+  return {
+    sourceArtifactId: 42,
+    sourceArtifactSha256: 'd'.repeat(64),
+    sourceArtifactCreatedAt: '2026-06-30T20:15:00.000Z',
+    attestedByActorId: 7,
+    observation: {
+      contractVersion: 'fund-accounting-state-observation/1.1.0',
+      cutoverInstant: '2026-06-30T23:59:59.000Z',
+      currency: 'USD',
+      cashBalanceUsd: '1250000.000000',
+      cumulativeLpPaidInUsd: '10000000.000000',
+      cumulativeGpPaidInUsd: '250000.000000',
+      gpUnreturnedContributedCapitalUsd: '150000.000000',
+      lpDistributionsReturnOfCapitalUsd: '3500000.000000',
+      lpDistributionsProfitUsd: '875000.000000',
+      actualLpDistributionsCumulativeUsd: '4375000.000000',
+      gpInvestmentDistributionsPaidUsd: '125000.000000',
+      gpCarryPaidUsd: '200000.000000',
+      accruedPreferredReturnUsd: '325000.000000',
+      accruedPreferredReturnThroughInstant: '2026-06-30T23:59:59.000Z',
+      recallableDistributionsCumulativeUsd: '600000.000000',
+      recallableDistributionsOutstandingUsd: '400000.000000',
+      recycledProceedsCumulativeUsd: '250000.000000',
+      realizedProceedsCumulativeUsd: '5000000.000000',
+      methodologyVersion: 'fund-accounting-methodology/1.0.0',
+    },
+  };
+}
+
+const DERIVED_LP_UNRETURNED = '6500000.000000';
+
+function emptyPayload(): FinancialFactsPayloadV1 {
+  return FinancialFactsPayloadV1Schema.parse({
+    companyActuals: {
+      fundId: 10,
+      asOfDate: '2026-07-21',
+      facts: [],
+      inputHash: 'a'.repeat(64),
+    },
+    sourceObservationIds: [],
+    workingValueSelectionIds: [],
+    participationTermRefs: [],
+    cashFlowSeries: {
+      series: [],
+      totals: {
+        contributions: '0.000000',
+        distributions: '0.000000',
+        recallableDistributions: '0.000000',
+      },
+      warnings: [],
+    },
+    marksSeries: { marks: [], periodNav: [], warnings: [] },
+    vehicleRoster: [],
+  });
+}
+
+function emptyPayloadV2(): FinancialFactsPayloadV2 {
+  return FinancialFactsPayloadV2Schema.parse({
+    ...emptyPayload(),
+    participationTermRefs: [],
+    positionRefs: [],
+    positionComponentRefs: [],
+    ownershipRefs: [],
+    valuationRefs: [],
+    observationRefs: [],
+  });
+}
+
+function emptyPayloadV3(): FinancialFactsPayloadV3 {
+  return FinancialFactsPayloadV3Schema.parse({
+    ...emptyPayloadV2(),
+    openingAccountingState: null,
+  });
+}
+
+function emptyPayloadV4(openingAccountingState: unknown = null): FinancialFactsPayloadV4 {
+  return FinancialFactsPayloadV4Schema.parse({
+    ...emptyPayloadV2(),
+    openingAccountingState,
+  });
+}
+
+function snapshotEnvelopeCommon() {
+  return {
+    fundId: 10,
+    asOfDate: '2026-07-21',
+    knowledgeCutoff: '2026-07-22T01:42:44.186Z',
+    vehicleScope: 'fund_all' as const,
+    vehicleIds: [] as number[],
+    selectionSetHash: EMPTY_SELECTION_SET_HASH,
+    sourceFactsInputHash: 'a'.repeat(64),
+    snapshotInputHash: 'b'.repeat(64),
+    actorId: 7,
+    createdAt: '2026-07-22T01:42:44.186Z',
+  };
+}
+
+function snapshotV4(): FinancialFactsSnapshotV4 {
+  return FinancialFactsSnapshotV4Schema.parse({
+    ...snapshotEnvelopeCommon(),
+    policyVersion: FINANCIAL_FACTS_POLICY_VERSION_1_3_0,
+    payloadSchemaId: FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID_4,
+    consumerEvaluations: [],
+    payload: emptyPayloadV4(rawEmbeddedRef()),
+  });
+}
+
+function preimageV4(): FinancialFactsSnapshotInputHashPreimageV4 {
+  return FinancialFactsSnapshotInputHashPreimageV4Schema.parse({
+    fundId: 10,
+    vehicleIds: [20, 10],
+    asOfDate: '2026-07-21',
+    knowledgeCutoff: '2026-07-22T01:42:44.186Z',
+    policyVersion: FINANCIAL_FACTS_POLICY_VERSION_1_3_0,
+    payloadSchemaId: FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID_4,
+    selectionSetHash: EMPTY_SELECTION_SET_HASH,
+    payload: emptyPayloadV4(rawEmbeddedRef()),
+  });
+}
+
+describe('embedded v1.1 snapshot-ref adapter (T-D1, R10)', () => {
+  it('derives unreturned LP capital from a raw-shape v1.1 ref via the frozen schema', () => {
+    const resolved = EmbeddedFundAccountingStateSnapshotRefV1_1Schema.parse(rawEmbeddedRef());
+
+    expect(resolved.observation.lpUnreturnedContributedCapitalUsd).toBe(DERIVED_LP_UNRETURNED);
+    expect(resolved.observation.contractVersion).toBe('fund-accounting-state-observation/1.1.0');
+  });
+
+  it('is byte-stable when parsing its own resolved output again', () => {
+    const first = EmbeddedFundAccountingStateSnapshotRefV1_1Schema.parse(rawEmbeddedRef());
+    const second = EmbeddedFundAccountingStateSnapshotRefV1_1Schema.parse(first);
+    const roundTripped = EmbeddedFundAccountingStateSnapshotRefV1_1Schema.parse(
+      JSON.parse(JSON.stringify(first)) as unknown
+    );
+
+    expect(JSON.stringify(second)).toBe(JSON.stringify(first));
+    expect(JSON.stringify(roundTripped)).toBe(JSON.stringify(first));
+  });
+
+  it('rejects a supplied derived value that differs from the frozen recomputation', () => {
+    const resolved = EmbeddedFundAccountingStateSnapshotRefV1_1Schema.parse(rawEmbeddedRef());
+    const tampered = {
+      ...resolved,
+      observation: {
+        ...resolved.observation,
+        lpUnreturnedContributedCapitalUsd: '6500000.000001',
+      },
+    };
+    const nonString = {
+      ...resolved,
+      observation: {
+        ...resolved.observation,
+        lpUnreturnedContributedCapitalUsd: 6_500_000,
+      },
+    };
+
+    expect(EmbeddedFundAccountingStateSnapshotRefV1_1Schema.safeParse(tampered).success).toBe(
+      false
+    );
+    expect(EmbeddedFundAccountingStateSnapshotRefV1_1Schema.safeParse(nonString).success).toBe(
+      false
+    );
+  });
+
+  it('delegates every other validation to the frozen v1.1 schema in both shapes', () => {
+    const rawBrokenIdentity = rawEmbeddedRef();
+    rawBrokenIdentity.observation.actualLpDistributionsCumulativeUsd = '4375000.000001';
+
+    const resolved = EmbeddedFundAccountingStateSnapshotRefV1_1Schema.parse(rawEmbeddedRef());
+    const resolvedBrokenIdentity = {
+      ...resolved,
+      observation: {
+        ...resolved.observation,
+        actualLpDistributionsCumulativeUsd: '4375000.000001',
+      },
+    };
+
+    expect(
+      EmbeddedFundAccountingStateSnapshotRefV1_1Schema.safeParse(rawBrokenIdentity).success
+    ).toBe(false);
+    expect(
+      EmbeddedFundAccountingStateSnapshotRefV1_1Schema.safeParse(resolvedBrokenIdentity).success
+    ).toBe(false);
+  });
+});
+
+describe('financial facts payload v4 and persisted cascade (T-D1)', () => {
+  it('parses payload v4 with a null or raw opening state and resolves the derived field', () => {
+    expect(emptyPayloadV4(null).openingAccountingState).toBeNull();
+
+    const resolved = emptyPayloadV4(rawEmbeddedRef());
+    expect(resolved.openingAccountingState?.observation.lpUnreturnedContributedCapitalUsd).toBe(
+      DERIVED_LP_UNRETURNED
+    );
+  });
+
+  it('round-trips payload v4 byte-identically through a reparse of its resolved output', () => {
+    const first = emptyPayloadV4(rawEmbeddedRef());
+    const second = FinancialFactsPayloadV4Schema.parse(JSON.parse(JSON.stringify(first)));
+
+    expect(JSON.stringify(second)).toBe(JSON.stringify(first));
+  });
+
+  it('parses a persisted 1.3.0 snapshot through the union and back from stored bytes', () => {
+    const snapshot = snapshotV4();
+    const viaUnion = PersistedFinancialFactsSnapshotV1Schema.parse(snapshot);
+    const readback = PersistedFinancialFactsSnapshotV1Schema.parse(
+      JSON.parse(JSON.stringify(snapshot)) as unknown
+    );
+
+    expect(snapshot.policyVersion).toBe('financial-facts-policy/1.3.0');
+    expect(snapshot.payloadSchemaId).toBe('financial-facts-payload/4');
+    expect(JSON.stringify(viaUnion)).toBe(JSON.stringify(snapshot));
+    expect(JSON.stringify(readback)).toBe(JSON.stringify(snapshot));
+  });
+
+  it('keeps stored v1/v2/v3 snapshot fixtures parsing through the widened union', () => {
+    const v1 = {
+      ...snapshotEnvelopeCommon(),
+      policyVersion: FINANCIAL_FACTS_POLICY_VERSION_1_0_1,
+      consumerEvaluations: [],
+      payload: emptyPayload(),
+    };
+    const v2 = {
+      ...snapshotEnvelopeCommon(),
+      policyVersion: FINANCIAL_FACTS_POLICY_VERSION_1_1_0,
+      payloadSchemaId: FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID_2,
+      consumerEvaluations: [],
+      payload: emptyPayloadV2(),
+    };
+    const v3 = {
+      ...snapshotEnvelopeCommon(),
+      policyVersion: FINANCIAL_FACTS_POLICY_VERSION_1_2_0,
+      payloadSchemaId: FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID_3,
+      consumerEvaluations: [],
+      payload: emptyPayloadV3(),
+    };
+
+    for (const stored of [v1, v2, v3]) {
+      expect(PersistedFinancialFactsSnapshotV1Schema.parse(stored)).toEqual(stored);
+    }
+  });
+
+  it('rejects cross-version tuples on both discriminant axes', () => {
+    const snapshot = snapshotV4();
+
+    expect(
+      FinancialFactsSnapshotV4Schema.safeParse({
+        ...snapshot,
+        payloadSchemaId: FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID_3,
+      }).success
+    ).toBe(false);
+    expect(
+      PersistedFinancialFactsSnapshotV1Schema.safeParse({
+        ...snapshot,
+        policyVersion: FINANCIAL_FACTS_POLICY_VERSION_1_2_0,
+      }).success
+    ).toBe(false);
+  });
+});
+
+describe('buildSnapshotInputHash totality (T-D3 contract slice, R9)', () => {
+  it('returns, not throws, for a SHA-rich schema-valid V4 preimage carrying the be150 empty-selection hash', () => {
+    expect(EMPTY_SELECTION_SET_HASH.startsWith('be150')).toBe(true);
+
+    const preimage = preimageV4();
+    expect(preimage.selectionSetHash).toBe(EMPTY_SELECTION_SET_HASH);
+
+    let hash = '';
+    expect(() => {
+      hash = buildSnapshotInputHash(preimage);
+    }).not.toThrow();
+    expect(hash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('hashes the explicit schema-parsed preimage object exactly as canonicalSha256', () => {
+    const preimage = preimageV4();
+    const expected = canonicalSha256({
+      fundId: preimage.fundId,
+      vehicleIds: [...preimage.vehicleIds].sort((left, right) => left - right),
+      asOfDate: preimage.asOfDate,
+      knowledgeCutoff: preimage.knowledgeCutoff,
+      policyVersion: preimage.policyVersion,
+      selectionSetHash: preimage.selectionSetHash,
+      payloadSchemaId: preimage.payloadSchemaId,
+      payload: preimage.payload,
+    });
+
+    expect(buildSnapshotInputHash(preimage)).toBe(expected);
+    expect(
+      buildSnapshotInputHash(FinancialFactsSnapshotInputHashPreimageV4Schema.parse(preimage))
+    ).toBe(expected);
+  });
+
+  it('dispatches V4 preimages to the V4 member, never silently to V3', () => {
+    const preimage = preimageV4();
+    const nullOpeningState = FinancialFactsSnapshotInputHashPreimageV4Schema.parse({
+      ...preimage,
+      payload: emptyPayloadV4(null),
+    });
+
+    expect(buildSnapshotInputHash(nullOpeningState)).not.toBe(buildSnapshotInputHash(preimage));
+    expect(() =>
+      buildSnapshotInputHash({
+        ...preimage,
+        policyVersion: FINANCIAL_FACTS_POLICY_VERSION_1_2_0,
+        payloadSchemaId: FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID_3,
+      } as PersistedFinancialFactsSnapshotInputHashPreimage)
+    ).toThrow();
+  });
+
+  it('keeps the pinned legacy hash fixtures byte-identical after the totality change', () => {
+    const identity = {
+      fundId: 10,
+      vehicleIds: [20, 10],
+      asOfDate: '2026-07-21',
+      knowledgeCutoff: '2026-07-22T01:42:44.186Z',
+      selectionSetHash: 'a'.repeat(64),
+    };
+    const legacy = FinancialFactsSnapshotInputHashPreimageV1_0_0Schema.parse({
+      ...identity,
+      policyVersion: FINANCIAL_FACTS_POLICY_VERSION_1_0_0,
+      payload: FinancialFactsPayloadV1_0_0Schema.parse(emptyPayload()),
+    });
+    const current = FinancialFactsSnapshotInputHashPreimageSchema.parse({
+      ...identity,
+      policyVersion: FINANCIAL_FACTS_POLICY_VERSION_1_0_1,
+      payload: emptyPayload(),
+    });
+
+    expect(buildSnapshotInputHash(legacy)).toBe(
+      'ea4cc7f7765abc2240d72df3a8cb7affde14fa235219fd3705fdad153b63c4ed'
+    );
+    expect(buildSnapshotInputHash(current)).toBe(
+      '9a51f1cbc1beba5aa659c5bd2817e8ea908508d560ce2f92728ecac13f502e62'
+    );
+  });
+});

--- a/tests/unit/contract/internal-economics/capital-envelope-v1.contract.test.ts
+++ b/tests/unit/contract/internal-economics/capital-envelope-v1.contract.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CAPITAL_ENVELOPE_CONTRACT_VERSION,
+  CAPITAL_ENVELOPE_SEED_REFUSAL_CODES_V1,
+  CapitalEnvelopeCreateRequestV1Schema,
+  CapitalEnvelopeHashPreimageV1Schema,
+  CapitalEnvelopeSeedRefusalCodeV1Schema,
+  buildCapitalEnvelopeHashPreimageV1,
+  type CapitalEnvelopeCreateRequestV1,
+} from '../../../../shared/contracts/internal-economics/capital-envelope-v1.contract';
+
+const validRequest = {
+  mainFundVehicleId: 7,
+  lpCommitmentUsd: '95000000.000000',
+  gpCommitmentUsd: '5000000.000000',
+  totalCommitmentUsd: '100000000.000000',
+  currency: 'USD',
+  effectiveAt: '2026-01-01T00:00:00.000Z',
+  sourceArtifactId: 41,
+  sourceConfigId: 3,
+  sourceConfigVersion: 5,
+  sourceConfigHash: 'ab'.repeat(32),
+  attestedBy: 9,
+  attestedAt: '2026-01-02T12:00:00.000Z',
+} satisfies CapitalEnvelopeCreateRequestV1;
+
+function issueMessages(candidate: unknown): string[] {
+  const parsed = CapitalEnvelopeCreateRequestV1Schema.safeParse(candidate);
+  if (parsed.success) return [];
+  return parsed.error.issues.map((issue) => issue.message);
+}
+
+describe('capital-envelope/1.0.0 contract', () => {
+  it('pins the contract version literal', () => {
+    expect(CAPITAL_ENVELOPE_CONTRACT_VERSION).toBe('capital-envelope/1.0.0');
+  });
+
+  it('round-trips a valid Brief 3 creation request', () => {
+    const parsed = CapitalEnvelopeCreateRequestV1Schema.parse(validRequest);
+    expect(parsed).toEqual(validRequest);
+  });
+
+  it('rejects unknown keys (strict request shape)', () => {
+    expect(
+      CapitalEnvelopeCreateRequestV1Schema.safeParse({ ...validRequest, extra: 'x' }).success
+    ).toBe(false);
+  });
+
+  it('rejects non-canonical commitment strings (money is 6dp canonical)', () => {
+    expect(
+      CapitalEnvelopeCreateRequestV1Schema.safeParse({
+        ...validRequest,
+        lpCommitmentUsd: '95000000.00',
+      }).success
+    ).toBe(false);
+    expect(
+      CapitalEnvelopeCreateRequestV1Schema.safeParse({
+        ...validRequest,
+        lpCommitmentUsd: 95000000,
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects a non-USD currency', () => {
+    expect(
+      CapitalEnvelopeCreateRequestV1Schema.safeParse({ ...validRequest, currency: 'EUR' }).success
+    ).toBe(false);
+  });
+
+  it('flags a negative LP commitment with its refusal code', () => {
+    expect(
+      issueMessages({
+        ...validRequest,
+        lpCommitmentUsd: '-1.000000',
+        totalCommitmentUsd: '4999999.000000',
+      })
+    ).toContain('ENVELOPE_LP_COMMITMENT_NEGATIVE');
+  });
+
+  it('flags a negative GP commitment with its refusal code', () => {
+    expect(
+      issueMessages({
+        ...validRequest,
+        gpCommitmentUsd: '-0.000001',
+        totalCommitmentUsd: '94999999.999999',
+      })
+    ).toContain('ENVELOPE_GP_COMMITMENT_NEGATIVE');
+  });
+
+  it('flags a non-positive total commitment with its refusal code', () => {
+    expect(
+      issueMessages({
+        ...validRequest,
+        lpCommitmentUsd: '0.000000',
+        gpCommitmentUsd: '0.000000',
+        totalCommitmentUsd: '0.000000',
+      })
+    ).toContain('ENVELOPE_TOTAL_COMMITMENT_NOT_POSITIVE');
+  });
+
+  it('flags an exact-sum violation with its refusal code', () => {
+    expect(
+      issueMessages({
+        ...validRequest,
+        totalCommitmentUsd: '100000000.000001',
+      })
+    ).toContain('ENVELOPE_COMMITMENT_SUM_MISMATCH');
+  });
+
+  it('accepts an exact lp + gp = total at full 6dp precision', () => {
+    expect(
+      CapitalEnvelopeCreateRequestV1Schema.safeParse({
+        ...validRequest,
+        lpCommitmentUsd: '0.000001',
+        gpCommitmentUsd: '0.000002',
+        totalCommitmentUsd: '0.000003',
+      }).success
+    ).toBe(true);
+  });
+
+  it('carries the complete Brief 3 seed-refusal registry', () => {
+    expect(CAPITAL_ENVELOPE_SEED_REFUSAL_CODES_V1).toEqual([
+      'ENVELOPE_LP_COMMITMENT_NEGATIVE',
+      'ENVELOPE_GP_COMMITMENT_NEGATIVE',
+      'ENVELOPE_TOTAL_COMMITMENT_NOT_POSITIVE',
+      'ENVELOPE_COMMITMENT_SUM_MISMATCH',
+      'ENVELOPE_CURRENCY_UNSUPPORTED',
+      'ENVELOPE_VEHICLE_NOT_IN_FUND',
+      'ENVELOPE_VEHICLE_NOT_MAIN_FUND',
+    ]);
+    expect(CapitalEnvelopeSeedRefusalCodeV1Schema.options).toEqual(
+      CAPITAL_ENVELOPE_SEED_REFUSAL_CODES_V1
+    );
+  });
+
+  it('builds the envelope hash preimage from fundId + contract version + content fields only', () => {
+    const preimage = buildCapitalEnvelopeHashPreimageV1({ fundId: 12, request: validRequest });
+
+    expect(preimage).toEqual({
+      contractVersion: 'capital-envelope/1.0.0',
+      fundId: 12,
+      ...validRequest,
+    });
+    expect(CapitalEnvelopeHashPreimageV1Schema.parse(preimage)).toEqual(preimage);
+  });
+
+  it('keeps lineage fields out of the hash preimage shape', () => {
+    expect(
+      CapitalEnvelopeHashPreimageV1Schema.safeParse({
+        contractVersion: 'capital-envelope/1.0.0',
+        fundId: 12,
+        ...validRequest,
+        idempotencyKey: 'k',
+      }).success
+    ).toBe(false);
+    expect(
+      CapitalEnvelopeHashPreimageV1Schema.safeParse({
+        contractVersion: 'capital-envelope/1.0.0',
+        fundId: 12,
+        ...validRequest,
+        parentEnvelopeVersionId: 4,
+      }).success
+    ).toBe(false);
+  });
+});

--- a/tests/unit/contract/internal-economics/economics-policy-v1.contract.test.ts
+++ b/tests/unit/contract/internal-economics/economics-policy-v1.contract.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ECONOMICS_POLICY_CONTRACT_VERSION,
+  ECONOMICS_POLICY_SEED_REFUSAL_CODES_V1,
+  EconomicsPolicyBodyV1Schema,
+  EconomicsPolicyCreateRequestV1Schema,
+  EconomicsPolicyNormalizationWarningV1Schema,
+  EconomicsPolicySeedRefusalCodeV1Schema,
+  type EconomicsPolicyBodyV1,
+} from '../../../../shared/contracts/internal-economics/economics-policy-v1.contract';
+
+const validBody = {
+  waterfallTemplate: 'deal_by_deal',
+  carryPct: 0.2,
+  hurdle: { basis: 'none' },
+  managementFeesUsd: '0.000000',
+  fundExpenses: [],
+  cashBufferQuarters: 2,
+  terminalMode: 'liquidate_at_horizon',
+  termStartDate: '2020-01-15',
+  fundLifeYears: '10',
+} satisfies EconomicsPolicyBodyV1;
+
+describe('internal-economics-policy/1.0.0 contract', () => {
+  it('pins the contract version literal', () => {
+    expect(ECONOMICS_POLICY_CONTRACT_VERSION).toBe('internal-economics-policy/1.0.0');
+  });
+
+  it('round-trips a valid V1 policy body', () => {
+    expect(EconomicsPolicyBodyV1Schema.parse(validBody)).toEqual(validBody);
+  });
+
+  it('admits only the deal_by_deal template (no whole_fund stub)', () => {
+    expect(
+      EconomicsPolicyBodyV1Schema.safeParse({ ...validBody, waterfallTemplate: 'whole_fund' })
+        .success
+    ).toBe(false);
+    expect(
+      EconomicsPolicyBodyV1Schema.safeParse({ ...validBody, waterfallTemplate: 'american' }).success
+    ).toBe(false);
+  });
+
+  it('bounds carryPct to a finite [0, 1] number', () => {
+    expect(EconomicsPolicyBodyV1Schema.safeParse({ ...validBody, carryPct: 1 }).success).toBe(true);
+    expect(EconomicsPolicyBodyV1Schema.safeParse({ ...validBody, carryPct: 0 }).success).toBe(true);
+    for (const carryPct of [-0.1, 1.2, Number.POSITIVE_INFINITY, Number.NaN]) {
+      expect(EconomicsPolicyBodyV1Schema.safeParse({ ...validBody, carryPct }).success).toBe(false);
+    }
+  });
+
+  it("admits only hurdle basis 'none' in schema V1", () => {
+    expect(
+      EconomicsPolicyBodyV1Schema.safeParse({ ...validBody, hurdle: { basis: 'compounded' } })
+        .success
+    ).toBe(false);
+    expect(
+      EconomicsPolicyBodyV1Schema.safeParse({
+        ...validBody,
+        hurdle: { basis: 'none', rate: 0.08 },
+      }).success
+    ).toBe(false);
+  });
+
+  it('requires explicit zero fees and empty expenses', () => {
+    expect(
+      EconomicsPolicyBodyV1Schema.safeParse({ ...validBody, managementFeesUsd: '1.000000' }).success
+    ).toBe(false);
+    expect(
+      EconomicsPolicyBodyV1Schema.safeParse({ ...validBody, managementFeesUsd: '0.00' }).success
+    ).toBe(false);
+    expect(
+      EconomicsPolicyBodyV1Schema.safeParse({ ...validBody, fundExpenses: ['0.000000'] }).success
+    ).toBe(false);
+  });
+
+  it('requires a nonnegative integer cash buffer', () => {
+    expect(
+      EconomicsPolicyBodyV1Schema.safeParse({ ...validBody, cashBufferQuarters: 0 }).success
+    ).toBe(true);
+    expect(
+      EconomicsPolicyBodyV1Schema.safeParse({ ...validBody, cashBufferQuarters: -1 }).success
+    ).toBe(false);
+    expect(
+      EconomicsPolicyBodyV1Schema.safeParse({ ...validBody, cashBufferQuarters: 1.5 }).success
+    ).toBe(false);
+  });
+
+  it('accepts both terminal modes and rejects others', () => {
+    expect(
+      EconomicsPolicyBodyV1Schema.safeParse({ ...validBody, terminalMode: 'hold_unrealized' })
+        .success
+    ).toBe(true);
+    expect(
+      EconomicsPolicyBodyV1Schema.safeParse({ ...validBody, terminalMode: 'liquidate' }).success
+    ).toBe(false);
+  });
+
+  it('validates term anchor inputs (calendar date + positive decimal-string years)', () => {
+    expect(
+      EconomicsPolicyBodyV1Schema.safeParse({ ...validBody, termStartDate: '2020-13-01' }).success
+    ).toBe(false);
+    expect(
+      EconomicsPolicyBodyV1Schema.safeParse({ ...validBody, fundLifeYears: '10.25' }).success
+    ).toBe(true);
+    for (const fundLifeYears of ['0', '-10', 'ten', '1e1']) {
+      expect(EconomicsPolicyBodyV1Schema.safeParse({ ...validBody, fundLifeYears }).success).toBe(
+        false
+      );
+    }
+  });
+
+  it('rejects unknown body keys (strict)', () => {
+    expect(EconomicsPolicyBodyV1Schema.safeParse({ ...validBody, hurdleRate: 0.08 }).success).toBe(
+      false
+    );
+  });
+
+  it('round-trips a creation request pinning envelope + source config lineage', () => {
+    const request = {
+      capitalEnvelopeVersionId: 3,
+      sourceConfigId: 1,
+      sourceConfigVersion: 2,
+      body: validBody,
+    };
+    expect(EconomicsPolicyCreateRequestV1Schema.parse(request)).toEqual(request);
+    expect(
+      EconomicsPolicyCreateRequestV1Schema.safeParse({ ...request, capitalEnvelopeVersionId: 0 })
+        .success
+    ).toBe(false);
+    expect(
+      EconomicsPolicyCreateRequestV1Schema.safeParse({ ...request, extra: true }).success
+    ).toBe(false);
+  });
+
+  it('carries the complete section 5 seed-refusal registry in ratified order', () => {
+    expect(ECONOMICS_POLICY_SEED_REFUSAL_CODES_V1).toEqual([
+      'CATCH_UP_UNSUPPORTED',
+      'CLAWBACK_UNSUPPORTED',
+      'ESCROW_UNSUPPORTED',
+      'RECYCLING_UNSUPPORTED',
+      'HURDLE_BASIS_UNSUPPORTED',
+      'FUND_LIFE_ABSENT',
+      'FUND_LIFE_GRID_UNREPRESENTABLE',
+      'FUND_TERM_START_ABSENT',
+      'EVERGREEN_STATUS_ABSENT',
+      'EVERGREEN_UNSUPPORTED',
+      'CREDIT_FACILITY_UNSUPPORTED',
+    ]);
+    expect(EconomicsPolicySeedRefusalCodeV1Schema.options).toEqual(
+      ECONOMICS_POLICY_SEED_REFUSAL_CODES_V1
+    );
+  });
+
+  it('round-trips a normalization warning with explicit/defaulted provenance', () => {
+    const warning = {
+      parameter: 'clawbackEnabled',
+      provenance: 'defaulted',
+      resolvedValue: 'true',
+      detail: 'defaultWaterfall seeds clawbackEnabled into every defaulted config.',
+    };
+    expect(EconomicsPolicyNormalizationWarningV1Schema.parse(warning)).toEqual(warning);
+
+    expect(
+      EconomicsPolicyNormalizationWarningV1Schema.safeParse({
+        ...warning,
+        provenance: 'implicit',
+      }).success
+    ).toBe(false);
+    expect(
+      EconomicsPolicyNormalizationWarningV1Schema.safeParse({ ...warning, detail: '' }).success
+    ).toBe(false);
+    expect(
+      EconomicsPolicyNormalizationWarningV1Schema.safeParse({ ...warning, extra: 1 }).success
+    ).toBe(false);
+  });
+});

--- a/tests/unit/contract/internal-economics/lp-economics-run-v1.contract.test.ts
+++ b/tests/unit/contract/internal-economics/lp-economics-run-v1.contract.test.ts
@@ -1,0 +1,518 @@
+import { describe, expect, it } from 'vitest';
+
+import { canonicalSha256 } from '../../../../shared/lib/canonical-hash';
+import type { CashAssemblyQuarterRowV1 } from '../../../../shared/lib/internal-economics/cash-assembly-types-v1';
+import type { CashAssemblyWaterfallEventV1 } from '../../../../shared/lib/internal-economics/cash-assembly-period-loop-v1';
+import {
+  LP_ECONOMICS_RUN_CONTRACT_VERSION,
+  LP_ECONOMICS_RUN_UNAVAILABILITY_REASON_CODES_V1,
+  LP_ECONOMICS_INDICATIVE_REASON_CODES_V1,
+  OPENING_STATE_CONTRACT_V1_INELIGIBLE_DETAIL,
+  LpEconomicsRunRequestV1Schema,
+  LpEconomicsRunIdempotencyPreimageV1Schema,
+  LpEconomicsRunUnavailabilityReasonCodeV1Schema,
+  LpEconomicsIndicativeReasonCodeV1Schema,
+  LpEconomicsRunUnavailabilityReasonV1Schema,
+  LpEconomicsIndicativeReasonV1Schema,
+  LpEconomicsQuarterRowV1Schema,
+  LpEconomicsWaterfallEventV1Schema,
+  LpEconomicsTotalsV1Schema,
+  LpEconomicsResultV1Schema,
+  buildLpEconomicsRunIdempotencyPreimageV1,
+  buildLpEconomicsEventIdV1,
+  sortAndDedupeLpEconomicsReasonsV1,
+  type LpEconomicsRunRequestV1,
+} from '../../../../shared/contracts/internal-economics/lp-economics-run-v1.contract';
+
+const validRequest = {
+  policyVersionId: 11,
+  factsSnapshotId: 22,
+  planVersionId: 33,
+  forecastSnapshotId: 44,
+  terminalMode: 'liquidate_at_horizon',
+  clock: '2026-06-30T23:59:59.000Z',
+} satisfies LpEconomicsRunRequestV1;
+
+// Hand-mirrored from the frozen loop's emitted shapes; the strict parses below
+// prove exact field parity at runtime (extra or missing fields fail).
+const quarterRow = {
+  periodStart: '2026-07-01',
+  periodEnd: '2026-09-30',
+  source: 'projected',
+  openingCashUsd: '1000000.000000',
+  lpCapitalCallUsd: '500000.000000',
+  gpCommitmentCallUsd: '0.000000',
+  portfolioDeploymentUsd: '400000.000000',
+  managementFeesUsd: '0.000000',
+  fundExpensesUsd: '0.000000',
+  grossRealizedProceedsUsd: '250000.000000',
+  lpDistributionUsd: '200000.000000',
+  gpInvestmentDistributionUsd: '0.000000',
+  gpCarryDistributedUsd: '50000.000000',
+  endingCashUsd: '1100000.000000',
+  grossNavUsd: '9000000.000000',
+  lpNetNavUsd: '7200000.000000',
+  cumulativeLpPaidInUsd: '10500000.000000',
+  cumulativeLpDistributedUsd: '4575000.000000',
+  dpi: '0.435714285714',
+  rvpi: '0.685714285714',
+  tvpi: '1.121428571428',
+} satisfies CashAssemblyQuarterRowV1;
+
+const loopEvent = {
+  periodEnd: '2026-09-30',
+  sourceId: 'forecast|2026-09-30|distribution',
+  grossDistributionUsd: '250000.000000',
+  lpCapitalReturnUsd: '150000.000000',
+  lpProfitUsd: '50000.000000',
+  gpInvestmentDistributionUsd: '0.000000',
+  gpCarryUsd: '50000.000000',
+} satisfies CashAssemblyWaterfallEventV1;
+
+const enrichedEvent = {
+  ...loopEvent,
+  eventSequence: 0,
+  eventId: buildLpEconomicsEventIdV1({
+    sourceId: loopEvent.sourceId,
+    periodEnd: loopEvent.periodEnd,
+    eventSequence: 0,
+  }),
+  sourceRefs: [{ sourceId: loopEvent.sourceId }],
+  eventKind: 'forecast_quarterly_distribution',
+};
+
+const totals = {
+  lpCapitalCallUsd: '500000.000000',
+  gpCommitmentCallUsd: '0.000000',
+  portfolioDeploymentUsd: '400000.000000',
+  managementFeesUsd: '0.000000',
+  fundExpensesUsd: '0.000000',
+  grossRealizedProceedsUsd: '250000.000000',
+  lpCapitalReturnUsd: '150000.000000',
+  lpProfitUsd: '50000.000000',
+  lpDistributionUsd: '200000.000000',
+  gpInvestmentDistributionUsd: '0.000000',
+  gpCarryDistributedUsd: '50000.000000',
+  endingCashUsd: '1100000.000000',
+  grossNavUsd: '9000000.000000',
+  lpNetNavUsd: '7200000.000000',
+  dpi: '0.435714285714',
+  rvpi: '0.685714285714',
+  tvpi: '1.121428571428',
+};
+
+const envelopeCommon = {
+  waterfallTemplate: 'deal_by_deal',
+  clock: '2026-06-30T23:59:59.000Z',
+  currency: 'USD',
+  perspective: 'lp_net',
+  precisionMode: 'decimal_native_with_float64_xirr',
+} as const;
+
+const indicativeResult = {
+  ...envelopeCommon,
+  resultStatus: 'indicative',
+  quarters: [quarterRow],
+  waterfallEvents: [enrichedEvent],
+  totals,
+  terminalNavBeforeRealizationUsd: '9000000.000000',
+  lpNetIrr: '0.142500000000',
+  lpNetIrrBasis: 'cash_plus_terminal_nav',
+  lpNetIrrDiagnostic: {
+    convergence: 'converged',
+    iterations: 12,
+    method: 'newton',
+    boundHit: null,
+    failureReason: null,
+  },
+  reasons: [{ code: 'DECIMAL_CORE_UNCERTIFIED' }, { code: 'LP_NET_NAV_FLAT_SHARE_APPROXIMATION' }],
+};
+
+const unavailableResult = {
+  ...envelopeCommon,
+  resultStatus: 'unavailable',
+  reasons: [{ code: 'MAIN_FUND_VEHICLE_ABSENT', detail: 'no main_fund vehicle on roster' }],
+};
+
+describe('lp-economics run contract (D8/D9)', () => {
+  it('pins the contract version literal', () => {
+    expect(LP_ECONOMICS_RUN_CONTRACT_VERSION).toBe('lp-economics/1.0.0');
+  });
+
+  it('round-trips a run request of explicit basis IDs only', () => {
+    expect(LpEconomicsRunRequestV1Schema.parse(validRequest)).toEqual(validRequest);
+  });
+
+  it('rejects requests missing any basis ID (no latest-resolution fallback shape)', () => {
+    for (const key of [
+      'policyVersionId',
+      'factsSnapshotId',
+      'planVersionId',
+      'forecastSnapshotId',
+      'terminalMode',
+      'clock',
+    ] as const) {
+      const { [key]: _omitted, ...rest } = validRequest;
+      expect(LpEconomicsRunRequestV1Schema.safeParse(rest).success).toBe(false);
+    }
+  });
+
+  it('rejects non-positive-integer basis IDs and unknown keys', () => {
+    expect(
+      LpEconomicsRunRequestV1Schema.safeParse({ ...validRequest, policyVersionId: 0 }).success
+    ).toBe(false);
+    expect(
+      LpEconomicsRunRequestV1Schema.safeParse({ ...validRequest, factsSnapshotId: 2.5 }).success
+    ).toBe(false);
+    expect(LpEconomicsRunRequestV1Schema.safeParse({ ...validRequest, latest: true }).success).toBe(
+      false
+    );
+  });
+
+  it('builds the P-D8 idempotency preimage (fundId + contractVersion + body + engine/methodology versions)', () => {
+    const preimage = buildLpEconomicsRunIdempotencyPreimageV1({
+      fundId: 5,
+      request: validRequest,
+      engineVersion: 'internal-economics-engine/1.0.0',
+      methodologyVersion: 'internal-economics-cash-assembly/1.0.0',
+    });
+
+    expect(preimage).toEqual({
+      fundId: 5,
+      contractVersion: 'lp-economics/1.0.0',
+      request: validRequest,
+      engineVersion: 'internal-economics-engine/1.0.0',
+      methodologyVersion: 'internal-economics-cash-assembly/1.0.0',
+    });
+    expect(LpEconomicsRunIdempotencyPreimageV1Schema.parse(preimage)).toEqual(preimage);
+
+    // An engine/methodology bump changes the canonical preimage identity
+    // (T-C10's changed-preimage 409 depends on this).
+    const bumped = buildLpEconomicsRunIdempotencyPreimageV1({
+      fundId: 5,
+      request: validRequest,
+      engineVersion: 'internal-economics-engine/1.1.0',
+      methodologyVersion: 'internal-economics-cash-assembly/1.0.0',
+    });
+    expect(canonicalSha256(bumped)).not.toBe(canonicalSha256(preimage));
+  });
+
+  it('carries the complete run-unavailability registry in section 8 order', () => {
+    expect(LP_ECONOMICS_RUN_UNAVAILABILITY_REASON_CODES_V1).toEqual([
+      'MAIN_FUND_VEHICLE_ABSENT',
+      'MAIN_FUND_SCOPED_FORECAST_UNAVAILABLE',
+      'MAIN_FUND_COMMITMENT_ABSENT',
+      'MAIN_FUND_CURRENCY_UNSUPPORTED',
+      'CONFIG_LINEAGE_MISMATCH',
+      'FORECAST_UNAVAILABLE',
+      'FORECAST_FAILED',
+      'FORECAST_HELD_UNSUPPORTED',
+      'FACTS_ECONOMICS_EVALUATION_BLOCKED',
+      'OPENING_CASH_UNAVAILABLE',
+      'OPENING_STATE_CONTRACT_INELIGIBLE',
+      'OPENING_STATE_INELIGIBLE',
+      'GP_COMMITMENT_UNSUPPORTED',
+      'FORECAST_FEE_BASIS_INCOMPATIBLE',
+      'TERMINAL_RESOLUTION_METHODOLOGY_UNSUPPORTED',
+      'TERMINAL_RESOLUTION_MISMATCH',
+      'TERMINAL_BEFORE_CUTOVER',
+      'FORECAST_HORIZON_SHORT',
+      'FORECAST_TERMINAL_PERIOD_UNREPRESENTABLE',
+      'POST_TERM_ACTIVITY',
+      'NEGATIVE_SOURCE_MONEY',
+      'FORECAST_DEPLOYMENT_CUMULATIVE_DECREASE',
+      'COMMITTED_CAPITAL_EXCEEDED',
+    ]);
+    expect(LpEconomicsRunUnavailabilityReasonCodeV1Schema.options).toEqual(
+      LP_ECONOMICS_RUN_UNAVAILABILITY_REASON_CODES_V1
+    );
+  });
+
+  it('carries the indicative reason registry (D-11 pair + float64 waterfall path)', () => {
+    expect(LP_ECONOMICS_INDICATIVE_REASON_CODES_V1).toEqual([
+      'DECIMAL_CORE_UNCERTIFIED',
+      'FLOAT64_WATERFALL_PATH',
+      'LP_NET_NAV_FLAT_SHARE_APPROXIMATION',
+    ]);
+    expect(LpEconomicsIndicativeReasonCodeV1Schema.options).toEqual(
+      LP_ECONOMICS_INDICATIVE_REASON_CODES_V1
+    );
+  });
+
+  it('parses a bare-code reason and rejects empty details and unknown keys', () => {
+    expect(
+      LpEconomicsRunUnavailabilityReasonV1Schema.parse({ code: 'FORECAST_UNAVAILABLE' })
+    ).toEqual({ code: 'FORECAST_UNAVAILABLE' });
+    expect(
+      LpEconomicsRunUnavailabilityReasonV1Schema.safeParse({
+        code: 'FORECAST_UNAVAILABLE',
+        detail: '',
+      }).success
+    ).toBe(false);
+    expect(
+      LpEconomicsRunUnavailabilityReasonV1Schema.safeParse({
+        code: 'FORECAST_UNAVAILABLE',
+        extra: 'x',
+      }).success
+    ).toBe(false);
+    expect(
+      LpEconomicsRunUnavailabilityReasonV1Schema.safeParse({ code: 'NOT_A_CODE' }).success
+    ).toBe(false);
+  });
+
+  it('requires the {field, valueUsd} context on OPENING_STATE_INELIGIBLE', () => {
+    const valid = {
+      code: 'OPENING_STATE_INELIGIBLE',
+      context: { field: 'cumulativeGpPaidInUsd', valueUsd: '250000.000000' },
+    };
+    expect(LpEconomicsRunUnavailabilityReasonV1Schema.parse(valid)).toEqual(valid);
+
+    for (const context of [
+      undefined,
+      {},
+      { field: 'cashBalanceUsd', valueUsd: '1.000000' },
+      { field: 'accruedPreferredReturnUsd', valueUsd: '12.5' },
+      { field: 'accruedPreferredReturnUsd', valueUsd: '1.000000', extra: 'x' },
+    ]) {
+      expect(
+        LpEconomicsRunUnavailabilityReasonV1Schema.safeParse({
+          code: 'OPENING_STATE_INELIGIBLE',
+          ...(context !== undefined && { context }),
+        }).success
+      ).toBe(false);
+    }
+  });
+
+  it('requires the v1 version discriminant on OPENING_STATE_CONTRACT_INELIGIBLE', () => {
+    expect(OPENING_STATE_CONTRACT_V1_INELIGIBLE_DETAIL).toBe(
+      'OPENING_STATE_CONTRACT_V1_INELIGIBLE'
+    );
+    const valid = {
+      code: 'OPENING_STATE_CONTRACT_INELIGIBLE',
+      context: { detail: 'OPENING_STATE_CONTRACT_V1_INELIGIBLE' },
+    };
+    expect(LpEconomicsRunUnavailabilityReasonV1Schema.parse(valid)).toEqual(valid);
+
+    expect(
+      LpEconomicsRunUnavailabilityReasonV1Schema.safeParse({
+        code: 'OPENING_STATE_CONTRACT_INELIGIBLE',
+      }).success
+    ).toBe(false);
+    expect(
+      LpEconomicsRunUnavailabilityReasonV1Schema.safeParse({
+        code: 'OPENING_STATE_CONTRACT_INELIGIBLE',
+        context: { detail: 'V2_INELIGIBLE' },
+      }).success
+    ).toBe(false);
+  });
+
+  it('parses loop-emitted quarter rows verbatim and rejects drifted shapes', () => {
+    expect(LpEconomicsQuarterRowV1Schema.parse(quarterRow)).toEqual(quarterRow);
+    expect(
+      LpEconomicsQuarterRowV1Schema.safeParse({ ...quarterRow, extraField: '0.000000' }).success
+    ).toBe(false);
+    const { tvpi: _tvpi, ...missingTvpi } = quarterRow;
+    expect(LpEconomicsQuarterRowV1Schema.safeParse(missingTvpi).success).toBe(false);
+    expect(
+      LpEconomicsQuarterRowV1Schema.safeParse({ ...quarterRow, openingCashUsd: '1.00' }).success
+    ).toBe(false);
+    // Pre-positive-paid-in ratios are null, never fabricated zero.
+    expect(
+      LpEconomicsQuarterRowV1Schema.safeParse({
+        ...quarterRow,
+        dpi: null,
+        rvpi: null,
+        tvpi: null,
+      }).success
+    ).toBe(true);
+  });
+
+  it('parses enriched waterfall events (loop fields + enrichment) and pins eventKind', () => {
+    expect(LpEconomicsWaterfallEventV1Schema.parse(enrichedEvent)).toEqual(enrichedEvent);
+    expect(LpEconomicsWaterfallEventV1Schema.safeParse(loopEvent).success).toBe(false);
+    expect(
+      LpEconomicsWaterfallEventV1Schema.safeParse({ ...enrichedEvent, eventKind: 'forecast_exit' })
+        .success
+    ).toBe(false);
+    expect(
+      LpEconomicsWaterfallEventV1Schema.safeParse({ ...enrichedEvent, sourceRefs: [] }).success
+    ).toBe(false);
+    expect(
+      LpEconomicsWaterfallEventV1Schema.safeParse({ ...enrichedEvent, eventId: 'not-a-hash' })
+        .success
+    ).toBe(false);
+    expect(
+      LpEconomicsWaterfallEventV1Schema.safeParse({
+        ...enrichedEvent,
+        eventKind: 'terminal_realization',
+      }).success
+    ).toBe(true);
+    // The ratified E1 contingency: the legacy-ledger-only unreturned-capital
+    // fields must never appear on emitted events.
+    expect(
+      LpEconomicsWaterfallEventV1Schema.safeParse({
+        ...enrichedEvent,
+        lpUnreturnedCapitalBeforeUsd: '0.000000',
+      }).success
+    ).toBe(false);
+  });
+
+  it('derives deterministic, basis-only event IDs', () => {
+    const first = buildLpEconomicsEventIdV1({
+      sourceId: 'src-a',
+      periodEnd: '2026-09-30',
+      eventSequence: 0,
+    });
+    const replay = buildLpEconomicsEventIdV1({
+      sourceId: 'src-a',
+      periodEnd: '2026-09-30',
+      eventSequence: 0,
+    });
+    const shifted = buildLpEconomicsEventIdV1({
+      sourceId: 'src-a',
+      periodEnd: '2026-09-30',
+      eventSequence: 1,
+    });
+
+    expect(first).toMatch(/^[a-f0-9]{64}$/);
+    expect(replay).toBe(first);
+    expect(shifted).not.toBe(first);
+  });
+
+  it('parses the section 6(c) totals block', () => {
+    expect(LpEconomicsTotalsV1Schema.parse(totals)).toEqual(totals);
+    const { lpProfitUsd: _lpProfit, ...missingSplit } = totals;
+    expect(LpEconomicsTotalsV1Schema.safeParse(missingSplit).success).toBe(false);
+    expect(LpEconomicsTotalsV1Schema.safeParse({ ...totals, netIrr: null }).success).toBe(false);
+  });
+
+  it('parses the indicative branch of the D9 envelope', () => {
+    const parsed = LpEconomicsResultV1Schema.parse(indicativeResult);
+    expect(parsed.resultStatus).toBe('indicative');
+    expect(parsed.waterfallTemplate).toBe('deal_by_deal');
+    if (parsed.resultStatus === 'indicative') {
+      expect(parsed.quarters).toHaveLength(1);
+      expect(parsed.lpNetIrr).toBe('0.142500000000');
+    }
+  });
+
+  it('parses the unavailable branch (reasons only, no value arrays)', () => {
+    const parsed = LpEconomicsResultV1Schema.parse(unavailableResult);
+    expect(parsed.resultStatus).toBe('unavailable');
+    expect(
+      LpEconomicsResultV1Schema.safeParse({ ...unavailableResult, quarters: [] }).success
+    ).toBe(false);
+    expect(LpEconomicsResultV1Schema.safeParse({ ...unavailableResult, totals }).success).toBe(
+      false
+    );
+  });
+
+  it('requires nonempty reasons on both branches', () => {
+    expect(LpEconomicsResultV1Schema.safeParse({ ...indicativeResult, reasons: [] }).success).toBe(
+      false
+    );
+    expect(LpEconomicsResultV1Schema.safeParse({ ...unavailableResult, reasons: [] }).success).toBe(
+      false
+    );
+  });
+
+  it('locks the envelope literals (template, currency, perspective, precision mode)', () => {
+    expect(
+      LpEconomicsResultV1Schema.safeParse({ ...unavailableResult, waterfallTemplate: 'whole_fund' })
+        .success
+    ).toBe(false);
+    expect(
+      LpEconomicsResultV1Schema.safeParse({ ...unavailableResult, currency: 'EUR' }).success
+    ).toBe(false);
+    expect(
+      LpEconomicsResultV1Schema.safeParse({ ...unavailableResult, perspective: 'gp_net' }).success
+    ).toBe(false);
+    expect(
+      LpEconomicsResultV1Schema.safeParse({
+        ...unavailableResult,
+        precisionMode: 'float64',
+      }).success
+    ).toBe(false);
+  });
+
+  it('accepts a null IRR with its diagnostic on the indicative branch', () => {
+    expect(
+      LpEconomicsResultV1Schema.safeParse({
+        ...indicativeResult,
+        lpNetIrr: null,
+        lpNetIrrBasis: 'cash_only',
+        lpNetIrrDiagnostic: {
+          convergence: 'failed',
+          iterations: 0,
+          method: 'none',
+          boundHit: null,
+          failureReason: 'NO_SIGN_CHANGE',
+        },
+      }).success
+    ).toBe(true);
+  });
+
+  it('sorts reasons by code then detail with a deterministic final tiebreak', () => {
+    const input = [
+      { code: 'POST_TERM_ACTIVITY', detail: 'z-detail' },
+      { code: 'COMMITTED_CAPITAL_EXCEEDED' },
+      { code: 'POST_TERM_ACTIVITY', detail: 'a-detail' },
+      { code: 'NEGATIVE_SOURCE_MONEY' },
+    ];
+    expect(sortAndDedupeLpEconomicsReasonsV1(input)).toEqual([
+      { code: 'COMMITTED_CAPITAL_EXCEEDED' },
+      { code: 'NEGATIVE_SOURCE_MONEY' },
+      { code: 'POST_TERM_ACTIVITY', detail: 'a-detail' },
+      { code: 'POST_TERM_ACTIVITY', detail: 'z-detail' },
+    ]);
+  });
+
+  it('dedupes on the canonicalSha256 of the full {code, detail, context} tuple', () => {
+    const deduped = sortAndDedupeLpEconomicsReasonsV1([
+      {
+        code: 'OPENING_STATE_INELIGIBLE',
+        context: { field: 'cumulativeGpPaidInUsd', valueUsd: '1.000000' },
+      },
+      // Same tuple content, different context key order: must collapse.
+      {
+        code: 'OPENING_STATE_INELIGIBLE',
+        context: { valueUsd: '1.000000', field: 'cumulativeGpPaidInUsd' },
+      },
+      // Different context value: must survive (context discriminants are
+      // never collapsed by a code-only dedupe).
+      {
+        code: 'OPENING_STATE_INELIGIBLE',
+        context: { field: 'accruedPreferredReturnUsd', valueUsd: '2.000000' },
+      },
+    ]);
+    expect(deduped).toHaveLength(2);
+    expect(
+      new Set(
+        deduped.map((reason) =>
+          canonicalSha256({ code: reason.code, detail: reason.detail, context: reason.context })
+        )
+      ).size
+    ).toBe(2);
+  });
+
+  it('is order-insensitive end to end (T-C14 shape)', () => {
+    const reasons = [
+      { code: 'FORECAST_UNAVAILABLE' },
+      { code: 'CONFIG_LINEAGE_MISMATCH', detail: 'plan/config divergence' },
+      { code: 'OPENING_CASH_UNAVAILABLE' },
+    ];
+    const forward = sortAndDedupeLpEconomicsReasonsV1(reasons);
+    const reversed = sortAndDedupeLpEconomicsReasonsV1([...reasons].reverse());
+    expect(reversed).toEqual(forward);
+    expect(canonicalSha256(reversed)).toBe(canonicalSha256(forward));
+  });
+
+  it('keeps indicative reasons within the indicative registry', () => {
+    expect(
+      LpEconomicsIndicativeReasonV1Schema.safeParse({ code: 'MAIN_FUND_VEHICLE_ABSENT' }).success
+    ).toBe(false);
+    expect(LpEconomicsIndicativeReasonV1Schema.parse({ code: 'FLOAT64_WATERFALL_PATH' })).toEqual({
+      code: 'FLOAT64_WATERFALL_PATH',
+    });
+  });
+});

--- a/tests/unit/fixtures/dynamic-reserve-intelligence.ts
+++ b/tests/unit/fixtures/dynamic-reserve-intelligence.ts
@@ -8,7 +8,10 @@ const HASH_B = 'b'.repeat(64);
 const HASH_C = 'c'.repeat(64);
 
 type PolicyVersion =
-  'financial-facts-policy/1.0.1' | 'financial-facts-policy/1.1.0' | 'financial-facts-policy/1.2.0';
+  | 'financial-facts-policy/1.0.1'
+  | 'financial-facts-policy/1.1.0'
+  | 'financial-facts-policy/1.2.0'
+  | 'financial-facts-policy/1.3.0';
 
 function companyFact(companyId: number, companyName: string, withWarning: boolean) {
   const warnings = withWarning
@@ -162,9 +165,11 @@ function factsSnapshot(policyVersion: PolicyVersion) {
     ...common,
     policyVersion,
     payloadSchemaId:
-      policyVersion === 'financial-facts-policy/1.2.0'
-        ? 'financial-facts-payload/3'
-        : 'financial-facts-payload/2',
+      policyVersion === 'financial-facts-policy/1.3.0'
+        ? 'financial-facts-payload/4'
+        : policyVersion === 'financial-facts-policy/1.2.0'
+          ? 'financial-facts-payload/3'
+          : 'financial-facts-payload/2',
     consumerEvaluations: [
       {
         consumer: 'reserve',
@@ -181,7 +186,10 @@ function factsSnapshot(policyVersion: PolicyVersion) {
     ],
     payload: {
       ...sharedFactsPayload(),
-      ...(policyVersion === 'financial-facts-policy/1.2.0' ? { openingAccountingState: null } : {}),
+      ...(policyVersion === 'financial-facts-policy/1.2.0' ||
+      policyVersion === 'financial-facts-policy/1.3.0'
+        ? { openingAccountingState: null }
+        : {}),
       positionRefs: [],
       positionComponentRefs: [
         {

--- a/tests/unit/hooks/use-reserve-intelligence.test.tsx
+++ b/tests/unit/hooks/use-reserve-intelligence.test.tsx
@@ -146,4 +146,20 @@ describe('useReserveIntelligence', () => {
     await waitFor(() => expect(result.current.data?.kind).toBe('ready'));
     expect(result.current.error).toBeNull();
   });
+
+  it('accepts a policy 1.3.0 payload 4 facts snapshot', async () => {
+    const run = makeReserveIntelligenceRun('financial-facts-policy/1.3.0');
+    fetchMock.mockResolvedValue(jsonResponse(run));
+
+    const { result } = renderHook(() => useReserveIntelligence(7), { wrapper });
+
+    await waitFor(() => expect(result.current.data?.kind).toBe('ready'));
+    expect(result.current.error).toBeNull();
+    if (result.current.data?.kind !== 'ready') {
+      throw new Error('Expected ready reserve intelligence state');
+    }
+    expect(result.current.data.run.result.provenance.factsSnapshot.policyVersion).toBe(
+      'financial-facts-policy/1.3.0'
+    );
+  });
 });

--- a/tests/unit/internal-economics/lp-economics-run-worst-case-benchmark.test.ts
+++ b/tests/unit/internal-economics/lp-economics-run-worst-case-benchmark.test.ts
@@ -1,0 +1,210 @@
+/**
+ * lp-economics-run-worst-case-benchmark.test.ts
+ *
+ * WP-L3 Phase C, T-C18 (P-D7 R5/R6 amendments): a standalone pure-compute
+ * benchmark proving the admission-control bound the run service enforces
+ * (`MAX_CASH_ASSEMBLY_PERIOD_COUNT = 200`,
+ * `MAX_CASH_ASSEMBLY_TOTAL_EVENT_COUNT = 10000`) is safe -- a worst-case
+ * admissible input completes well under the 5-second budget.
+ *
+ * Isolated from the DB-backed suite by design (phoenix round-5 test-design
+ * guidance, folded into P-D7 R6): calls `executeCashAssemblyPeriodLoopV1`
+ * directly, no DB, no server bootstrap, so it cannot be caught by the
+ * integration suite's known setupFiles resource-ceiling flake vector.
+ *
+ * Worst-case shape: R6 identified the bucketing scan
+ * (`cash-assembly-event-stream-v1.ts`'s per-event linear period search) as
+ * the O(events x periods) risk, not the quarterly fold itself. This fixture
+ * maximizes that specifically: 200 periods, all `actual` (historical), and
+ * 9700 facts cash-flow events spread across their full date range so a
+ * meaningful fraction require scanning deep into the sorted bucket list --
+ * plus 100 NAV marks and the 200 forecast series points themselves, for an
+ * event-count total of exactly 10000 (the firm bound, not exceeding it: a
+ * valid, admissible worst-case run, not a rejected one). Historical
+ * reconciliation is satisfied by construction (opening state's
+ * `cumulativeLpPaidInUsd` equals the summed lp_capital_call amounts), so the
+ * loop runs to genuine completion rather than short-circuiting on an early
+ * typed-error throw -- the full bucketing + fold cost is actually paid.
+ *
+ * @module tests/unit/internal-economics/lp-economics-run-worst-case-benchmark
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  MAX_CASH_ASSEMBLY_PERIOD_COUNT,
+  MAX_CASH_ASSEMBLY_TOTAL_EVENT_COUNT,
+} from '../../../server/services/internal-economics/lp-economics-run-service';
+import { INTERNAL_ECONOMICS_TERMINAL_RESOLUTION_VERSION } from '../../../shared/contracts/internal-economics/terminal-policy-v1.contract';
+import { Decimal } from '../../../shared/lib/decimal-config';
+import { executeCashAssemblyPeriodLoopV1 } from '../../../shared/lib/internal-economics/cash-assembly-period-loop-v1';
+import { FundAccountingStateObservationV1_1Schema } from '../../../shared/contracts/internal-economics/fund-accounting-state-observation-v1.1.contract';
+
+const WALL_CLOCK_BUDGET_MS = 5000;
+const EPOCH = new Date('2000-01-01T00:00:00.000Z');
+
+function addDays(date: Date, days: number): Date {
+  return new Date(date.getTime() + days * 24 * 60 * 60 * 1000);
+}
+
+function isoDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function buildPeriods(count: number): Array<{ periodStart: string; periodEnd: string }> {
+  const periods: Array<{ periodStart: string; periodEnd: string }> = [];
+  let cursor = EPOCH;
+  for (let index = 0; index < count; index += 1) {
+    const periodStart = cursor;
+    const periodEnd = addDays(cursor, 89);
+    periods.push({ periodStart: isoDate(periodStart), periodEnd: isoDate(periodEnd) });
+    cursor = addDays(periodEnd, 1);
+  }
+  return periods;
+}
+
+describe('lp-economics-run-service worst-case benchmark (T-C18)', () => {
+  it(`completes a ${MAX_CASH_ASSEMBLY_PERIOD_COUNT}-period, ${MAX_CASH_ASSEMBLY_TOTAL_EVENT_COUNT}-event bucketing-adversarial input under ${WALL_CLOCK_BUDGET_MS}ms`, () => {
+    expect(MAX_CASH_ASSEMBLY_PERIOD_COUNT).toBe(200);
+    expect(MAX_CASH_ASSEMBLY_TOTAL_EVENT_COUNT).toBe(10000);
+
+    const periods = buildPeriods(MAX_CASH_ASSEMBLY_PERIOD_COUNT);
+    // 199 historical (`actual`) periods carry the bucketing-adversarial
+    // event load; the call-sizing seam requires at least one `projected`
+    // period to run at all (`sizeCashAssemblyCallsV1`), so the final period
+    // is projected with zero scheduled deployment -- a trivial quarter
+    // fold that does not distort the benchmark's dominant cost.
+    const historicalPeriods = periods.slice(0, -1);
+    const projectedPeriod = periods.at(-1)!;
+    const cutoverInstant = `${historicalPeriods.at(-1)!.periodEnd}T23:59:59.999Z`;
+
+    const forecastSeries = [
+      ...historicalPeriods.map((period) => ({
+        periodStart: period.periodStart,
+        periodEnd: period.periodEnd,
+        source: 'actual' as const,
+        deployedUsd: '0.000000',
+        contributionsUsd: '0.000000',
+        distributionsUsd: '0.000000',
+        navUsd: '0.000000',
+        tvpi: '0.000000000000',
+        dpi: '0.000000000000',
+        activeCompanyCount: 0,
+        projectedCohortCount: 0,
+      })),
+      {
+        periodStart: projectedPeriod.periodStart,
+        periodEnd: projectedPeriod.periodEnd,
+        source: 'projected' as const,
+        deployedUsd: '0.000000',
+        contributionsUsd: '0.000000',
+        distributionsUsd: '0.000000',
+        navUsd: '0.000000',
+        tvpi: '0.000000000000',
+        dpi: '0.000000000000',
+        activeCompanyCount: 0,
+        projectedCohortCount: 0,
+      },
+    ];
+
+    const FACTS_EVENT_COUNT = 9700;
+    const NAV_MARK_COUNT = 100;
+    const totalEventCount = FACTS_EVENT_COUNT + NAV_MARK_COUNT + 0 + forecastSeries.length;
+    expect(totalEventCount).toBe(MAX_CASH_ASSEMBLY_TOTAL_EVENT_COUNT);
+
+    // Spread events across the FULL date range (not clustered at the very
+    // start) so a meaningful fraction require scanning deep into the
+    // sorted bucket list -- the O(events x periods) cost R6 identified.
+    const factsEvents = Array.from({ length: FACTS_EVENT_COUNT }, (_unused, index) => {
+      const periodIndex = index % historicalPeriods.length;
+      const period = historicalPeriods[periodIndex]!;
+      return {
+        eventId: index + 1,
+        eventType: 'lp_capital_call' as const,
+        effectiveAt: `${period.periodStart}T00:00:00.000Z`,
+        amountUsd: '1.000000',
+      };
+    });
+    const cumulativeLpPaidInUsd = factsEvents
+      .reduce((total, event) => total.plus(event.amountUsd), new Decimal(0))
+      .toFixed(6);
+
+    const factsNavMarks = Array.from({ length: NAV_MARK_COUNT }, (_unused, index) => {
+      const periodIndex = index % historicalPeriods.length;
+      const period = historicalPeriods[periodIndex]!;
+      return {
+        markId: index + 1,
+        effectiveAt: period.periodStart,
+        fairValueUsd: '0.000000',
+      };
+    });
+
+    const openingState = FundAccountingStateObservationV1_1Schema.parse({
+      contractVersion: 'fund-accounting-state-observation/1.1.0',
+      cutoverInstant,
+      currency: 'USD',
+      cashBalanceUsd: '0.000000',
+      cumulativeLpPaidInUsd,
+      cumulativeGpPaidInUsd: '0.000000',
+      gpUnreturnedContributedCapitalUsd: '0.000000',
+      lpDistributionsReturnOfCapitalUsd: '0.000000',
+      lpDistributionsProfitUsd: '0.000000',
+      actualLpDistributionsCumulativeUsd: '0.000000',
+      gpInvestmentDistributionsPaidUsd: '0.000000',
+      gpCarryPaidUsd: '0.000000',
+      accruedPreferredReturnUsd: '0.000000',
+      accruedPreferredReturnThroughInstant: cutoverInstant,
+      recallableDistributionsCumulativeUsd: '0.000000',
+      recallableDistributionsOutstandingUsd: '0.000000',
+      recycledProceedsCumulativeUsd: '0.000000',
+      realizedProceedsCumulativeUsd: '0.000000',
+      methodologyVersion: 'opening-state-methodology/1.0.0',
+    });
+
+    const startedAtMs = performance.now();
+    const result = executeCashAssemblyPeriodLoopV1({
+      factsSnapshotId: 1,
+      forecastSnapshotId: 1,
+      economicsPolicyVersion: 'internal-economics-policy/1.0.0',
+      engineVersion: 'cash-assembly-period-loop-v1/1.0.0',
+      methodologyVersion: 'cash-assembly-period-loop-methodology/1.0.0',
+      factsEvents,
+      factsNavMarks,
+      factsPeriodNav: [],
+      openingState,
+      forecastSeries,
+      // Exactly one `projected` period (the last), zero scheduled
+      // deployment/fee/expense -- a trivial quarter fold. The benchmark's
+      // dominant cost is the bucketing scan over all 200 periods x 10000
+      // events, per R6.
+      scheduledNeeds: [
+        {
+          period: {
+            periodStart: projectedPeriod.periodStart,
+            periodEnd: projectedPeriod.periodEnd,
+            source: 'projected',
+          },
+          scheduledDeploymentUsd: new Decimal(0),
+          scheduledFeeUsd: new Decimal(0),
+          scheduledExpenseUsd: new Decimal(0),
+        },
+      ],
+      cashBufferQuarters: 0,
+      unfundedEnvelopeRemainingUsd: new Decimal('1000000'),
+      persistedTerminalResolution: {
+        terminalPeriodEnd: projectedPeriod.periodEnd,
+        terminalResolutionMethodologyVersion: INTERNAL_ECONOMICS_TERMINAL_RESOLUTION_VERSION,
+      },
+      terminalMode: 'hold_unrealized',
+      carryPct: 0.2,
+    });
+    const elapsedMs = performance.now() - startedAtMs;
+
+    expect(result.resultStatus).toBe('indicative');
+    expect(result.quarters).toHaveLength(1); // exactly one projected period, by construction
+    // eslint-disable-next-line no-console -- benchmark visibility, not app logging
+    console.log(
+      `T-C18 worst-case loop invocation: ${elapsedMs.toFixed(2)}ms (budget ${WALL_CLOCK_BUDGET_MS}ms)`
+    );
+    expect(elapsedMs).toBeLessThan(WALL_CLOCK_BUDGET_MS);
+  });
+});

--- a/tests/unit/migration-ledger.test.ts
+++ b/tests/unit/migration-ledger.test.ts
@@ -55,6 +55,7 @@ const expectedJournaledDriftPatchFiles = [
   '0042_positions_ownership_compat.sql',
   '0043_position_source_basis_reliefs.sql',
   '0044_internal_analysis.sql',
+  '0045_internal_economics_policy_runs.sql',
 ].sort();
 
 afterEach(() => {
@@ -151,6 +152,20 @@ describe('migration ledger helpers', () => {
     expect(entry).toMatchObject({
       idx: 44,
       tag: '0043_position_source_basis_reliefs',
+      breakpoints: true,
+    });
+  });
+
+  // T-A1 (WP-L3 Phase A): the pin asserts THIS migration's OWN journal entry
+  // by tag, never entries.at(-1) (memory-pinned repo lesson).
+  it('pins internal economics policy runs migration to its own journal index 46 entry', () => {
+    const entry = readDrizzleJournal(repoRoot).entries.find(
+      (candidate) => candidate.tag === '0045_internal_economics_policy_runs'
+    );
+
+    expect(entry).toMatchObject({
+      idx: 46,
+      tag: '0045_internal_economics_policy_runs',
       breakpoints: true,
     });
   });

--- a/tests/unit/prod-schema-apply-policy.test.ts
+++ b/tests/unit/prod-schema-apply-policy.test.ts
@@ -310,11 +310,17 @@ describe('prod schema apply policy', () => {
 
   it('accepts additive-safe production manifests from M9 onward', async () => {
     const manifests = await loadManifests();
+    const humanReconciledManifests = new Set([
+      'business-time-comparison-lineage',
+      // WP-L3 T-A5 disposition: manifest 22's DROP TRIGGER IF EXISTS is an
+      // unknown drop for the additive-safe allow-list, so it follows the
+      // 0034 precedent — audit-visible, human-reconciled — see the dedicated
+      // refusal pin below and the REFUSE-FOR-HUMAN trigger audit.
+      'internal-economics-policy-runs',
+    ]);
     const applyingManifestNames = new Set(
       manifests
-        .filter(
-          (manifest) => manifest.order >= 9 && manifest.name !== 'business-time-comparison-lineage'
-        )
+        .filter((manifest) => manifest.order >= 9 && !humanReconciledManifests.has(manifest.name))
         .map((manifest) => manifest.name)
     );
 
@@ -333,6 +339,21 @@ describe('prod schema apply policy', () => {
       assertApplyPolicyForManifests({
         manifests,
         applyingManifestNames: new Set(['business-time-comparison-lineage']),
+      })
+    ).toThrow(ReconcileError);
+  });
+
+  // WP-L3 T-A5: trigger DDL cannot ride the additive-safe automated apply
+  // path. The operator applies migrations/0045 manually; the reconcile audit
+  // then proves convergence via the triggerDefinitions/functionDefinitions
+  // REFUSE-FOR-HUMAN -> SKIP cycle.
+  it('refuses automated apply for internal economics policy runs', async () => {
+    const manifests = await loadManifests();
+
+    expect(() =>
+      assertApplyPolicyForManifests({
+        manifests,
+        applyingManifestNames: new Set(['internal-economics-policy-runs']),
       })
     ).toThrow(ReconcileError);
   });

--- a/tests/unit/prod-schema-manifest-sentinels.test.ts
+++ b/tests/unit/prod-schema-manifest-sentinels.test.ts
@@ -139,6 +139,7 @@ describe('prod-schema manifest sentinels', () => {
       '19-user-identity-grants-revocation.json',
       '20-company-scenario-create-requests.json',
       '21-business-time-comparison-lineage.json',
+      '22-internal-economics-policy-runs.json',
     ]);
   });
 

--- a/tests/unit/prod-schema-manifest-trigger-audit.test.ts
+++ b/tests/unit/prod-schema-manifest-trigger-audit.test.ts
@@ -1,0 +1,428 @@
+/**
+ * T-A5 (WP-L3 Phase A, unit tier): `triggerDefinitions` / `functionDefinitions`
+ * audit extension of `scripts/reconcile-prod-schema.mjs`, analogous to
+ * manifest 0034's `indexDefinitions` mechanism.
+ *
+ * Trigger and function DDL cannot ride the additive-safe automated apply path
+ * (`DROP TRIGGER IF EXISTS` is an unknown DROP for
+ * `prod-schema-apply-policy.mjs`), so ANY trigger or function-body drift —
+ * missing, disabled, or redefined — must surface as `ACTION_REFUSE_FOR_HUMAN`,
+ * and the audit may end `ACTION_SKIP` only once the live
+ * `tgenabled`/`pg_get_triggerdef` wiring AND the `pg_proc`-sourced function
+ * body both match the manifest-pinned definitions. The real-database
+ * counterpart lives in
+ * `tests/integration/internal-economics/economics-schema.pg.test.ts`.
+ */
+// Default import on purpose: node-setup.ts vi.mock('fs') stubs the NAMED
+// readFileSync export, but its ...actual spread preserves `default` as the
+// real fs module - same pattern as the sibling reconcile/ledger tests.
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  ACTION_REFUSE_FOR_HUMAN,
+  ACTION_SKIP,
+  ReconcileError,
+  auditManifest,
+} from '../../scripts/reconcile-prod-schema.mjs';
+
+const repoRoot = process.cwd();
+
+interface ExpectedDefinition {
+  exactDefinition: string;
+  orderedFragments: string[];
+  stringLiterals: string[];
+}
+
+interface TriggerDefinition {
+  name: string;
+  expectedDefinition: ExpectedDefinition;
+}
+
+interface ManifestTable {
+  name: string;
+  sharedTable?: boolean;
+  columns?: Array<{ name: string; type?: string; nullable: boolean }>;
+  constraints?: string[];
+  indexes?: string[];
+  triggerDefinitions?: TriggerDefinition[];
+}
+
+interface Manifest {
+  name: string;
+  order: number;
+  description?: string;
+  missingTablePolicy?: string;
+  sqlFiles?: string[];
+  allowedCreateTables?: string[];
+  functionDefinitions?: Array<{ name: string; expectedDefinition: ExpectedDefinition }>;
+  expectedTables?: ManifestTable[];
+}
+
+function loadManifest22(): Manifest {
+  return JSON.parse(
+    fs.readFileSync(
+      path.join(
+        repoRoot,
+        'scripts',
+        'prod-schema-manifests',
+        '22-internal-economics-policy-runs.json'
+      ),
+      'utf8'
+    )
+  ) as Manifest;
+}
+
+interface TriggerRow {
+  table_name: string;
+  tgname: string;
+  tgenabled: string;
+  definition: string;
+}
+
+interface FunctionRow {
+  proname: string;
+  definition: string;
+}
+
+interface MockCatalog {
+  presentTables?: readonly string[];
+  columns?: ReadonlyArray<{
+    table_name: string;
+    column_name: string;
+    data_type: string;
+    udt_name?: string;
+    is_nullable: 'YES' | 'NO';
+  }>;
+  constraints?: ReadonlyArray<{ table_name: string; conname: string; definition: string }>;
+  indexes?: ReadonlyArray<{ tablename: string; indexname: string; indexdef: string }>;
+  triggers?: readonly TriggerRow[];
+  functions?: readonly FunctionRow[];
+}
+
+function createMockClient(catalog: MockCatalog) {
+  return {
+    query(text: string): Promise<{ rows: unknown[] }> {
+      if (text.includes('information_schema.tables')) {
+        return Promise.resolve({
+          rows: (catalog.presentTables ?? []).map((table_name) => ({ table_name })),
+        });
+      }
+      if (text.includes('information_schema.columns')) {
+        return Promise.resolve({ rows: [...(catalog.columns ?? [])] });
+      }
+      if (text.includes('pg_get_triggerdef')) {
+        return Promise.resolve({ rows: [...(catalog.triggers ?? [])] });
+      }
+      if (text.includes('pg_get_functiondef')) {
+        return Promise.resolve({ rows: [...(catalog.functions ?? [])] });
+      }
+      if (text.includes('pg_get_constraintdef')) {
+        return Promise.resolve({ rows: [...(catalog.constraints ?? [])] });
+      }
+      if (text.includes('FROM pg_indexes')) {
+        return Promise.resolve({ rows: [...(catalog.indexes ?? [])] });
+      }
+      if (text.includes('SELECT EXISTS')) {
+        return Promise.resolve({ rows: [{ populated: false }] });
+      }
+      throw new Error(`Unexpected mock query: ${text.slice(0, 120)}`);
+    },
+  };
+}
+
+function dataTypeFor(manifestType: string): { data_type: string; udt_name: string } {
+  if (manifestType === 'varchar') {
+    return { data_type: 'character varying', udt_name: 'varchar' };
+  }
+  if (manifestType === 'timestamptz') {
+    return { data_type: 'timestamp with time zone', udt_name: 'timestamptz' };
+  }
+  return { data_type: manifestType, udt_name: manifestType };
+}
+
+/** A synthetic catalog in full agreement with manifest 22's declarations. */
+function matchingCatalog(manifest: Manifest): Required<MockCatalog> {
+  const tables = manifest.expectedTables ?? [];
+  return {
+    presentTables: tables.map((table) => table.name),
+    columns: tables.flatMap((table) =>
+      (table.columns ?? []).map((column) => ({
+        table_name: table.name,
+        column_name: column.name,
+        ...dataTypeFor(column.type ?? 'text'),
+        is_nullable: column.nullable ? ('YES' as const) : ('NO' as const),
+      }))
+    ),
+    constraints: tables.flatMap((table) =>
+      (table.constraints ?? []).map((conname) => ({
+        table_name: table.name,
+        conname,
+        definition: '',
+      }))
+    ),
+    indexes: tables.flatMap((table) =>
+      (table.indexes ?? []).map((indexname) => ({
+        tablename: table.name,
+        indexname,
+        indexdef: '',
+      }))
+    ),
+    triggers: tables.flatMap((table) =>
+      (table.triggerDefinitions ?? []).map((trigger) => ({
+        table_name: table.name,
+        tgname: trigger.name,
+        tgenabled: 'O',
+        definition: trigger.expectedDefinition.exactDefinition,
+      }))
+    ),
+    functions: (manifest.functionDefinitions ?? []).map((fn) => ({
+      proname: fn.name,
+      definition: fn.expectedDefinition.exactDefinition,
+    })),
+  };
+}
+
+describe('manifest 22 trigger/function audit (T-A5)', () => {
+  const manifest = loadManifest22();
+
+  it('declares all four triggers and the shared function body', () => {
+    const triggerNames = (manifest.expectedTables ?? []).flatMap((table) =>
+      (table.triggerDefinitions ?? []).map((trigger) => trigger.name)
+    );
+    expect(triggerNames.sort()).toEqual(
+      [
+        'internal_capital_envelope_versions_forbid_update_trigger',
+        'internal_economics_policy_versions_forbid_update_trigger',
+        'internal_lp_economics_runs_forbid_update_trigger',
+        'fund_snapshots_internal_economics_forbid_update_trigger',
+      ].sort()
+    );
+    expect(manifest.functionDefinitions?.map((fn) => fn.name)).toEqual([
+      'internal_economics_forbid_update',
+    ]);
+    expect(manifest.missingTablePolicy).toBe('create_or_repair');
+    expect(manifest.allowedCreateTables).toEqual([
+      'internal_capital_envelope_versions',
+      'internal_economics_policy_versions',
+      'internal_lp_economics_runs',
+    ]);
+  });
+
+  it('types every declared column (G9 audit-SKIP lesson)', () => {
+    const missing = (manifest.expectedTables ?? []).flatMap((table) =>
+      (table.columns ?? [])
+        .filter((column) => !column.type?.trim())
+        .map((column) => `${table.name}.${column.name}`)
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it('audits SKIP when tables, triggers, and function body all match', async () => {
+    const client = createMockClient(matchingCatalog(manifest));
+    const audit = await auditManifest(client, manifest);
+
+    expect(audit.action).toBe(ACTION_SKIP);
+    for (const object of audit.objects) {
+      expect(object.deltas, `${object.table} deltas`).toEqual([]);
+      expect(object.action, `${object.table} action`).toBe(ACTION_SKIP);
+    }
+  });
+
+  it('REFUSES-FOR-HUMAN pre-reconciliation (tables and triggers absent)', async () => {
+    const catalog = matchingCatalog(manifest);
+    const client = createMockClient({
+      // fund_snapshots exists in prod; the three new tables and all four
+      // triggers do not until the operator applies 0045.
+      presentTables: ['fund_snapshots'],
+      columns: [],
+      constraints: [],
+      indexes: [],
+      triggers: [],
+      functions: [],
+    });
+    const audit = await auditManifest(client, manifest);
+
+    expect(catalog.triggers.length).toBe(4);
+    expect(audit.action).toBe(ACTION_REFUSE_FOR_HUMAN);
+    const fundSnapshotsObject = audit.objects.find((object) => object.table === 'fund_snapshots');
+    expect(fundSnapshotsObject?.action).toBe(ACTION_REFUSE_FOR_HUMAN);
+    expect(
+      fundSnapshotsObject?.deltas.some(
+        (delta: { kind: string }) => delta.kind === 'missing-trigger'
+      )
+    ).toBe(true);
+  });
+
+  it('REFUSES-FOR-HUMAN when a trigger definition drifts from the manifest pin', async () => {
+    const catalog = matchingCatalog(manifest);
+    const drifted = catalog.triggers.map((trigger) =>
+      trigger.tgname === 'fund_snapshots_internal_economics_forbid_update_trigger'
+        ? {
+            ...trigger,
+            definition: trigger.definition.replace(
+              /WHEN \(.*\) EXECUTE/,
+              "WHEN ((old.type)::text = 'INTERNAL_LP_ECONOMICS'::text) EXECUTE"
+            ),
+          }
+        : trigger
+    );
+    const client = createMockClient({ ...catalog, triggers: drifted });
+    const audit = await auditManifest(client, manifest);
+
+    expect(audit.action).toBe(ACTION_REFUSE_FOR_HUMAN);
+    const fundSnapshotsObject = audit.objects.find((object) => object.table === 'fund_snapshots');
+    expect(
+      fundSnapshotsObject?.deltas.some(
+        (delta: { kind: string }) => delta.kind === 'trigger-definition-mismatch'
+      )
+    ).toBe(true);
+  });
+
+  it('REFUSES-FOR-HUMAN when a trigger is present but disabled', async () => {
+    const catalog = matchingCatalog(manifest);
+    const disabled = catalog.triggers.map((trigger) =>
+      trigger.tgname === 'internal_lp_economics_runs_forbid_update_trigger'
+        ? { ...trigger, tgenabled: 'D' }
+        : trigger
+    );
+    const client = createMockClient({ ...catalog, triggers: disabled });
+    const audit = await auditManifest(client, manifest);
+
+    expect(audit.action).toBe(ACTION_REFUSE_FOR_HUMAN);
+    const runsObject = audit.objects.find(
+      (object) => object.table === 'internal_lp_economics_runs'
+    );
+    expect(
+      runsObject?.deltas.some((delta: { kind: string }) => delta.kind === 'trigger-disabled')
+    ).toBe(true);
+  });
+
+  it('REFUSES-FOR-HUMAN when the shared function body is redefined', async () => {
+    const catalog = matchingCatalog(manifest);
+    const client = createMockClient({
+      ...catalog,
+      functions: [
+        {
+          proname: 'internal_economics_forbid_update',
+          definition:
+            'CREATE OR REPLACE FUNCTION public.internal_economics_forbid_update() RETURNS trigger LANGUAGE plpgsql AS $function$ BEGIN RETURN NEW; END; $function$',
+        },
+      ],
+    });
+    const audit = await auditManifest(client, manifest);
+
+    expect(audit.action).toBe(ACTION_REFUSE_FOR_HUMAN);
+    const functionObject = audit.objects.find(
+      (object) => object.table === 'function:internal_economics_forbid_update'
+    );
+    expect(functionObject?.action).toBe(ACTION_REFUSE_FOR_HUMAN);
+    expect(
+      functionObject?.deltas.some(
+        (delta: { kind: string }) => delta.kind === 'function-definition-mismatch'
+      )
+    ).toBe(true);
+  });
+
+  it('REFUSES-FOR-HUMAN when the shared function is missing entirely', async () => {
+    const catalog = matchingCatalog(manifest);
+    const client = createMockClient({ ...catalog, functions: [] });
+    const audit = await auditManifest(client, manifest);
+
+    expect(audit.action).toBe(ACTION_REFUSE_FOR_HUMAN);
+    const functionObject = audit.objects.find(
+      (object) => object.table === 'function:internal_economics_forbid_update'
+    );
+    expect(
+      functionObject?.deltas.some((delta: { kind: string }) => delta.kind === 'missing-function')
+    ).toBe(true);
+  });
+
+  it('rejects malformed triggerDefinitions instead of silently skipping them', async () => {
+    const malformed: Manifest = {
+      name: 'malformed-trigger-fixture',
+      order: 999,
+      missingTablePolicy: 'create_or_repair',
+      expectedTables: [
+        {
+          name: 'internal_lp_economics_runs',
+          columns: [],
+          triggerDefinitions: [
+            {
+              name: 'internal_lp_economics_runs_forbid_update_trigger',
+              // orderedFragments empty: must be rejected, mirroring the
+              // indexDefinitions validation contract.
+              expectedDefinition: {
+                exactDefinition: 'CREATE TRIGGER x',
+                orderedFragments: [],
+                stringLiterals: [],
+              },
+            },
+          ],
+        },
+      ],
+    };
+    const client = createMockClient({ presentTables: ['internal_lp_economics_runs'] });
+
+    await expect(auditManifest(client, malformed)).rejects.toThrow(ReconcileError);
+  });
+
+  it('rejects malformed functionDefinitions', async () => {
+    const malformed: Manifest = {
+      name: 'malformed-function-fixture',
+      order: 998,
+      missingTablePolicy: 'create_or_repair',
+      functionDefinitions: [
+        {
+          name: 'internal_economics_forbid_update',
+          expectedDefinition: {
+            exactDefinition: '',
+            orderedFragments: ['CREATE'],
+            stringLiterals: [],
+          },
+        },
+      ],
+      expectedTables: [{ name: 'internal_lp_economics_runs', columns: [] }],
+    };
+    const client = createMockClient({ presentTables: ['internal_lp_economics_runs'] });
+
+    await expect(auditManifest(client, malformed)).rejects.toThrow(ReconcileError);
+  });
+
+  it('rejects duplicate trigger names within one table declaration', async () => {
+    const duplicate: Manifest = {
+      name: 'duplicate-trigger-fixture',
+      order: 997,
+      missingTablePolicy: 'create_or_repair',
+      expectedTables: [
+        {
+          name: 'internal_lp_economics_runs',
+          columns: [],
+          triggerDefinitions: [
+            {
+              name: 'internal_lp_economics_runs_forbid_update_trigger',
+              expectedDefinition: {
+                exactDefinition: 'CREATE TRIGGER a',
+                orderedFragments: ['CREATE TRIGGER'],
+                stringLiterals: [],
+              },
+            },
+            {
+              name: 'internal_lp_economics_runs_forbid_update_trigger',
+              expectedDefinition: {
+                exactDefinition: 'CREATE TRIGGER b',
+                orderedFragments: ['CREATE TRIGGER'],
+                stringLiterals: [],
+              },
+            },
+          ],
+        },
+      ],
+    };
+    const client = createMockClient({ presentTables: ['internal_lp_economics_runs'] });
+
+    await expect(auditManifest(client, duplicate)).rejects.toThrow(ReconcileError);
+  });
+});

--- a/tests/unit/routes/financial-facts.contract.test.ts
+++ b/tests/unit/routes/financial-facts.contract.test.ts
@@ -5,13 +5,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   EMPTY_SELECTION_SET_HASH,
+  EmbeddedFundAccountingStateSnapshotRefV1_1Schema,
   FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID_2,
   FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID_3,
+  FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID_4,
   FINANCIAL_FACTS_POLICY_VERSION_1_0_1,
   FINANCIAL_FACTS_POLICY_VERSION_1_1_0,
   FINANCIAL_FACTS_POLICY_VERSION_1_2_0,
+  FINANCIAL_FACTS_POLICY_VERSION_1_3_0,
   type FinancialFactsSnapshotV2,
   type FinancialFactsSnapshotV3,
+  type FinancialFactsSnapshotV4,
   type FinancialFactsSnapshotV1,
 } from '../../../shared/contracts/financial-facts-snapshot-v1.contract';
 import { IdempotentCommandError } from '../../../server/lib/idempotent-command';
@@ -193,6 +197,60 @@ function snapshotRowV3() {
   };
 }
 
+function resolvedOpeningAccountingState() {
+  return EmbeddedFundAccountingStateSnapshotRefV1_1Schema.parse({
+    sourceArtifactId: 42,
+    sourceArtifactSha256: 'd'.repeat(64),
+    sourceArtifactCreatedAt: '2026-06-30T20:15:00.000Z',
+    attestedByActorId: 7,
+    observation: {
+      contractVersion: 'fund-accounting-state-observation/1.1.0',
+      cutoverInstant: '2026-06-30T23:59:59.000Z',
+      currency: 'USD',
+      cashBalanceUsd: '1250000.000000',
+      cumulativeLpPaidInUsd: '10000000.000000',
+      cumulativeGpPaidInUsd: '250000.000000',
+      gpUnreturnedContributedCapitalUsd: '150000.000000',
+      lpDistributionsReturnOfCapitalUsd: '3500000.000000',
+      lpDistributionsProfitUsd: '875000.000000',
+      actualLpDistributionsCumulativeUsd: '4375000.000000',
+      gpInvestmentDistributionsPaidUsd: '125000.000000',
+      gpCarryPaidUsd: '200000.000000',
+      accruedPreferredReturnUsd: '325000.000000',
+      accruedPreferredReturnThroughInstant: '2026-06-30T23:59:59.000Z',
+      recallableDistributionsCumulativeUsd: '600000.000000',
+      recallableDistributionsOutstandingUsd: '400000.000000',
+      recycledProceedsCumulativeUsd: '250000.000000',
+      realizedProceedsCumulativeUsd: '5000000.000000',
+      methodologyVersion: 'fund-accounting-methodology/1.0.0',
+    },
+  });
+}
+
+function snapshotV4(overrides: Partial<FinancialFactsSnapshotV4> = {}): FinancialFactsSnapshotV4 {
+  return {
+    ...snapshotV2(),
+    policyVersion: FINANCIAL_FACTS_POLICY_VERSION_1_3_0,
+    payloadSchemaId: FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID_4,
+    payload: {
+      ...snapshotV2().payload,
+      openingAccountingState: resolvedOpeningAccountingState(),
+    },
+    ...overrides,
+  };
+}
+
+function snapshotRowV4() {
+  const value = snapshotV4();
+  return {
+    ...snapshotRowV2(),
+    policyVersion: value.policyVersion,
+    payloadSchemaId: value.payloadSchemaId,
+    payload: value.payload,
+    consumerEvaluations: value.consumerEvaluations,
+  };
+}
+
 function buildApp() {
   const app = express();
   app.use(express.json());
@@ -312,6 +370,20 @@ describe('financial-facts route contract', () => {
     expect(response.body.payloadSchemaId).toBe(FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID_3);
   });
 
+  it('GET serves a persisted policy 1.3.0 payload 4 snapshot with its tuple intact', async () => {
+    service.getLatestFinancialFactsSnapshot.mockResolvedValueOnce(snapshotRowV4());
+
+    const response = await request(buildApp()).get('/api/funds/1/financial-facts/latest');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(snapshotV4());
+    expect(response.body.policyVersion).toBe(FINANCIAL_FACTS_POLICY_VERSION_1_3_0);
+    expect(response.body.payloadSchemaId).toBe(FINANCIAL_FACTS_PAYLOAD_SCHEMA_ID_4);
+    expect(
+      response.body.payload.openingAccountingState.observation.lpUnreturnedContributedCapitalUsd
+    ).toBe('6500000.000000');
+  });
+
   it('GET rejects a corrupt legacy row that carries a payload 2 schema id', async () => {
     service.getLatestFinancialFactsSnapshot.mockResolvedValueOnce({
       ...snapshotRow(),
@@ -402,7 +474,7 @@ describe('financial-facts route contract', () => {
     expect(service.buildFinancialFactsSnapshot).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
-        idempotencyKey: 'facts:1:2026-07-21:financial-facts-policy/1.2.0:trigger-7',
+        idempotencyKey: 'facts:1:2026-07-21:financial-facts-policy/1.3.0:trigger-7',
       })
     );
   });

--- a/tests/unit/schema/internal-economics-schema.test.ts
+++ b/tests/unit/schema/internal-economics-schema.test.ts
@@ -1,0 +1,352 @@
+/**
+ * T-A4 (WP-L3 Phase A): Drizzle parity for migration 0045.
+ *
+ * The schema module `shared/schema/internal-economics.ts` must match
+ * `migrations/0045_internal_economics_policy_runs.sql` name-for-name so the
+ * journaled migration and a Drizzle push produce byte-identical catalogs (G5
+ * idiom). Composite-FK targets are declared as plain `unique()` constraints,
+ * never `uniqueIndex` (drizzle-kit 42830 lesson); the ONE partial unique
+ * (`internal_lp_economics_runs_result_snapshot_unique`) is correctly a
+ * `uniqueIndex().where(...)` because nothing FKs it.
+ */
+// Default import on purpose: node-setup.ts vi.mock('fs') stubs named exports,
+// while its actual-module spread preserves `default` as the real fs module.
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { PgDialect, getTableConfig } from 'drizzle-orm/pg-core';
+import { describe, expect, it } from 'vitest';
+
+import * as runtimeSchema from '@shared/schema';
+import { fundSnapshots } from '@shared/schema/fund';
+import {
+  internalCapitalEnvelopeVersions,
+  internalEconomicsPolicyVersions,
+  internalLpEconomicsRuns,
+} from '@shared/schema/internal-economics';
+
+const MIGRATION_PATH = path.join(
+  process.cwd(),
+  'migrations',
+  '0045_internal_economics_policy_runs.sql'
+);
+
+const tableEntries = [
+  ['internal_capital_envelope_versions', internalCapitalEnvelopeVersions],
+  ['internal_economics_policy_versions', internalEconomicsPolicyVersions],
+  ['internal_lp_economics_runs', internalLpEconomicsRuns],
+] as const;
+
+type OwnedTableName = (typeof tableEntries)[number][0];
+
+const tableConfigs = new Map(
+  tableEntries.map(([name, table]) => [name, getTableConfig(table)] as const)
+);
+const dialect = new PgDialect();
+
+function configFor(tableName: OwnedTableName) {
+  const config = tableConfigs.get(tableName);
+  if (!config) {
+    throw new Error(`Missing table config: ${tableName}`);
+  }
+  return config;
+}
+
+function constraintNames(tableName: OwnedTableName): string[] {
+  const config = configFor(tableName);
+  return [
+    ...config.foreignKeys.map((foreignKey) => foreignKey.getName()),
+    ...config.uniqueConstraints.map((constraint) => constraint.name ?? ''),
+    ...config.checks.map((constraint) => constraint.name),
+  ];
+}
+
+function checkSql(tableName: OwnedTableName, checkName: string): string {
+  const check = configFor(tableName).checks.find((candidate) => candidate.name === checkName);
+  if (!check) {
+    throw new Error(`Missing CHECK ${checkName}`);
+  }
+  // Strip the table qualifier Drizzle renders on column refs so assertions
+  // match the migration's unqualified in-table CHECK text.
+  return dialect.sqlToQuery(check.value).sql.replaceAll(`"${tableName}".`, '');
+}
+
+function migrationSql(): string {
+  return fs.readFileSync(MIGRATION_PATH, 'utf8');
+}
+
+interface MigrationTableBlock {
+  readonly name: string;
+  readonly body: string;
+}
+
+function migrationTableBlocks(): Map<string, MigrationTableBlock> {
+  const blocks = new Map<string, MigrationTableBlock>();
+  for (const match of migrationSql().matchAll(
+    /CREATE\s+TABLE\s+IF\s+NOT\s+EXISTS\s+"([a-z0-9_]+)"\s*\(([\s\S]*?)\);/gi
+  )) {
+    blocks.set(match[1]!, { name: match[1]!, body: match[2]! });
+  }
+  return blocks;
+}
+
+function blockFor(tableName: OwnedTableName): MigrationTableBlock {
+  const block = migrationTableBlocks().get(tableName);
+  if (!block) {
+    throw new Error(`Migration 0045 has no CREATE TABLE block for ${tableName}`);
+  }
+  return block;
+}
+
+function sqlConstraintNames(tableName: OwnedTableName): string[] {
+  return [...blockFor(tableName).body.matchAll(/CONSTRAINT\s+"([a-z0-9_]+)"/g)].map(
+    (match) => match[1]!
+  );
+}
+
+function sqlColumnNames(tableName: OwnedTableName): string[] {
+  return [...blockFor(tableName).body.matchAll(/^\s{2}"([a-z0-9_]+)"\s/gm)].map(
+    (match) => match[1]!
+  );
+}
+
+function normalizeTypeText(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/\(\s*/g, '(')
+    .replace(/\s*,\s*/g, ',')
+    .replace(/\s*\)/g, ')');
+}
+
+describe('internal economics Drizzle schema (T-A4)', () => {
+  it('exports all three tables through the runtime schema barrel', () => {
+    expect(runtimeSchema.internalCapitalEnvelopeVersions).toBe(internalCapitalEnvelopeVersions);
+    expect(runtimeSchema.internalEconomicsPolicyVersions).toBe(internalEconomicsPolicyVersions);
+    expect(runtimeSchema.internalLpEconomicsRuns).toBe(internalLpEconomicsRuns);
+  });
+
+  it('matches migration 0045 constraint names exactly, per table, both directions', () => {
+    for (const [tableName] of tableEntries) {
+      const declared = [...constraintNames(tableName)].sort();
+      const journaled = [...sqlConstraintNames(tableName)].sort();
+      expect(declared, `${tableName} constraint drift`).toEqual(journaled);
+    }
+  });
+
+  it('matches migration 0045 column names exactly, per table, both directions', () => {
+    for (const [tableName] of tableEntries) {
+      const declared = configFor(tableName)
+        .columns.map((column) => column.name)
+        .sort();
+      const journaled = [...sqlColumnNames(tableName)].sort();
+      expect(declared, `${tableName} column drift`).toEqual(journaled);
+    }
+  });
+
+  it('declares every column with the exact journaled SQL type', () => {
+    for (const [tableName] of tableEntries) {
+      const body = normalizeTypeText(blockFor(tableName).body);
+      for (const column of configFor(tableName).columns) {
+        const sqlType = normalizeTypeText(column.getSQLType());
+        expect(body, `${tableName}.${column.name} type drift`).toContain(
+          `"${column.name}" ${sqlType}`
+        );
+      }
+    }
+  });
+
+  it('fund-scopes every table with a required cascading fund FK', () => {
+    for (const [tableName] of tableEntries) {
+      const config = configFor(tableName);
+      const fundId = config.columns.find((column) => column.name === 'fund_id');
+      const fundFk = config.foreignKeys.find((foreignKey) =>
+        foreignKey.getName().endsWith('_fund_id_funds_id_fk')
+      );
+
+      expect(fundId?.notNull, `${tableName}.fund_id`).toBe(true);
+      expect(fundFk, `${tableName} fund FK`).toBeDefined();
+      expect(fundFk?.onDelete, `${tableName} fund FK delete action`).toBe('cascade');
+    }
+  });
+
+  it('declares every basis-version FK as ON DELETE restrict (L3-Q2 ruling)', () => {
+    const restrictFksByTable = {
+      internal_capital_envelope_versions: [
+        'internal_capital_envelope_versions_vehicle_fund_fk',
+        'internal_capital_envelope_versions_source_artifact_fund_fk',
+      ],
+      internal_economics_policy_versions: ['internal_economics_policy_versions_envelope_fund_fk'],
+      internal_lp_economics_runs: [
+        'internal_lp_economics_runs_policy_version_fund_fk',
+        'internal_lp_economics_runs_facts_snapshot_fund_fk',
+        'internal_lp_economics_runs_plan_version_fk',
+        'internal_lp_economics_runs_forecast_snapshot_type_fk',
+        'internal_lp_economics_runs_result_snapshot_type_fk',
+      ],
+    } as const;
+
+    for (const [tableName, names] of Object.entries(restrictFksByTable)) {
+      const foreignKeys = configFor(tableName as OwnedTableName).foreignKeys;
+      for (const name of names) {
+        const foreignKey = foreignKeys.find((candidate) => candidate.getName() === name);
+        expect(foreignKey, name).toBeDefined();
+        expect(foreignKey?.onDelete, `${name} delete action`).toBe('restrict');
+      }
+    }
+  });
+
+  it('keeps version-lineage self-FKs at NO ACTION, not restrict', () => {
+    const parentFks = [
+      ['internal_capital_envelope_versions', 'internal_capital_envelope_versions_parent_fund_fk'],
+      ['internal_economics_policy_versions', 'internal_economics_policy_versions_parent_fund_fk'],
+    ] as const;
+
+    for (const [tableName, name] of parentFks) {
+      const foreignKey = configFor(tableName).foreignKeys.find(
+        (candidate) => candidate.getName() === name
+      );
+      expect(foreignKey, name).toBeDefined();
+      expect(foreignKey?.onDelete ?? 'no action', `${name} delete action`).toBe('no action');
+    }
+  });
+
+  it('declares composite-FK targets as unique() constraints, never uniqueIndex (42830)', () => {
+    for (const [tableName] of tableEntries) {
+      const config = configFor(tableName);
+      const uniqueNames = config.uniqueConstraints.map((constraint) => constraint.name);
+      expect(uniqueNames).toContain(`${tableName}_id_fund_unique`);
+      expect(uniqueNames).toContain(`${tableName}_fund_idempotency_unique`);
+      const indexNames = config.indexes.map((index) => index.config.name);
+      expect(indexNames).not.toContain(`${tableName}_id_fund_unique`);
+    }
+    expect(
+      configFor('internal_capital_envelope_versions').uniqueConstraints.map((c) => c.name)
+    ).toContain('internal_capital_envelope_versions_fund_version_unique');
+    expect(
+      configFor('internal_economics_policy_versions').uniqueConstraints.map((c) => c.name)
+    ).toContain('internal_economics_policy_versions_fund_version_unique');
+  });
+
+  it('declares the one-result-snapshot-per-run rule as a partial uniqueIndex', () => {
+    const config = configFor('internal_lp_economics_runs');
+    const partial = config.indexes.find(
+      (index) => index.config.name === 'internal_lp_economics_runs_result_snapshot_unique'
+    );
+    expect(partial).toBeDefined();
+    expect(partial?.config.unique).toBe(true);
+    expect(partial?.config.where).toBeDefined();
+    expect(config.indexes.map((index) => index.config.name)).toContain(
+      'idx_internal_lp_economics_runs_fund_created'
+    );
+  });
+
+  it('adds fund_snapshots_id_type_unique to fund_snapshots as a unique() constraint', () => {
+    const config = getTableConfig(fundSnapshots);
+    const unique = config.uniqueConstraints.find(
+      (constraint) => constraint.name === 'fund_snapshots_id_type_unique'
+    );
+    expect(unique).toBeDefined();
+    expect(unique?.columns.map((column) => column.name)).toEqual(['id', 'type']);
+    expect(config.indexes.map((index) => index.config.name)).not.toContain(
+      'fund_snapshots_id_type_unique'
+    );
+    expect(migrationSql()).toContain(
+      'ADD CONSTRAINT "fund_snapshots_id_type_unique" UNIQUE ("id", "type")'
+    );
+  });
+
+  it('pins the P-D5 state-coupling and literal CHECK vocabularies', () => {
+    const coupling = checkSql(
+      'internal_lp_economics_runs',
+      'internal_lp_economics_runs_state_coupling_check'
+    );
+    for (const fragment of [
+      "'completed'",
+      "'failed'",
+      '"result_snapshot_id" is not null',
+      '"result_snapshot_type" is not null',
+      '"result_status" is not null',
+      '"result_hash" is not null',
+      '"failure_code" is null',
+      '"failure_context" is null',
+    ]) {
+      expect(coupling.toLowerCase()).toContain(fragment);
+    }
+
+    const resultStatus = checkSql(
+      'internal_lp_economics_runs',
+      'internal_lp_economics_runs_result_status_check'
+    );
+    expect(resultStatus).toContain("'indicative'");
+    expect(resultStatus).toContain("'unavailable'");
+    expect(resultStatus).not.toContain("'available'");
+
+    expect(
+      checkSql('internal_lp_economics_runs', 'internal_lp_economics_runs_terminal_mode_check')
+    ).toContain("'liquidate_at_horizon'");
+    expect(
+      checkSql(
+        'internal_lp_economics_runs',
+        'internal_lp_economics_runs_forecast_snapshot_type_check'
+      )
+    ).toContain("'CURRENT_FORECAST_V2'");
+    expect(
+      checkSql(
+        'internal_lp_economics_runs',
+        'internal_lp_economics_runs_result_snapshot_type_check'
+      )
+    ).toContain("'INTERNAL_LP_ECONOMICS'");
+
+    const sum = checkSql(
+      'internal_capital_envelope_versions',
+      'internal_capital_envelope_versions_commitment_sum_check'
+    );
+    expect(sum.toLowerCase()).toContain(
+      '"lp_commitment_usd" + "gp_commitment_usd" = "total_commitment_usd"'
+    );
+    expect(
+      checkSql(
+        'internal_capital_envelope_versions',
+        'internal_capital_envelope_versions_currency_check'
+      )
+    ).toContain("'USD'");
+  });
+
+  it('matches the migration trigger and index surface by name', () => {
+    const sql = migrationSql();
+    for (const trigger of [
+      'internal_capital_envelope_versions_forbid_update_trigger',
+      'internal_economics_policy_versions_forbid_update_trigger',
+      'internal_lp_economics_runs_forbid_update_trigger',
+      'fund_snapshots_internal_economics_forbid_update_trigger',
+    ]) {
+      expect(sql).toContain(`DROP TRIGGER IF EXISTS "${trigger}"`);
+      expect(sql).toContain(`CREATE TRIGGER "${trigger}"`);
+    }
+    expect(sql).toContain('CREATE OR REPLACE FUNCTION "internal_economics_forbid_update"()');
+    expect(sql).toContain(
+      'WHEN (OLD."type" = \'INTERNAL_LP_ECONOMICS\' OR NEW."type" = \'INTERNAL_LP_ECONOMICS\')'
+    );
+    expect(sql).toContain(
+      'CREATE UNIQUE INDEX IF NOT EXISTS "internal_lp_economics_runs_result_snapshot_unique"'
+    );
+    expect(sql).toContain(
+      'CREATE INDEX IF NOT EXISTS "idx_internal_lp_economics_runs_fund_created"'
+    );
+  });
+
+  it('keeps every new identifier within the PG 63-byte limit', () => {
+    const sql = migrationSql();
+    const identifiers = new Set<string>();
+    for (const match of sql.matchAll(/"([a-z0-9_]+)"/g)) {
+      identifiers.add(match[1]!);
+    }
+    for (const [tableName] of tableEntries) {
+      for (const name of [...constraintNames(tableName), tableName]) {
+        identifiers.add(name);
+      }
+    }
+    const overlong = [...identifiers].filter((name) => Buffer.byteLength(name, 'utf8') > 63);
+    expect(overlong).toEqual([]);
+  });
+});

--- a/tests/unit/services/current-forecast-v2-service.test.ts
+++ b/tests/unit/services/current-forecast-v2-service.test.ts
@@ -184,6 +184,33 @@ describe('current forecast v2 service', () => {
     ).resolves.toMatchObject({ contractVersion: 'current-forecast-v2' });
   });
 
+  it('runs from a payload 4 facts snapshot and round-trips its tuple', async () => {
+    const fakeDb = new FakeCurrentForecastDb();
+    const legacy = factsRow();
+    fakeDb.factsRows[0] = factsRow({
+      policyVersion: 'financial-facts-policy/1.3.0',
+      payloadSchemaId: 'financial-facts-payload/4',
+      payload: {
+        ...(legacy.payload as Record<string, unknown>),
+        positionRefs: [],
+        positionComponentRefs: [],
+        ownershipRefs: [],
+        valuationRefs: [],
+        observationRefs: [],
+        openingAccountingState: resolvedOpeningAccountingState(),
+      } as FactsRow['payload'],
+    });
+
+    await expect(
+      runCurrentForecastV2({
+        fundId: 1,
+        clock: '2026-07-22T18:24:32.051Z',
+        database: fakeDb.asDatabase(),
+      })
+    ).resolves.toMatchObject({ contractVersion: 'current-forecast-v2' });
+    expect(fakeDb.insertedSnapshots).toHaveLength(1);
+  });
+
   it('rejects facts rows whose stored policy and payload schema tuple is invalid', async () => {
     const fakeDb = new FakeCurrentForecastDb();
     fakeDb.factsRows[0] = factsRow({
@@ -316,6 +343,42 @@ function currentPlanRow(overrides: Partial<CurrentPlanRow> = {}): CurrentPlanRow
     requestHash: 'b'.repeat(64),
     createdAt: new Date('2026-07-22T02:00:00.000Z'),
     ...overrides,
+  };
+}
+
+/**
+ * A stored, already-resolved v1.1 embedded ref exactly as a persisted payload 4
+ * row would carry it: the derived lpUnreturnedContributedCapitalUsd is present
+ * and equals the frozen recomputation (20 paid-in minus 4 ROC).
+ */
+function resolvedOpeningAccountingState() {
+  return {
+    sourceArtifactId: 41,
+    sourceArtifactSha256: 'd'.repeat(64),
+    sourceArtifactCreatedAt: '2026-07-20T23:00:00.000Z',
+    attestedByActorId: 7,
+    observation: {
+      contractVersion: 'fund-accounting-state-observation/1.1.0',
+      cutoverInstant: '2026-07-20T23:59:59.000Z',
+      currency: 'USD',
+      cashBalanceUsd: '10.000000',
+      cumulativeLpPaidInUsd: '20.000000',
+      cumulativeGpPaidInUsd: '3.000000',
+      gpUnreturnedContributedCapitalUsd: '2.000000',
+      lpDistributionsReturnOfCapitalUsd: '4.000000',
+      lpDistributionsProfitUsd: '5.000000',
+      actualLpDistributionsCumulativeUsd: '9.000000',
+      gpInvestmentDistributionsPaidUsd: '1.000000',
+      gpCarryPaidUsd: '2.000000',
+      accruedPreferredReturnUsd: '3.000000',
+      accruedPreferredReturnThroughInstant: '2026-07-20T23:59:59.000Z',
+      recallableDistributionsCumulativeUsd: '6.000000',
+      recallableDistributionsOutstandingUsd: '2.000000',
+      recycledProceedsCumulativeUsd: '4.000000',
+      realizedProceedsCumulativeUsd: '8.000000',
+      methodologyVersion: 'manual-opening-state/1.0.0',
+      lpUnreturnedContributedCapitalUsd: '16.000000',
+    },
   };
 }
 

--- a/tests/unit/services/financial-facts-snapshot-service.test.ts
+++ b/tests/unit/services/financial-facts-snapshot-service.test.ts
@@ -7,7 +7,13 @@ import { describe, expect, it } from 'vitest';
 import type { db } from '../../../server/db';
 import { IdempotentCommandError } from '../../../server/lib/idempotent-command';
 import { buildFinancialFactsSnapshot } from '../../../server/services/financial-facts-snapshot-service';
-import { buildSelectionSetHash } from '../../../shared/contracts/financial-facts-snapshot-v1.contract';
+import {
+  FinancialFactsPayloadV4Schema,
+  FinancialFactsSnapshotInputHashPreimageV4Schema,
+  FinancialFactsSnapshotV4Schema,
+  buildSelectionSetHash,
+  buildSnapshotInputHash,
+} from '../../../shared/contracts/financial-facts-snapshot-v1.contract';
 import { funds } from '../../../shared/schema/fund';
 import { financialFactsSnapshots } from '../../../shared/schema/financial-facts-snapshots';
 import { sourceArtifacts, sourceObservations } from '../../../shared/schema/financial-observations';
@@ -29,14 +35,16 @@ import {
 
 type SnapshotDatabase = typeof db;
 const OBSERVATION_HASH = 'a'.repeat(64);
-const OPENING_STATE_OBSERVATION = {
-  contractVersion: 'fund-accounting-state-observation/1.0.0',
+// Raw (frozen v1.1 input-shape) opening-state observation: omits the derived
+// lpUnreturnedContributedCapitalUsd field, which the frozen schema computes
+// itself. This is what gets serialized into stored artifact bytes.
+const OPENING_STATE_OBSERVATION_INPUT = {
+  contractVersion: 'fund-accounting-state-observation/1.1.0',
   cutoverInstant: '2026-06-30T23:59:59.123456Z',
   currency: 'USD',
   cashBalanceUsd: '100.000000',
   cumulativeLpPaidInUsd: '80.000000',
   cumulativeGpPaidInUsd: '20.000000',
-  lpUnreturnedContributedCapitalUsd: '70.000000',
   gpUnreturnedContributedCapitalUsd: '15.000000',
   lpDistributionsReturnOfCapitalUsd: '10.000000',
   lpDistributionsProfitUsd: '5.000000',
@@ -51,6 +59,14 @@ const OPENING_STATE_OBSERVATION = {
   realizedProceedsCumulativeUsd: '21.000000',
   methodologyVersion: 'opening-state-methodology/1.0.0',
 } as const;
+// Resolved (output-shape) observation: derived by the frozen v1.1 schema as
+// cumulativeLpPaidInUsd (80) minus lpDistributionsReturnOfCapitalUsd (10).
+// This is what the producer/builder actually emits and what assertions
+// compare against.
+const OPENING_STATE_OBSERVATION = {
+  ...OPENING_STATE_OBSERVATION_INPUT,
+  lpUnreturnedContributedCapitalUsd: '70.000000',
+};
 
 function queryRows<T>(rows: T[]) {
   const query: {
@@ -108,7 +124,7 @@ function acceptedObservation(overrides: Record<string, unknown> = {}): Record<st
 }
 
 function openingStateArtifact(overrides: Record<string, unknown> = {}): Record<string, unknown> {
-  const payload = Buffer.from(JSON.stringify(OPENING_STATE_OBSERVATION), 'utf8');
+  const payload = Buffer.from(JSON.stringify(OPENING_STATE_OBSERVATION_INPUT), 'utf8');
   return {
     id: 42,
     fundId: 1,
@@ -462,7 +478,7 @@ describe('buildFinancialFactsSnapshot', () => {
     ).rejects.toMatchObject({ status: 400, code: 'CUTOFF_NOT_ACCEPTED' });
   });
 
-  it('emits payload 3 with a null opening state when no artifact id is supplied', async () => {
+  it('emits payload 4 with a null opening state when no artifact id is supplied', async () => {
     const fakeDb = new FakeSnapshotDb();
 
     const snapshot = await buildFinancialFactsSnapshot({
@@ -474,21 +490,21 @@ describe('buildFinancialFactsSnapshot', () => {
       now: new Date('2026-07-22T01:42:44.186Z'),
     });
 
-    if (snapshot.policyVersion !== 'financial-facts-policy/1.2.0') {
-      throw new Error(`Expected payload 3 snapshot, received ${snapshot.policyVersion}`);
+    if (snapshot.policyVersion !== 'financial-facts-policy/1.3.0') {
+      throw new Error(`Expected payload 4 snapshot, received ${snapshot.policyVersion}`);
     }
-    expect(snapshot.payloadSchemaId).toBe('financial-facts-payload/3');
+    expect(snapshot.payloadSchemaId).toBe('financial-facts-payload/4');
     expect(snapshot.payload.openingAccountingState).toBeNull();
     expect(fakeDb.sourceArtifactWhereClauses).toHaveLength(0);
   });
 
-  it('preserves the payload 3 schema id when reconstructing an exact replay', async () => {
+  it('preserves the payload 4 schema id when reconstructing an exact replay', async () => {
     const fakeDb = new FakeSnapshotDb();
     const input = {
       fundId: 1,
       asOfDate: '2026-06-30',
       actorId: 7,
-      idempotencyKey: 'snapshot-v3-reconstruction',
+      idempotencyKey: 'snapshot-v4-reconstruction',
       database: fakeDb.asDatabase(),
       now: new Date('2026-07-22T01:42:44.186Z'),
     };
@@ -498,12 +514,12 @@ describe('buildFinancialFactsSnapshot', () => {
 
     expect(replayed).toEqual(created);
     expect(replayed).toMatchObject({
-      policyVersion: 'financial-facts-policy/1.2.0',
-      payloadSchemaId: 'financial-facts-payload/3',
+      policyVersion: 'financial-facts-policy/1.3.0',
+      payloadSchemaId: 'financial-facts-payload/4',
     });
   });
 
-  it('pins the exact selected artifact ref into payload 3', async () => {
+  it('pins the exact selected artifact ref into payload 4', async () => {
     const fakeDb = new FakeSnapshotDb();
     const artifact = openingStateArtifact();
     fakeDb.sourceArtifactRows.push(artifact);
@@ -518,8 +534,8 @@ describe('buildFinancialFactsSnapshot', () => {
       now: new Date('2026-07-22T01:42:44.186Z'),
     });
 
-    if (snapshot.policyVersion !== 'financial-facts-policy/1.2.0') {
-      throw new Error(`Expected payload 3 snapshot, received ${snapshot.policyVersion}`);
+    if (snapshot.policyVersion !== 'financial-facts-policy/1.3.0') {
+      throw new Error(`Expected payload 4 snapshot, received ${snapshot.policyVersion}`);
     }
     expect(snapshot.payload.openingAccountingState).toEqual({
       sourceArtifactId: 42,
@@ -528,6 +544,71 @@ describe('buildFinancialFactsSnapshot', () => {
       attestedByActorId: 7,
       observation: OPENING_STATE_OBSERVATION,
     });
+  });
+
+  it('emits an authoritative V4 hash that reconstructs via the exported preimage schema and helper, and survives the five-stage traversal (T-D3)', async () => {
+    const fakeDb = new FakeSnapshotDb();
+    const artifact = openingStateArtifact();
+    fakeDb.sourceArtifactRows.push(artifact);
+
+    const snapshot = await buildFinancialFactsSnapshot({
+      fundId: 1,
+      asOfDate: '2026-06-30',
+      openingAccountingStateArtifactId: 42,
+      actorId: 7,
+      idempotencyKey: 'snapshot-v4-hash-oracle',
+      database: fakeDb.asDatabase(),
+      now: new Date('2026-07-22T01:42:44.186Z'),
+    });
+
+    if (snapshot.policyVersion !== 'financial-facts-policy/1.3.0') {
+      throw new Error(`Expected payload 4 snapshot, received ${snapshot.policyVersion}`);
+    }
+    expect(snapshot.payloadSchemaId).toBe('financial-facts-payload/4');
+
+    // Reconstruct-and-compare oracle (R8 amendment): rebuild the V4
+    // hash-preimage object from the emitted snapshot's own authoritative
+    // fields, validate it under the V4 preimage schema (never silently
+    // accepted by V3's), and assert the exported hash helper reproduces the
+    // persisted hash exactly -- proving V4 dispatch, not a fabricated value.
+    const reconstructedPreimage = FinancialFactsSnapshotInputHashPreimageV4Schema.parse({
+      fundId: snapshot.fundId,
+      vehicleIds: snapshot.vehicleIds,
+      asOfDate: snapshot.asOfDate,
+      knowledgeCutoff: snapshot.knowledgeCutoff,
+      policyVersion: snapshot.policyVersion,
+      payloadSchemaId: snapshot.payloadSchemaId,
+      selectionSetHash: snapshot.selectionSetHash,
+      payload: snapshot.payload,
+    });
+    expect(buildSnapshotInputHash(reconstructedPreimage)).toBe(snapshot.snapshotInputHash);
+
+    // Five-stage traversal (R10 amendment): payload parse -> V4-preimage
+    // parse -> direct hash-helper reparse -> persisted-envelope parse ->
+    // readback parse, none of which may reject, each preserving the resolved
+    // opening state and exact hash.
+    const payloadStage = FinancialFactsPayloadV4Schema.parse(snapshot.payload);
+    expect(payloadStage.openingAccountingState).toEqual(snapshot.payload.openingAccountingState);
+
+    const preimageStage = FinancialFactsSnapshotInputHashPreimageV4Schema.parse({
+      ...reconstructedPreimage,
+      payload: payloadStage,
+    });
+    expect(preimageStage.payload.openingAccountingState).toEqual(
+      snapshot.payload.openingAccountingState
+    );
+
+    const hashStage = buildSnapshotInputHash(preimageStage);
+    expect(hashStage).toBe(snapshot.snapshotInputHash);
+
+    const envelopeStage = FinancialFactsSnapshotV4Schema.parse(snapshot);
+    const readbackStage = FinancialFactsSnapshotV4Schema.parse(
+      JSON.parse(JSON.stringify(snapshot)) as unknown
+    );
+    for (const stage of [envelopeStage, readbackStage]) {
+      expect(stage.payload.openingAccountingState).toEqual(snapshot.payload.openingAccountingState);
+      expect(stage.snapshotInputHash).toBe(snapshot.snapshotInputHash);
+    }
   });
 
   it('replays an artifact-backed snapshot after the source payload is purged', async () => {
@@ -760,7 +841,7 @@ describe('buildFinancialFactsSnapshot', () => {
     ).rejects.toMatchObject({
       status: 422,
       code: 'VEHICLE_SCOPE_UNSUPPORTED',
-      message: 'Policy 1.2.0 supports only the complete fund vehicle roster.',
+      message: 'Policy 1.3.0 supports only the complete fund vehicle roster.',
     });
 
     const accepted = await buildFinancialFactsSnapshot({

--- a/tests/unit/services/financial-facts/opening-accounting-state-artifact.test.ts
+++ b/tests/unit/services/financial-facts/opening-accounting-state-artifact.test.ts
@@ -5,13 +5,12 @@ import { describe, expect, it } from 'vitest';
 import { parseOpeningAccountingStateArtifact } from '../../../../server/services/financial-facts/opening-accounting-state-artifact';
 
 const observation = {
-  contractVersion: 'fund-accounting-state-observation/1.0.0',
+  contractVersion: 'fund-accounting-state-observation/1.1.0',
   cutoverInstant: '2026-06-30T23:59:59.123456Z',
   currency: 'USD',
   cashBalanceUsd: '100.000000',
   cumulativeLpPaidInUsd: '80.000000',
   cumulativeGpPaidInUsd: '20.000000',
-  lpUnreturnedContributedCapitalUsd: '70.000000',
   gpUnreturnedContributedCapitalUsd: '15.000000',
   lpDistributionsReturnOfCapitalUsd: '10.000000',
   lpDistributionsProfitUsd: '5.000000',
@@ -26,6 +25,40 @@ const observation = {
   realizedProceedsCumulativeUsd: '21.000000',
   methodologyVersion: 'opening-state-methodology/1.0.0',
 } as const;
+
+// The frozen v1.1 schema derives lpUnreturnedContributedCapitalUsd as
+// cumulativeLpPaidInUsd (80) minus lpDistributionsReturnOfCapitalUsd (10);
+// this is the shape parseOpeningAccountingStateArtifact actually returns.
+const resolvedObservation = {
+  ...observation,
+  lpUnreturnedContributedCapitalUsd: '70.000000',
+};
+
+// G20 founding fixture (shared with fund-accounting-state-observation-v1.1
+// contract tests and the V4 contract adapter tests): paidIn 10,000,000 minus
+// ROC 3,500,000 derives 6,500,000.
+const G20_FOUNDING_OBSERVATION_INPUT = {
+  contractVersion: 'fund-accounting-state-observation/1.1.0',
+  cutoverInstant: '2026-06-30T23:59:59.000Z',
+  currency: 'USD',
+  cashBalanceUsd: '1250000.000000',
+  cumulativeLpPaidInUsd: '10000000.000000',
+  cumulativeGpPaidInUsd: '250000.000000',
+  gpUnreturnedContributedCapitalUsd: '150000.000000',
+  lpDistributionsReturnOfCapitalUsd: '3500000.000000',
+  lpDistributionsProfitUsd: '875000.000000',
+  actualLpDistributionsCumulativeUsd: '4375000.000000',
+  gpInvestmentDistributionsPaidUsd: '125000.000000',
+  gpCarryPaidUsd: '200000.000000',
+  accruedPreferredReturnUsd: '325000.000000',
+  accruedPreferredReturnThroughInstant: '2026-06-30T23:59:59.000Z',
+  recallableDistributionsCumulativeUsd: '600000.000000',
+  recallableDistributionsOutstandingUsd: '400000.000000',
+  recycledProceedsCumulativeUsd: '250000.000000',
+  realizedProceedsCumulativeUsd: '5000000.000000',
+  methodologyVersion: 'fund-accounting-methodology/1.0.0',
+} as const;
+const G20_DERIVED_LP_UNRETURNED = '6500000.000000';
 
 function artifactRow(overrides: Record<string, unknown> = {}) {
   const payload = Buffer.from(JSON.stringify(observation), 'utf8');
@@ -67,7 +100,7 @@ describe('parseOpeningAccountingStateArtifact', () => {
         sourceArtifactSha256: row.payloadSha256,
         sourceArtifactCreatedAt: '2026-06-30T23:59:59.500Z',
         attestedByActorId: 99,
-        observation,
+        observation: resolvedObservation,
       });
     }
   );
@@ -210,6 +243,71 @@ describe('parseOpeningAccountingStateArtifact', () => {
       expect.objectContaining({
         status: 422,
         code: 'OPENING_ACCOUNTING_STATE_AS_OF_MISMATCH',
+      })
+    );
+  });
+});
+
+describe('parseOpeningAccountingStateArtifact v1.1 parse boundary (T-D2)', () => {
+  it('derives lpUnreturnedContributedCapitalUsd from the G20 founding fixture (paidIn 10,000,000 / ROC 3,500,000 -> 6,500,000)', () => {
+    const payload = Buffer.from(JSON.stringify(G20_FOUNDING_OBSERVATION_INPUT), 'utf8');
+
+    const resolved = parseOpeningAccountingStateArtifact({
+      ...parseInput,
+      row: artifactRow({
+        payload,
+        payloadSha256: createHash('sha256').update(payload).digest('hex'),
+      }),
+    });
+
+    expect(resolved.observation.lpUnreturnedContributedCapitalUsd).toBe(G20_DERIVED_LP_UNRETURNED);
+    expect(resolved.observation.contractVersion).toBe('fund-accounting-state-observation/1.1.0');
+  });
+
+  it('rejects a stored v1.0.0 artifact as typed INVALID with version context, not a silent v1 fallback', () => {
+    const v1Observation = {
+      ...G20_FOUNDING_OBSERVATION_INPUT,
+      contractVersion: 'fund-accounting-state-observation/1.0.0',
+      lpUnreturnedContributedCapitalUsd: G20_DERIVED_LP_UNRETURNED,
+    };
+    const payload = Buffer.from(JSON.stringify(v1Observation), 'utf8');
+
+    expect(() =>
+      parseOpeningAccountingStateArtifact({
+        ...parseInput,
+        row: artifactRow({
+          payload,
+          payloadSha256: createHash('sha256').update(payload).digest('hex'),
+        }),
+      })
+    ).toThrowError(
+      expect.objectContaining({
+        status: 422,
+        code: 'OPENING_ACCOUNTING_STATE_ARTIFACT_INVALID',
+        message: expect.stringContaining('fund-accounting-state-observation/1.0.0'),
+      })
+    );
+  });
+
+  it('rejects a source artifact that supplies lpUnreturnedContributedCapitalUsd directly, even when its value equals the correct derivation', () => {
+    const suppliedDerivedObservation = {
+      ...G20_FOUNDING_OBSERVATION_INPUT,
+      lpUnreturnedContributedCapitalUsd: G20_DERIVED_LP_UNRETURNED,
+    };
+    const payload = Buffer.from(JSON.stringify(suppliedDerivedObservation), 'utf8');
+
+    expect(() =>
+      parseOpeningAccountingStateArtifact({
+        ...parseInput,
+        row: artifactRow({
+          payload,
+          payloadSha256: createHash('sha256').update(payload).digest('hex'),
+        }),
+      })
+    ).toThrowError(
+      expect.objectContaining({
+        status: 422,
+        code: 'OPENING_ACCOUNTING_STATE_ARTIFACT_INVALID',
       })
     );
   });

--- a/tests/unit/services/internal-economics/capital-envelope-service.test.ts
+++ b/tests/unit/services/internal-economics/capital-envelope-service.test.ts
@@ -1,0 +1,496 @@
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { describe, expect, it } from 'vitest';
+
+import type { db } from '../../../../server/db';
+import {
+  assertOwnedByFund,
+  FundScopeError,
+  type FundScopedOwnershipDatabase,
+} from '../../../../server/lib/fund-scoped-ownership';
+import { IdempotentCommandError } from '../../../../server/lib/idempotent-command';
+import {
+  CapitalEnvelopeServiceError,
+  createCapitalEnvelopeVersion,
+} from '../../../../server/services/internal-economics/capital-envelope-service';
+import {
+  CapitalEnvelopeCreateRequestV1Schema,
+  type CapitalEnvelopeCreateRequestV1,
+} from '../../../../shared/contracts/internal-economics/capital-envelope-v1.contract';
+import { internalCapitalEnvelopeVersions } from '../../../../shared/schema/internal-economics';
+import { vehicles } from '../../../../shared/schema/vehicles';
+
+type EnvelopeDatabase = typeof db;
+
+function queryRows<T>(rows: T[]) {
+  const query: {
+    limit: (count: number) => Promise<T[]>;
+    orderBy: (..._order: unknown[]) => typeof query;
+    where: (_condition: unknown) => typeof query;
+    then: Promise<T[]>['then'];
+  } = {
+    limit: (count: number) => Promise.resolve(rows.slice(0, count)),
+    orderBy: (..._order: unknown[]) => query,
+    where: (_condition: unknown) => query,
+    then: <TResult1 = T[], TResult2 = never>(
+      onfulfilled?: ((value: T[]) => TResult1 | PromiseLike<TResult1>) | null,
+      onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ) => Promise.resolve(rows).then(onfulfilled, onrejected),
+  };
+  return query;
+}
+
+function validEnvelopeRequestFields(
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    mainFundVehicleId: 10,
+    lpCommitmentUsd: '900000.000000',
+    gpCommitmentUsd: '100000.000000',
+    totalCommitmentUsd: '1000000.000000',
+    currency: 'USD',
+    effectiveAt: '2026-01-01T00:00:00.000Z',
+    sourceArtifactId: 501,
+    sourceConfigId: 7,
+    sourceConfigVersion: 3,
+    sourceConfigHash: 'a'.repeat(64),
+    attestedBy: 42,
+    attestedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+/** Schema-valid fixture (routed through `.parse` so tests catch fixture drift). */
+function envelopeRequest(overrides: Record<string, unknown> = {}): CapitalEnvelopeCreateRequestV1 {
+  return CapitalEnvelopeCreateRequestV1Schema.parse(validEnvelopeRequestFields(overrides));
+}
+
+/** Deliberately invalid fixture (bypasses `.parse` so the service's own
+ * validation, not the fixture builder, is what rejects it). */
+function invalidEnvelopeRequest(
+  overrides: Record<string, unknown>
+): CapitalEnvelopeCreateRequestV1 {
+  return validEnvelopeRequestFields(overrides) as unknown as CapitalEnvelopeCreateRequestV1;
+}
+
+/**
+ * In-memory Drizzle double for `internal_capital_envelope_versions` +
+ * `vehicles`, mirroring the `FakeSnapshotDb` idiom in
+ * financial-facts-snapshot-service.test.ts. `pg_advisory_xact_lock` is
+ * modeled as a real per-key async mutex (queued FIFO, released when the
+ * owning `transaction()` callback settles) so concurrent-creation races
+ * (T-B5 / P-D11) serialize exactly like a real advisory lock would.
+ */
+class FakeCapitalEnvelopeDb {
+  readonly envelopeRows: Array<Record<string, unknown>> = [];
+  readonly vehicleRows: Array<Record<string, unknown>> = [];
+  readonly executedStatements: SQL[] = [];
+  readonly transactionConfigs: Array<Record<string, unknown> | undefined> = [];
+  private readonly lockTails = new Map<string, Promise<void>>();
+
+  asDatabase(): EnvelopeDatabase {
+    return this.buildHandle([]);
+  }
+
+  private buildHandle(releases: Array<() => void>): EnvelopeDatabase {
+    return {
+      select: (projection?: Record<string, unknown>) => this.select(projection),
+      insert: (table: unknown) => this.insert(table),
+      execute: (query: SQL) => this.execute(query, releases),
+      transaction: <T>(
+        callback: (tx: EnvelopeDatabase) => Promise<T>,
+        config?: Record<string, unknown>
+      ) => this.transaction(callback, config),
+    } as unknown as EnvelopeDatabase;
+  }
+
+  private async transaction<T>(
+    callback: (tx: EnvelopeDatabase) => Promise<T>,
+    config?: Record<string, unknown>
+  ): Promise<T> {
+    this.transactionConfigs.push(config);
+    const releases: Array<() => void> = [];
+    const handle = this.buildHandle(releases);
+    try {
+      return await callback(handle);
+    } finally {
+      for (const release of releases) release();
+    }
+  }
+
+  private async execute(query: SQL, releases: Array<() => void>): Promise<{ rows: unknown[] }> {
+    this.executedStatements.push(query);
+    const rendered = new PgDialect().sqlToQuery(query);
+    if (rendered.sql.includes('pg_advisory_xact_lock')) {
+      const key = String(rendered.params[0]);
+      const release = await this.acquireLock(key);
+      releases.push(release);
+    }
+    return { rows: [] };
+  }
+
+  private async acquireLock(key: string): Promise<() => void> {
+    const previousTail = this.lockTails.get(key) ?? Promise.resolve();
+    let release: () => void = () => {};
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    this.lockTails.set(
+      key,
+      previousTail.then(() => held)
+    );
+    await previousTail;
+    return release;
+  }
+
+  private select(projection?: Record<string, unknown>) {
+    return {
+      from: (table: unknown) => ({
+        where: (condition: unknown) => this.whereRows(table, projection, condition),
+      }),
+    };
+  }
+
+  private whereRows(
+    table: unknown,
+    projection: Record<string, unknown> | undefined,
+    condition: unknown
+  ) {
+    const rendered = new PgDialect().sqlToQuery(condition as SQL);
+    if (table === vehicles) {
+      const [idParam, fundIdParam] = rendered.params;
+      return queryRows(
+        this.vehicleRows.filter((row) => row['id'] === idParam && row['fundId'] === fundIdParam)
+      );
+    }
+    if (table === internalCapitalEnvelopeVersions) {
+      const keys = projection ? Object.keys(projection) : [];
+      if (keys.includes('version')) {
+        const [fundIdParam] = rendered.params;
+        const filtered = this.envelopeRows
+          .filter((row) => row['fundId'] === fundIdParam)
+          .sort((left, right) => (right['version'] as number) - (left['version'] as number));
+        return queryRows(filtered);
+      }
+      if (keys.length === 1 && keys[0] === 'id') {
+        const [idParam, fundIdParam] = rendered.params;
+        return queryRows(
+          this.envelopeRows.filter((row) => row['id'] === idParam && row['fundId'] === fundIdParam)
+        );
+      }
+      const [fundIdParam, keyParam] = rendered.params;
+      return queryRows(
+        this.envelopeRows.filter(
+          (row) => row['fundId'] === fundIdParam && row['idempotencyKey'] === keyParam
+        )
+      );
+    }
+    return queryRows([]);
+  }
+
+  private insert(table: unknown) {
+    return {
+      values: (values: Record<string, unknown>) => ({
+        onConflictDoNothing: (_options: unknown) => ({
+          returning: () => {
+            if (table !== internalCapitalEnvelopeVersions) return Promise.resolve([]);
+            const conflict = this.envelopeRows.some(
+              (row) =>
+                row['fundId'] === values['fundId'] &&
+                row['idempotencyKey'] === values['idempotencyKey']
+            );
+            if (conflict) return Promise.resolve([]);
+            const inserted = { id: this.envelopeRows.length + 1, createdAt: new Date(), ...values };
+            this.envelopeRows.push(inserted);
+            return Promise.resolve([inserted]);
+          },
+        }),
+      }),
+    };
+  }
+}
+
+function seedMainFundVehicle(
+  fakeDb: FakeCapitalEnvelopeDb,
+  overrides: Record<string, unknown> = {}
+): void {
+  fakeDb.vehicleRows.push({ id: 10, fundId: 1, vehicleType: 'main_fund', ...overrides });
+}
+
+describe('createCapitalEnvelopeVersion', () => {
+  it('creates version 1 with no parent on the happy path', async () => {
+    const fakeDb = new FakeCapitalEnvelopeDb();
+    seedMainFundVehicle(fakeDb);
+
+    const row = await createCapitalEnvelopeVersion({
+      fundId: 1,
+      actorId: 7,
+      idempotencyKey: 'envelope-create-1',
+      request: envelopeRequest(),
+      database: fakeDb.asDatabase(),
+    });
+
+    expect(row['version']).toBe(1);
+    expect(row['parentEnvelopeVersionId']).toBeNull();
+    expect(row['fundId']).toBe(1);
+    expect(row['envelopeHash']).toMatch(/^[0-9a-f]{64}$/);
+    expect(row['requestHash']).toMatch(/^[0-9a-f]{64}$/);
+    expect(fakeDb.envelopeRows).toHaveLength(1);
+  });
+
+  it('replays the same row for a repeated idempotency key without a second insert', async () => {
+    const fakeDb = new FakeCapitalEnvelopeDb();
+    seedMainFundVehicle(fakeDb);
+    const request = envelopeRequest();
+
+    const first = await createCapitalEnvelopeVersion({
+      fundId: 1,
+      actorId: 7,
+      idempotencyKey: 'envelope-replay',
+      request,
+      database: fakeDb.asDatabase(),
+    });
+    const second = await createCapitalEnvelopeVersion({
+      fundId: 1,
+      actorId: 7,
+      idempotencyKey: 'envelope-replay',
+      request,
+      database: fakeDb.asDatabase(),
+    });
+
+    expect(second).toEqual(first);
+    expect(fakeDb.envelopeRows).toHaveLength(1);
+  });
+
+  it('rejects a changed preimage reusing the same idempotency key with 409', async () => {
+    const fakeDb = new FakeCapitalEnvelopeDb();
+    seedMainFundVehicle(fakeDb);
+
+    await createCapitalEnvelopeVersion({
+      fundId: 1,
+      actorId: 7,
+      idempotencyKey: 'envelope-reuse',
+      request: envelopeRequest(),
+      database: fakeDb.asDatabase(),
+    });
+
+    await expect(
+      createCapitalEnvelopeVersion({
+        fundId: 1,
+        actorId: 7,
+        idempotencyKey: 'envelope-reuse',
+        request: envelopeRequest({
+          lpCommitmentUsd: '800000.000000',
+          totalCommitmentUsd: '900000.000000',
+        }),
+        database: fakeDb.asDatabase(),
+      })
+    ).rejects.toMatchObject({
+      status: 409,
+      code: 'IDEMPOTENCY_KEY_REUSE',
+    });
+    await expect(
+      createCapitalEnvelopeVersion({
+        fundId: 1,
+        actorId: 7,
+        idempotencyKey: 'envelope-reuse',
+        request: envelopeRequest({
+          lpCommitmentUsd: '800000.000000',
+          totalCommitmentUsd: '900000.000000',
+        }),
+        database: fakeDb.asDatabase(),
+      })
+    ).rejects.toBeInstanceOf(IdempotentCommandError);
+    expect(fakeDb.envelopeRows).toHaveLength(1);
+  });
+});
+
+describe('createCapitalEnvelopeVersion Brief 3 invariant refusals', () => {
+  const cases: ReadonlyArray<{
+    readonly name: string;
+    readonly overrides: Record<string, unknown>;
+    readonly code: string;
+  }> = [
+    {
+      name: 'negative LP commitment',
+      overrides: { lpCommitmentUsd: '-1.000000', totalCommitmentUsd: '99999.000000' },
+      code: 'ENVELOPE_LP_COMMITMENT_NEGATIVE',
+    },
+    {
+      name: 'negative GP commitment',
+      overrides: { gpCommitmentUsd: '-1.000000', totalCommitmentUsd: '899999.000000' },
+      code: 'ENVELOPE_GP_COMMITMENT_NEGATIVE',
+    },
+    {
+      name: 'non-positive total commitment',
+      overrides: {
+        lpCommitmentUsd: '0.000000',
+        gpCommitmentUsd: '0.000000',
+        totalCommitmentUsd: '0.000000',
+      },
+      code: 'ENVELOPE_TOTAL_COMMITMENT_NOT_POSITIVE',
+    },
+    {
+      name: 'lp + gp != total',
+      overrides: { totalCommitmentUsd: '1000001.000000' },
+      code: 'ENVELOPE_COMMITMENT_SUM_MISMATCH',
+    },
+  ];
+
+  it.each(cases)('refuses 422 $code for $name, nothing persisted', async ({ overrides, code }) => {
+    const fakeDb = new FakeCapitalEnvelopeDb();
+    seedMainFundVehicle(fakeDb);
+
+    await expect(
+      createCapitalEnvelopeVersion({
+        fundId: 1,
+        actorId: 7,
+        idempotencyKey: `envelope-invariant-${code}`,
+        request: invalidEnvelopeRequest(overrides),
+        database: fakeDb.asDatabase(),
+      })
+    ).rejects.toMatchObject({ status: 422, code });
+    expect(fakeDb.envelopeRows).toHaveLength(0);
+  });
+});
+
+describe('createCapitalEnvelopeVersion vehicle refusals', () => {
+  it('refuses 422 ENVELOPE_VEHICLE_NOT_MAIN_FUND for a non-main-fund vehicle, nothing persisted', async () => {
+    const fakeDb = new FakeCapitalEnvelopeDb();
+    fakeDb.vehicleRows.push({ id: 10, fundId: 1, vehicleType: 'spv' });
+
+    await expect(
+      createCapitalEnvelopeVersion({
+        fundId: 1,
+        actorId: 7,
+        idempotencyKey: 'envelope-non-main-fund',
+        request: envelopeRequest(),
+        database: fakeDb.asDatabase(),
+      })
+    ).rejects.toBeInstanceOf(CapitalEnvelopeServiceError);
+    await expect(
+      createCapitalEnvelopeVersion({
+        fundId: 1,
+        actorId: 7,
+        idempotencyKey: 'envelope-non-main-fund-2',
+        request: envelopeRequest(),
+        database: fakeDb.asDatabase(),
+      })
+    ).rejects.toMatchObject({ status: 422, code: 'ENVELOPE_VEHICLE_NOT_MAIN_FUND' });
+    expect(fakeDb.envelopeRows).toHaveLength(0);
+  });
+
+  it('refuses 422 ENVELOPE_VEHICLE_NOT_IN_FUND for a vehicle owned by a different fund, nothing persisted', async () => {
+    const fakeDb = new FakeCapitalEnvelopeDb();
+    fakeDb.vehicleRows.push({ id: 10, fundId: 2, vehicleType: 'main_fund' });
+
+    await expect(
+      createCapitalEnvelopeVersion({
+        fundId: 1,
+        actorId: 7,
+        idempotencyKey: 'envelope-cross-fund-vehicle',
+        request: envelopeRequest(),
+        database: fakeDb.asDatabase(),
+      })
+    ).rejects.toMatchObject({ status: 422, code: 'ENVELOPE_VEHICLE_NOT_IN_FUND' });
+    expect(fakeDb.envelopeRows).toHaveLength(0);
+  });
+});
+
+describe('createCapitalEnvelopeVersion child-version correction chain', () => {
+  it('chains version 2 to version 1 as parent', async () => {
+    const fakeDb = new FakeCapitalEnvelopeDb();
+    seedMainFundVehicle(fakeDb);
+
+    const v1 = await createCapitalEnvelopeVersion({
+      fundId: 1,
+      actorId: 7,
+      idempotencyKey: 'envelope-chain-1',
+      request: envelopeRequest(),
+      database: fakeDb.asDatabase(),
+    });
+    const v2 = await createCapitalEnvelopeVersion({
+      fundId: 1,
+      actorId: 7,
+      idempotencyKey: 'envelope-chain-2',
+      request: envelopeRequest({
+        lpCommitmentUsd: '850000.000000',
+        totalCommitmentUsd: '950000.000000',
+      }),
+      database: fakeDb.asDatabase(),
+    });
+
+    expect(v1['version']).toBe(1);
+    expect(v1['parentEnvelopeVersionId']).toBeNull();
+    expect(v2['version']).toBe(2);
+    expect(v2['parentEnvelopeVersionId']).toBe(v1['id']);
+    expect(fakeDb.envelopeRows).toHaveLength(2);
+  });
+});
+
+describe('createCapitalEnvelopeVersion P-D11 concurrent version allocation', () => {
+  it('serializes concurrent creates for the same fund into distinct, non-colliding versions', async () => {
+    const fakeDb = new FakeCapitalEnvelopeDb();
+    seedMainFundVehicle(fakeDb);
+
+    const [left, right] = await Promise.all([
+      createCapitalEnvelopeVersion({
+        fundId: 1,
+        actorId: 7,
+        idempotencyKey: 'envelope-concurrent-left',
+        request: envelopeRequest(),
+        database: fakeDb.asDatabase(),
+      }),
+      createCapitalEnvelopeVersion({
+        fundId: 1,
+        actorId: 7,
+        idempotencyKey: 'envelope-concurrent-right',
+        request: envelopeRequest({
+          lpCommitmentUsd: '850000.000000',
+          totalCommitmentUsd: '950000.000000',
+        }),
+        database: fakeDb.asDatabase(),
+      }),
+    ]);
+
+    expect(fakeDb.envelopeRows).toHaveLength(2);
+    const versions = [left['version'], right['version']].sort();
+    expect(versions).toEqual([1, 2]);
+    // Whichever row landed second must chain to whichever landed first.
+    const byVersion = new Map([
+      [left['version'] as number, left],
+      [right['version'] as number, right],
+    ]);
+    expect(byVersion.get(2)?.['parentEnvelopeVersionId']).toBe(byVersion.get(1)?.['id']);
+  });
+});
+
+describe("fund-scoped-ownership 'capital_envelope_version' kind", () => {
+  it('resolves for an envelope version owned by the given fund and rejects across funds', async () => {
+    const fakeDb = new FakeCapitalEnvelopeDb();
+    seedMainFundVehicle(fakeDb);
+    const envelope = await createCapitalEnvelopeVersion({
+      fundId: 1,
+      actorId: 7,
+      idempotencyKey: 'envelope-ownership-kind',
+      request: envelopeRequest(),
+      database: fakeDb.asDatabase(),
+    });
+
+    await expect(
+      assertOwnedByFund({
+        db: fakeDb.asDatabase() as unknown as FundScopedOwnershipDatabase,
+        fundId: 1,
+        ref: { kind: 'capital_envelope_version', id: envelope['id'] as number },
+      })
+    ).resolves.toBeUndefined();
+
+    await expect(
+      assertOwnedByFund({
+        db: fakeDb.asDatabase() as unknown as FundScopedOwnershipDatabase,
+        fundId: 2,
+        ref: { kind: 'capital_envelope_version', id: envelope['id'] as number },
+      })
+    ).rejects.toBeInstanceOf(FundScopeError);
+  });
+});

--- a/tests/unit/services/internal-economics/economics-policy-service.test.ts
+++ b/tests/unit/services/internal-economics/economics-policy-service.test.ts
@@ -1,0 +1,705 @@
+/**
+ * economics-policy-service.test.ts
+ *
+ * WP-L3 Phase B acceptance fixtures for the policy half of T-B2/T-B3/T-B4/T-B5.
+ * Mirrors the in-memory Drizzle-query-shaped `FakeCapitalEnvelopeDb` idiom in
+ * tests/unit/services/internal-economics/capital-envelope-service.test.ts,
+ * extended with a `fundConfigs` table and a real per-key async mutex
+ * simulation of `pg_advisory_xact_lock` so T-B5's concurrency fixture
+ * exercises genuine serialization. No real Postgres connection is used.
+ */
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { describe, expect, it } from 'vitest';
+
+import type { db } from '../../../../server/db';
+import {
+  assertOwnedByFund,
+  FundScopeError,
+  type FundScopedOwnershipDatabase,
+} from '../../../../server/lib/fund-scoped-ownership';
+import {
+  createEconomicsPolicyVersion,
+  EconomicsPolicySeedRefusalError,
+  getPolicyVersion,
+} from '../../../../server/services/internal-economics/economics-policy-service';
+import {
+  EconomicsPolicyCreateRequestV1Schema,
+  type EconomicsPolicyCreateRequestV1,
+} from '../../../../shared/contracts/internal-economics/economics-policy-v1.contract';
+import { TerminalPolicyV1Error } from '../../../../shared/contracts/internal-economics/terminal-policy-v1.contract';
+import {
+  internalCapitalEnvelopeVersions,
+  internalEconomicsPolicyVersions,
+} from '../../../../shared/schema/internal-economics';
+import { fundConfigs } from '../../../../shared/schema/fund';
+
+type PolicyDatabase = typeof db;
+
+function queryRows<T>(rows: T[]) {
+  const query: {
+    limit: (count: number) => Promise<T[]>;
+    orderBy: (..._order: unknown[]) => typeof query;
+    where: (_condition: unknown) => typeof query;
+    then: Promise<T[]>['then'];
+  } = {
+    limit: (count: number) => Promise.resolve(rows.slice(0, count)),
+    orderBy: (..._order: unknown[]) => query,
+    where: (_condition: unknown) => query,
+    then: <TResult1 = T[], TResult2 = never>(
+      onfulfilled?: ((value: T[]) => TResult1 | PromiseLike<TResult1>) | null,
+      onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ) => Promise.resolve(rows).then(onfulfilled, onrejected),
+  };
+  return query;
+}
+
+// ---------------------------------------------------------------------------
+// Fund config fixtures. A PASSING config requires an EXPLICIT
+// `economicsAssumptions.waterfallModel` (the only branch where
+// `clawbackEnabled` can resolve to `false` -- the defaulted-derivation branch
+// always resolves it to `true`, G14), with every dormant toggle off.
+// ---------------------------------------------------------------------------
+
+function passingWaterfallModel(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    type: 'american',
+    carryPct: 0.2,
+    hurdleRate: 0,
+    prefType: 'none',
+    prefCompounding: 'annual',
+    prefCatchUp: false,
+    catchUpRate: 0,
+    catchUpTargetCarryPct: 0.2,
+    clawbackEnabled: false,
+    clawbackTrigger: 'final_liquidation',
+    escrowPct: 0,
+    feeOffsetTreatment: 'none',
+    ...overrides,
+  };
+}
+
+/** A fully-dormant, passing fund config: clears all 11 seed-refusal checks. */
+function passingFundConfig(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    fundName: 'Test Fund',
+    isEvergreen: false,
+    fundLife: 10,
+    establishmentDate: '2020-01-01',
+    economicsAssumptions: {
+      version: 'v1',
+      waterfallModel: passingWaterfallModel(),
+    },
+    ...overrides,
+  };
+}
+
+/** No `economicsAssumptions` at all: the legacy-derivation branch, which
+ * always resolves `clawbackEnabled: true` unconditionally (G14). */
+function defaultedClawbackFundConfig(): Record<string, unknown> {
+  return {
+    fundName: 'Test Fund',
+    isEvergreen: false,
+    fundLife: 10,
+    establishmentDate: '2020-01-01',
+  };
+}
+
+function policyRequest(overrides: Record<string, unknown> = {}): EconomicsPolicyCreateRequestV1 {
+  return EconomicsPolicyCreateRequestV1Schema.parse({
+    capitalEnvelopeVersionId: 900,
+    sourceConfigId: 7,
+    sourceConfigVersion: 1,
+    body: {
+      waterfallTemplate: 'deal_by_deal',
+      carryPct: 0.2,
+      hurdle: { basis: 'none' },
+      managementFeesUsd: '0.000000',
+      fundExpenses: [],
+      cashBufferQuarters: 4,
+      terminalMode: 'liquidate_at_horizon',
+      termStartDate: '2020-01-01',
+      fundLifeYears: '10',
+      ...(overrides['body'] as Record<string, unknown> | undefined),
+    },
+    ...overrides,
+    ...(overrides['body'] !== undefined ? {} : {}),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// In-memory Drizzle double.
+// ---------------------------------------------------------------------------
+
+class FakePolicyDb {
+  readonly policyRows: Array<Record<string, unknown>> = [];
+  readonly fundConfigRows: Array<Record<string, unknown>> = [];
+  readonly envelopeRows: Array<Record<string, unknown>> = [];
+  readonly executedStatements: SQL[] = [];
+  private readonly lockTails = new Map<string, Promise<void>>();
+
+  asDatabase(): PolicyDatabase {
+    return this.buildHandle([]);
+  }
+
+  private buildHandle(releases: Array<() => void>): PolicyDatabase {
+    return {
+      select: (projection?: Record<string, unknown>) => this.select(projection),
+      insert: (table: unknown) => this.insert(table),
+      execute: (query: SQL) => this.execute(query, releases),
+      transaction: <T>(
+        callback: (tx: PolicyDatabase) => Promise<T>,
+        config?: Record<string, unknown>
+      ) => this.transaction(callback, config),
+    } as unknown as PolicyDatabase;
+  }
+
+  private async transaction<T>(
+    callback: (tx: PolicyDatabase) => Promise<T>,
+    _config?: Record<string, unknown>
+  ): Promise<T> {
+    const releases: Array<() => void> = [];
+    const handle = this.buildHandle(releases);
+    try {
+      return await callback(handle);
+    } finally {
+      for (const release of releases) release();
+    }
+  }
+
+  private async execute(query: SQL, releases: Array<() => void>): Promise<{ rows: unknown[] }> {
+    this.executedStatements.push(query);
+    const rendered = new PgDialect().sqlToQuery(query);
+    if (rendered.sql.includes('pg_advisory_xact_lock')) {
+      const key = String(rendered.params[0]);
+      const release = await this.acquireLock(key);
+      releases.push(release);
+    }
+    return { rows: [] };
+  }
+
+  private async acquireLock(key: string): Promise<() => void> {
+    const previousTail = this.lockTails.get(key) ?? Promise.resolve();
+    let release: () => void = () => {};
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    this.lockTails.set(
+      key,
+      previousTail.then(() => held)
+    );
+    await previousTail;
+    return release;
+  }
+
+  private select(projection?: Record<string, unknown>) {
+    return {
+      from: (table: unknown) => ({
+        where: (condition: unknown) => this.whereRows(table, projection, condition),
+      }),
+    };
+  }
+
+  private whereRows(
+    table: unknown,
+    projection: Record<string, unknown> | undefined,
+    condition: unknown
+  ) {
+    const rendered = new PgDialect().sqlToQuery(condition as SQL);
+
+    if (table === fundConfigs) {
+      const [idParam, fundIdParam] = rendered.params;
+      return queryRows(
+        this.fundConfigRows.filter((row) => row['id'] === idParam && row['fundId'] === fundIdParam)
+      );
+    }
+
+    if (table === internalCapitalEnvelopeVersions) {
+      const [idParam, fundIdParam] = rendered.params;
+      return queryRows(
+        this.envelopeRows.filter((row) => row['id'] === idParam && row['fundId'] === fundIdParam)
+      );
+    }
+
+    if (table === internalEconomicsPolicyVersions) {
+      const keys = projection ? Object.keys(projection) : [];
+      if (keys.includes('version')) {
+        const [fundIdParam] = rendered.params;
+        const filtered = this.policyRows
+          .filter((row) => row['fundId'] === fundIdParam)
+          .sort((left, right) => (right['version'] as number) - (left['version'] as number));
+        return queryRows(filtered);
+      }
+      // getPolicyVersion: (fundId, id); loadExisting: (fundId, idempotencyKey).
+      const [firstParam, secondParam] = rendered.params;
+      return queryRows(
+        this.policyRows.filter(
+          (row) =>
+            row['fundId'] === firstParam &&
+            (row['id'] === secondParam || row['idempotencyKey'] === secondParam)
+        )
+      );
+    }
+
+    return queryRows([]);
+  }
+
+  private insert(table: unknown) {
+    return {
+      values: (values: Record<string, unknown>) => ({
+        onConflictDoNothing: (_options: unknown) => ({
+          returning: () => {
+            if (table !== internalEconomicsPolicyVersions) return Promise.resolve([]);
+            const conflict = this.policyRows.some(
+              (row) =>
+                row['fundId'] === values['fundId'] &&
+                row['idempotencyKey'] === values['idempotencyKey']
+            );
+            if (conflict) return Promise.resolve([]);
+            const inserted = { id: this.policyRows.length + 1, createdAt: new Date(), ...values };
+            this.policyRows.push(inserted);
+            return Promise.resolve([inserted]);
+          },
+        }),
+      }),
+    };
+  }
+}
+
+function seedEnvelope(fakeDb: FakePolicyDb, overrides: Record<string, unknown> = {}): void {
+  fakeDb.envelopeRows.push({ id: 900, fundId: 1, ...overrides });
+}
+
+function seedFundConfigRaw(fakeDb: FakePolicyDb, config: Record<string, unknown>): void {
+  fakeDb.fundConfigRows.push({ id: 7, fundId: 1, version: 1, config });
+}
+
+function readyFakeDb(configOverride?: Record<string, unknown>): FakePolicyDb {
+  const fakeDb = new FakePolicyDb();
+  seedEnvelope(fakeDb);
+  seedFundConfigRaw(fakeDb, configOverride ?? passingFundConfig());
+  return fakeDb;
+}
+
+function fundConfigOmitting(keys: string[]): Record<string, unknown> {
+  const config = passingFundConfig();
+  for (const key of keys) delete config[key];
+  return config;
+}
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+describe('createEconomicsPolicyVersion happy path', () => {
+  it('creates version 1 with no parent and persists normalization warnings', async () => {
+    const fakeDb = readyFakeDb();
+
+    const row = await createEconomicsPolicyVersion({
+      fundId: 1,
+      actorId: 7,
+      idempotencyKey: 'policy-create-1',
+      request: policyRequest(),
+      database: fakeDb.asDatabase(),
+    });
+
+    expect(row['version']).toBe(1);
+    expect(row['parentPolicyVersionId']).toBeNull();
+    expect(row['fundId']).toBe(1);
+    expect(row['assumptionsHash']).toMatch(/^[0-9a-f]{64}$/);
+    expect(row['terminalPeriodEnd']).toBe('2030-03-31');
+    expect(
+      (row['normalizationWarnings'] as Array<{ parameter: string }>).map((entry) => entry.parameter)
+    ).toEqual(
+      expect.arrayContaining([
+        'prefCatchUp',
+        'clawbackEnabled',
+        'escrowPct',
+        'recyclingEnabled',
+        'hurdleBasis',
+        'isEvergreen',
+      ])
+    );
+    expect(fakeDb.policyRows).toHaveLength(1);
+  });
+
+  it('replays the same row for a repeated idempotency key without a second insert', async () => {
+    const fakeDb = readyFakeDb();
+    const request = policyRequest();
+
+    const first = await createEconomicsPolicyVersion({
+      fundId: 1,
+      actorId: 7,
+      idempotencyKey: 'policy-replay',
+      request,
+      database: fakeDb.asDatabase(),
+    });
+    const second = await createEconomicsPolicyVersion({
+      fundId: 1,
+      actorId: 7,
+      idempotencyKey: 'policy-replay',
+      request,
+      database: fakeDb.asDatabase(),
+    });
+
+    expect(second).toEqual(first);
+    expect(fakeDb.policyRows).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-B2: seed-refusal registry, every code from real fundConfigs.config
+// fixtures. CREDIT_FACILITY_UNSUPPORTED is excluded: FundDraftWriteV1Schema
+// carries no credit-facility/line-of-credit field, and it is `.strict()`, so
+// injecting one fails config parsing (SOURCE_CONFIG_MALFORMED) before the
+// seed-refusal registry ever runs -- the code is structurally unreachable
+// through any real fixture (see economics-policy-service.ts's own comment).
+// ---------------------------------------------------------------------------
+
+describe('createEconomicsPolicyVersion T-B2 seed-refusal registry', () => {
+  const cases: ReadonlyArray<{
+    readonly name: string;
+    readonly config: Record<string, unknown>;
+    readonly code: string;
+  }> = [
+    {
+      name: 'active GP catch-up (strict ruling: refuses even though hurdle basis is none)',
+      config: passingFundConfig({
+        economicsAssumptions: {
+          version: 'v1',
+          waterfallModel: passingWaterfallModel({ prefCatchUp: true }),
+        },
+      }),
+      code: 'CATCH_UP_UNSUPPORTED',
+    },
+    {
+      name: 'active clawback (explicit)',
+      config: passingFundConfig({
+        economicsAssumptions: {
+          version: 'v1',
+          waterfallModel: passingWaterfallModel({ clawbackEnabled: true }),
+        },
+      }),
+      code: 'CLAWBACK_UNSUPPORTED',
+    },
+    {
+      name: 'active clawback (defaulted -- no economicsAssumptions at all, G14)',
+      config: defaultedClawbackFundConfig(),
+      code: 'CLAWBACK_UNSUPPORTED',
+    },
+    {
+      name: 'active escrow',
+      config: passingFundConfig({
+        economicsAssumptions: {
+          version: 'v1',
+          waterfallModel: passingWaterfallModel({ escrowPct: 0.05 }),
+        },
+      }),
+      code: 'ESCROW_UNSUPPORTED',
+    },
+    {
+      name: 'active recycling',
+      config: passingFundConfig({
+        economicsAssumptions: {
+          version: 'v1',
+          waterfallModel: passingWaterfallModel(),
+          recyclingModel: {
+            enabled: true,
+            sources: ['exit_proceeds'],
+            capPctOfCommitments: 0.1,
+            timing: 'before_waterfall',
+          },
+        },
+      }),
+      code: 'RECYCLING_UNSUPPORTED',
+    },
+    {
+      name: 'pref-bearing hurdle basis',
+      config: passingFundConfig({
+        economicsAssumptions: {
+          version: 'v1',
+          waterfallModel: passingWaterfallModel({ prefType: 'compounded', hurdleRate: 0.08 }),
+        },
+      }),
+      code: 'HURDLE_BASIS_UNSUPPORTED',
+    },
+    {
+      name: 'no fund life resolvable',
+      config: fundConfigOmitting(['fundLife']),
+      code: 'FUND_LIFE_ABSENT',
+    },
+    {
+      name: 'fund life resolves to a non-integer quarter count',
+      config: passingFundConfig({ fundLife: 0.1 }),
+      code: 'FUND_LIFE_GRID_UNREPRESENTABLE',
+    },
+    {
+      name: 'no term start date resolvable',
+      config: fundConfigOmitting(['establishmentDate']),
+      code: 'FUND_TERM_START_ABSENT',
+    },
+    {
+      name: 'evergreen flag missing',
+      config: fundConfigOmitting(['isEvergreen']),
+      code: 'EVERGREEN_STATUS_ABSENT',
+    },
+    {
+      name: 'evergreen fund',
+      config: passingFundConfig({ isEvergreen: true }),
+      code: 'EVERGREEN_UNSUPPORTED',
+    },
+  ];
+
+  it.each(cases)('refuses 422 $code for $name, nothing persisted', async ({ config, code }) => {
+    const fakeDb = new FakePolicyDb();
+    seedEnvelope(fakeDb);
+    seedFundConfigRaw(fakeDb, config);
+
+    await expect(
+      createEconomicsPolicyVersion({
+        fundId: 1,
+        actorId: 7,
+        idempotencyKey: `policy-refusal-${code}-${Math.random()}`,
+        request: policyRequest(),
+        database: fakeDb.asDatabase(),
+      })
+    ).rejects.toMatchObject({ status: 422, code });
+    expect(fakeDb.policyRows).toHaveLength(0);
+  });
+
+  it('throws EconomicsPolicySeedRefusalError (not a generic error) on refusal', async () => {
+    const fakeDb = readyFakeDb(
+      passingFundConfig({
+        economicsAssumptions: {
+          version: 'v1',
+          waterfallModel: passingWaterfallModel({ prefCatchUp: true }),
+        },
+      })
+    );
+
+    await expect(
+      createEconomicsPolicyVersion({
+        fundId: 1,
+        actorId: 7,
+        idempotencyKey: 'policy-refusal-type-check',
+        request: policyRequest(),
+        database: fakeDb.asDatabase(),
+      })
+    ).rejects.toBeInstanceOf(EconomicsPolicySeedRefusalError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-B2: dormant-param normalization warnings persist AND participate in
+// assumptions_hash -- two policies differing only in a dormant param's
+// provenance hash differently. Every PASSING config requires an explicit
+// waterfallModel (only branch where clawback can be dormant), so the one
+// dormant parameter that can still vary provenance while passing is
+// `recyclingEnabled` (independent top-level fallback field).
+// ---------------------------------------------------------------------------
+
+describe('createEconomicsPolicyVersion T-B2 dormant-param normalization warnings', () => {
+  it('hashes two otherwise-identical policies differently when a dormant param differs only in provenance', async () => {
+    const defaultedDb = readyFakeDb(passingFundConfig()); // no recyclingEnabled / recyclingModel anywhere -> defaulted
+    const explicitDb = readyFakeDb(passingFundConfig({ recyclingEnabled: false })); // explicit top-level false
+
+    const defaultedRow = await createEconomicsPolicyVersion({
+      fundId: 1,
+      actorId: 7,
+      idempotencyKey: 'policy-dormant-defaulted',
+      request: policyRequest(),
+      database: defaultedDb.asDatabase(),
+    });
+    const explicitRow = await createEconomicsPolicyVersion({
+      fundId: 1,
+      actorId: 7,
+      idempotencyKey: 'policy-dormant-explicit',
+      request: policyRequest(),
+      database: explicitDb.asDatabase(),
+    });
+
+    const defaultedWarning = (
+      defaultedRow['normalizationWarnings'] as Array<{ parameter: string; provenance: string }>
+    ).find((entry) => entry.parameter === 'recyclingEnabled');
+    const explicitWarning = (
+      explicitRow['normalizationWarnings'] as Array<{ parameter: string; provenance: string }>
+    ).find((entry) => entry.parameter === 'recyclingEnabled');
+
+    expect(defaultedWarning?.provenance).toBe('defaulted');
+    expect(explicitWarning?.provenance).toBe('explicit');
+    expect(defaultedRow['assumptionsHash']).not.toBe(explicitRow['assumptionsHash']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-B3: terminal pair written via the exported helpers; readback validators
+// reject a tampered row (direct fixture mutation, bypassing the service) with
+// TERMINAL_RESOLUTION_MISMATCH.
+// ---------------------------------------------------------------------------
+
+describe('createEconomicsPolicyVersion / getPolicyVersion T-B3 terminal pair', () => {
+  it('writes the terminal pair via the exported helpers and reads it back unchanged', async () => {
+    const fakeDb = readyFakeDb();
+    const created = await createEconomicsPolicyVersion({
+      fundId: 1,
+      actorId: 7,
+      idempotencyKey: 'policy-terminal-pair',
+      request: policyRequest(),
+      database: fakeDb.asDatabase(),
+    });
+
+    const read = await getPolicyVersion(1, created['id'] as number, fakeDb.asDatabase());
+
+    expect(read?.['terminalPeriodEnd']).toBe('2030-03-31');
+    expect(read?.['terminalResolutionMethodologyVersion']).toBe(
+      'internal-economics-terminal-resolution/1.0.0'
+    );
+  });
+
+  it('rejects a tampered terminal_period_end on readback with TERMINAL_RESOLUTION_MISMATCH', async () => {
+    const fakeDb = readyFakeDb();
+    const created = await createEconomicsPolicyVersion({
+      fundId: 1,
+      actorId: 7,
+      idempotencyKey: 'policy-terminal-tamper',
+      request: policyRequest(),
+      database: fakeDb.asDatabase(),
+    });
+
+    // Direct fixture corruption, bypassing the service entirely (simulates a
+    // tampered row / direct SQL write).
+    const storedRow = fakeDb.policyRows.find((row) => row['id'] === created['id']);
+    expect(storedRow).toBeDefined();
+    storedRow!['terminalPeriodEnd'] = '1999-12-31';
+
+    await expect(
+      getPolicyVersion(1, created['id'] as number, fakeDb.asDatabase())
+    ).rejects.toMatchObject({
+      code: 'TERMINAL_RESOLUTION_MISMATCH',
+    });
+    await expect(
+      getPolicyVersion(1, created['id'] as number, fakeDb.asDatabase())
+    ).rejects.toBeInstanceOf(TerminalPolicyV1Error);
+  });
+
+  it('returns null for an id not owned by the given fund', async () => {
+    const fakeDb = readyFakeDb();
+    const created = await createEconomicsPolicyVersion({
+      fundId: 1,
+      actorId: 7,
+      idempotencyKey: 'policy-terminal-wrong-fund',
+      request: policyRequest(),
+      database: fakeDb.asDatabase(),
+    });
+
+    await expect(
+      getPolicyVersion(2, created['id'] as number, fakeDb.asDatabase())
+    ).resolves.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-B4: fund-scoped-ownership 'economics_policy_version' kind resolves for
+// the owning fund and rejects across funds.
+// ---------------------------------------------------------------------------
+
+describe("fund-scoped-ownership 'economics_policy_version' kind T-B4", () => {
+  it('resolves for a policy version owned by the given fund and rejects across funds', async () => {
+    const fakeDb = readyFakeDb();
+    const policy = await createEconomicsPolicyVersion({
+      fundId: 1,
+      actorId: 7,
+      idempotencyKey: 'policy-ownership-kind',
+      request: policyRequest(),
+      database: fakeDb.asDatabase(),
+    });
+
+    await expect(
+      assertOwnedByFund({
+        db: fakeDb.asDatabase() as unknown as FundScopedOwnershipDatabase,
+        fundId: 1,
+        ref: { kind: 'economics_policy_version', id: policy['id'] as number },
+      })
+    ).resolves.toBeUndefined();
+
+    await expect(
+      assertOwnedByFund({
+        db: fakeDb.asDatabase() as unknown as FundScopedOwnershipDatabase,
+        fundId: 2,
+        ref: { kind: 'economics_policy_version', id: policy['id'] as number },
+      })
+    ).rejects.toBeInstanceOf(FundScopeError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-B5 (P-D11 policy half): concurrent policy-creation requests for the same
+// fund with different idempotency keys never collide on `version` -- one
+// serializes behind the advisory lock and is allocated the next version,
+// never an unhandled unique-constraint error.
+// ---------------------------------------------------------------------------
+
+describe('createEconomicsPolicyVersion T-B5 concurrent version allocation', () => {
+  it('serializes concurrent creates for the same fund into distinct, non-colliding versions', async () => {
+    const fakeDb = readyFakeDb();
+
+    const [left, right] = await Promise.all([
+      createEconomicsPolicyVersion({
+        fundId: 1,
+        actorId: 7,
+        idempotencyKey: 'policy-concurrent-left',
+        request: policyRequest(),
+        database: fakeDb.asDatabase(),
+      }),
+      createEconomicsPolicyVersion({
+        fundId: 1,
+        actorId: 7,
+        idempotencyKey: 'policy-concurrent-right',
+        request: policyRequest(),
+        database: fakeDb.asDatabase(),
+      }),
+    ]);
+
+    expect(fakeDb.policyRows).toHaveLength(2);
+    const versions = [left['version'], right['version']].sort();
+    expect(versions).toEqual([1, 2]);
+    const byVersion = new Map([
+      [left['version'] as number, left],
+      [right['version'] as number, right],
+    ]);
+    expect(byVersion.get(2)?.['parentPolicyVersionId']).toBe(byVersion.get(1)?.['id']);
+  });
+
+  it('does not throw an unhandled unique-constraint error under concurrent creation', async () => {
+    const fakeDb = readyFakeDb();
+
+    const results = await Promise.allSettled([
+      createEconomicsPolicyVersion({
+        fundId: 1,
+        actorId: 7,
+        idempotencyKey: 'policy-concurrent-safety-a',
+        request: policyRequest(),
+        database: fakeDb.asDatabase(),
+      }),
+      createEconomicsPolicyVersion({
+        fundId: 1,
+        actorId: 7,
+        idempotencyKey: 'policy-concurrent-safety-b',
+        request: policyRequest(),
+        database: fakeDb.asDatabase(),
+      }),
+      createEconomicsPolicyVersion({
+        fundId: 1,
+        actorId: 7,
+        idempotencyKey: 'policy-concurrent-safety-c',
+        request: policyRequest(),
+        database: fakeDb.asDatabase(),
+      }),
+    ]);
+
+    expect(results.every((result) => result.status === 'fulfilled')).toBe(true);
+    const versions = fakeDb.policyRows.map((row) => row['version']).sort();
+    expect(versions).toEqual([1, 2, 3]);
+    expect(new Set(versions).size).toBe(3);
+  });
+});

--- a/tests/unit/services/internal-economics/lp-economics-run-service.test.ts
+++ b/tests/unit/services/internal-economics/lp-economics-run-service.test.ts
@@ -1,0 +1,1880 @@
+/**
+ * lp-economics-run-service.test.ts
+ *
+ * WP-L3 Phase C acceptance fixtures (T-C1..T-C17, T-C19, T-C20). T-C18 (the
+ * worst-case wall-clock benchmark) lives in its own pure-compute file per
+ * the plan's isolation requirement (P-D7 R6):
+ * tests/unit/internal-economics/lp-economics-run-worst-case-benchmark.test.ts.
+ *
+ * Uses an in-memory Drizzle-query-shaped mock database (`FakeRunDb`),
+ * mirroring the precedent established by
+ * tests/unit/services/financial-facts-snapshot-service.test.ts, extended
+ * with a real per-fundId keyed-mutex simulation of
+ * `pg_advisory_xact_lock` so the concurrency fixtures (T-C6/T-C7) exercise
+ * genuine serialization rather than JS microtask ordering alone. No real
+ * Postgres connection is used or required.
+ */
+import { randomUUID } from 'node:crypto';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { db } from '../../../../server/db';
+import { IdempotentCommandError } from '../../../../server/lib/idempotent-command';
+import {
+  LP_ECONOMICS_RESULT_CALC_VERSION,
+  LP_ECONOMICS_RUN_ENGINE_VERSION,
+  LP_ECONOMICS_RUN_METHODOLOGY_VERSION,
+  MAX_CASH_ASSEMBLY_PERIOD_COUNT,
+  MAX_CASH_ASSEMBLY_TOTAL_EVENT_COUNT,
+  executeLpEconomicsRun,
+  getRunWithResult,
+} from '../../../../server/services/internal-economics/lp-economics-run-service';
+import { canonicalSha256 } from '../../../../shared/lib/canonical-hash';
+import { Decimal } from '../../../../shared/lib/decimal-config';
+import * as cashAssemblyPeriodLoopModule from '../../../../shared/lib/internal-economics/cash-assembly-period-loop-v1';
+import {
+  CashAssemblyPeriodLoopV1Error,
+  executeCashAssemblyPeriodLoopV1,
+} from '../../../../shared/lib/internal-economics/cash-assembly-period-loop-v1';
+import { DecimalWaterfallCoreV1Error } from '../../../../shared/lib/internal-economics/decimal-waterfall-core-v1';
+import {
+  CashAssemblyEventStreamInvariantError,
+  CashAssemblyEventStreamV1Error,
+} from '../../../../shared/lib/internal-economics/cash-assembly-event-stream-v1';
+import { CashAssemblyCallSizingV1Error } from '../../../../shared/lib/internal-economics/cash-assembly-call-sizing-v1';
+import { PresentationRoundingError } from '../../../../shared/lib/internal-economics/presentation-rounding-v1';
+import {
+  TerminalPolicyV1Error,
+  INTERNAL_ECONOMICS_TERMINAL_RESOLUTION_VERSION,
+} from '../../../../shared/contracts/internal-economics/terminal-policy-v1.contract';
+import {
+  LP_ECONOMICS_RUN_CONTRACT_VERSION,
+  LpEconomicsRunRequestV1Schema,
+  type LpEconomicsRunRequestV1,
+} from '../../../../shared/contracts/internal-economics/lp-economics-run-v1.contract';
+import {
+  internalCapitalEnvelopeVersions,
+  internalEconomicsPolicyVersions,
+  internalLpEconomicsRuns,
+} from '../../../../shared/schema/internal-economics';
+import { financialFactsSnapshots } from '../../../../shared/schema/financial-facts-snapshots';
+import { currentPlanVersions } from '../../../../shared/schema/current-plans';
+import { fundConfigs, fundSnapshots } from '../../../../shared/schema/fund';
+
+type RunDatabase = typeof db;
+
+// ---------------------------------------------------------------------------
+// Keyed mutex: faithfully simulates `pg_advisory_xact_lock`'s
+// transaction-scoped, per-key serialization (real Postgres semantics this
+// service's correctness depends on -- see P-D7 step 1).
+// ---------------------------------------------------------------------------
+
+class KeyedMutex {
+  private tails = new Map<string, Promise<unknown>>();
+
+  async acquire(key: string): Promise<() => void> {
+    const prior = this.tails.get(key) ?? Promise.resolve();
+    let release!: () => void;
+    const next = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    this.tails.set(
+      key,
+      prior.then(() => next)
+    );
+    await prior;
+    return release;
+  }
+}
+
+function paramMatches(rowValue: unknown, param: unknown): boolean {
+  if (rowValue instanceof Date) {
+    const paramTime = param instanceof Date ? param.getTime() : new Date(String(param)).getTime();
+    return rowValue.getTime() === paramTime;
+  }
+  return rowValue === param;
+}
+
+class FakeRunDb {
+  policyRows: Record<string, unknown>[] = [];
+  envelopeRows: Record<string, unknown>[] = [];
+  factsRows: Record<string, unknown>[] = [];
+  planRows: Record<string, unknown>[] = [];
+  fundSnapshotRows: Record<string, unknown>[] = [];
+  fundConfigRows: Record<string, unknown>[] = [];
+  runRows: Record<string, unknown>[] = [];
+
+  transactionAttempts = 0;
+  readonly transactionConfigs: Record<string, unknown>[] = [];
+  insertSerializationFailuresRemaining = 0;
+  readonly runInsertAttempts: Record<string, unknown>[] = [];
+
+  private readonly mutex = new KeyedMutex();
+  private readonly pendingReleases: Array<() => void> = [];
+  private nextRunRowId = 1;
+
+  asDatabase(): RunDatabase {
+    return this as unknown as RunDatabase;
+  }
+
+  async transaction<T>(
+    callback: (transaction: RunDatabase) => Promise<T>,
+    config?: Record<string, unknown>
+  ): Promise<T> {
+    this.transactionAttempts += 1;
+    this.transactionConfigs.push(config ?? {});
+    const releasesBefore = this.pendingReleases.length;
+    try {
+      return await callback(this.asDatabase());
+    } finally {
+      while (this.pendingReleases.length > releasesBefore) {
+        const release = this.pendingReleases.pop();
+        release?.();
+      }
+    }
+  }
+
+  async execute(query: SQL): Promise<{ rows: unknown[] }> {
+    const rendered = new PgDialect().sqlToQuery(query);
+    if (rendered.sql.includes('pg_advisory_xact_lock')) {
+      const lockKey = String(rendered.params[0]);
+      const release = await this.mutex.acquire(lockKey);
+      this.pendingReleases.push(release);
+      return { rows: [] };
+    }
+    return { rows: [] };
+  }
+
+  select(_projection?: unknown) {
+    return {
+      from: (table: unknown) => ({
+        where: (condition: unknown) => ({
+          limit: async (_count: number) => this.filterRows(table, condition),
+        }),
+      }),
+    };
+  }
+
+  insert(table: unknown) {
+    return {
+      values: (values: Record<string, unknown>) => ({
+        onConflictDoNothing: (_opts: unknown) => ({
+          returning: async () => {
+            if (table !== internalLpEconomicsRuns) return [];
+            this.runInsertAttempts.push(values);
+            if (this.insertSerializationFailuresRemaining > 0) {
+              this.insertSerializationFailuresRemaining -= 1;
+              throw Object.assign(new Error('serialization_failure'), { code: '40001' });
+            }
+            const conflict = this.runRows.some(
+              (row) =>
+                row['fundId'] === values['fundId'] &&
+                row['idempotencyKey'] === values['idempotencyKey']
+            );
+            if (conflict) return [];
+            const inserted = { id: this.nextRunRowId, createdAt: new Date(), ...values };
+            this.nextRunRowId += 1;
+            this.runRows.push(inserted);
+            return [inserted];
+          },
+        }),
+        returning: async (projection?: Record<string, unknown>) => {
+          if (table !== fundSnapshots) return [];
+          // Computed from current rows (not a standalone counter) so a
+          // pre-seeded row (e.g. the golden fixture's forecast snapshot,
+          // inserted directly into the array rather than through this
+          // method) can never collide with a later service-issued insert.
+          const nextId =
+            Math.max(0, ...this.fundSnapshotRows.map((row) => Number(row['id']) || 0)) + 1;
+          const inserted: Record<string, unknown> = {
+            id: nextId,
+            eventCount: 0,
+            metadata: null,
+            stateHash: null,
+            runId: null,
+            configId: null,
+            configVersion: null,
+            scenarioSetId: null,
+            h9MoicSourceInputHash: null,
+            h9RoundEvidenceInputHash: null,
+            h9RoundEvidenceAssumptionsHash: null,
+            h9FingerprintHash: null,
+            h9PolicyVersion: null,
+            h9ActionabilityStatus: null,
+            createdAt: new Date(),
+            ...values,
+          };
+          this.fundSnapshotRows.push(inserted);
+          if (projection) return [{ id: inserted['id'] }];
+          return [inserted];
+        },
+      }),
+    };
+  }
+
+  private rowsFor(table: unknown): Record<string, unknown>[] {
+    if (table === internalEconomicsPolicyVersions) return this.policyRows;
+    if (table === internalCapitalEnvelopeVersions) return this.envelopeRows;
+    if (table === financialFactsSnapshots) return this.factsRows;
+    if (table === currentPlanVersions) return this.planRows;
+    if (table === fundSnapshots) return this.fundSnapshotRows;
+    if (table === fundConfigs) return this.fundConfigRows;
+    if (table === internalLpEconomicsRuns) return this.runRows;
+    return [];
+  }
+
+  private filterRows(table: unknown, condition: unknown): Record<string, unknown>[] {
+    const rows = this.rowsFor(table);
+    const rendered = new PgDialect().sqlToQuery(condition as SQL);
+    return rows.filter((row) =>
+      rendered.params.every((param) =>
+        Object.values(row).some((value) => paramMatches(value, param))
+      )
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Golden-path fixture: the minimal, mutually-consistent basis set that
+// clears every section 8 gate and produces a genuine indicative loop
+// result. FUND_ID is shared across the whole suite; each test builds its
+// own FakeRunDb instance so rows never leak across tests.
+// ---------------------------------------------------------------------------
+
+const FUND_ID = 500;
+const ACTOR_ID = 7;
+const CLOCK = '2026-06-30T23:59:59.000Z';
+const CUTOVER_INSTANT = '2025-12-31T23:59:59.999Z';
+const PERIOD_START = '2026-01-01';
+const PERIOD_END = '2026-03-31';
+
+const ZERO_MONEY = '0.000000';
+const ZERO_RATIO = '0.000000000000';
+const ONE_RATIO = '1.000000000000';
+
+/** A syntactically valid (lowercase hex, 64 chars) sha256-shaped fixture. */
+function hex64(index: number): string {
+  return '0123456789abcdef'[index % 16]!.repeat(64);
+}
+
+interface GoldenFixtureIds {
+  readonly policyId: number;
+  readonly envelopeId: number;
+  readonly factsId: number;
+  readonly planId: number;
+  readonly forecastSnapshotId: number;
+  readonly fundConfigId: number;
+}
+
+function zeroOpeningStateFields() {
+  return {
+    cashBalanceUsd: ZERO_MONEY,
+    cumulativeLpPaidInUsd: ZERO_MONEY,
+    cumulativeGpPaidInUsd: ZERO_MONEY,
+    gpUnreturnedContributedCapitalUsd: ZERO_MONEY,
+    lpDistributionsReturnOfCapitalUsd: ZERO_MONEY,
+    lpDistributionsProfitUsd: ZERO_MONEY,
+    actualLpDistributionsCumulativeUsd: ZERO_MONEY,
+    gpInvestmentDistributionsPaidUsd: ZERO_MONEY,
+    gpCarryPaidUsd: ZERO_MONEY,
+    accruedPreferredReturnUsd: ZERO_MONEY,
+    recallableDistributionsCumulativeUsd: ZERO_MONEY,
+    recallableDistributionsOutstandingUsd: ZERO_MONEY,
+    recycledProceedsCumulativeUsd: ZERO_MONEY,
+    realizedProceedsCumulativeUsd: ZERO_MONEY,
+  } as const;
+}
+
+/** Resolved (post-adapter) v1.1 opening-state observation, embedded exactly
+ * as it would be persisted in a v4 facts payload row. Overrides apply to the
+ * raw fields; `lpUnreturnedContributedCapitalUsd` is re-derived to stay
+ * internally consistent (cumulativeLpPaidInUsd - lpDistributionsReturnOfCapitalUsd). */
+function resolvedOpeningState(overrides: Partial<ReturnType<typeof zeroOpeningStateFields>> = {}) {
+  const base = { ...zeroOpeningStateFields(), ...overrides };
+  const paidIn = Number(base.cumulativeLpPaidInUsd);
+  const roc = Number(base.lpDistributionsReturnOfCapitalUsd);
+  return {
+    contractVersion: 'fund-accounting-state-observation/1.1.0',
+    cutoverInstant: CUTOVER_INSTANT,
+    currency: 'USD',
+    ...base,
+    accruedPreferredReturnThroughInstant: CUTOVER_INSTANT,
+    methodologyVersion: 'opening-state-methodology/1.0.0',
+    lpUnreturnedContributedCapitalUsd: (paidIn - roc).toFixed(6),
+  } as const;
+}
+
+/** The full embedded ref shape a v4 facts payload row persists (P-D10 R1):
+ * `{sourceArtifactId, sourceArtifactSha256, sourceArtifactCreatedAt,
+ * attestedByActorId, observation}`, resolved (post-adapter) form. */
+function resolvedOpeningAccountingStateRef(
+  overrides: Partial<ReturnType<typeof zeroOpeningStateFields>> = {}
+) {
+  return {
+    sourceArtifactId: 1,
+    sourceArtifactSha256: hex64(15),
+    sourceArtifactCreatedAt: '2026-01-01T00:00:00.000Z',
+    attestedByActorId: ACTOR_ID,
+    observation: resolvedOpeningState(overrides),
+  };
+}
+
+function goldenForecastSeries() {
+  return [
+    {
+      periodStart: PERIOD_START,
+      periodEnd: PERIOD_END,
+      source: 'projected' as const,
+      deployedUsd: ZERO_MONEY,
+      contributionsUsd: ZERO_MONEY,
+      distributionsUsd: ZERO_MONEY,
+      navUsd: ZERO_MONEY,
+      tvpi: ZERO_RATIO,
+      dpi: ZERO_RATIO,
+      activeCompanyCount: 0,
+      projectedCohortCount: 0,
+    },
+  ];
+}
+
+function goldenForecastPayload() {
+  return {
+    contractVersion: 'current-forecast-v2' as const,
+    fundId: FUND_ID,
+    financialFactsSnapshotId: '1',
+    currentPlanVersionId: '1',
+    asOfDate: '2026-06-30',
+    status: 'available' as const,
+    series: goldenForecastSeries(),
+    remainingDeployableCapitalUsd: ZERO_MONEY,
+    committedCapitalUsd: '1000000.000000',
+    calledToDateUsd: ZERO_MONEY,
+    projectedFeesRemainingUsd: ZERO_MONEY,
+    recallableDistributionsUsd: ZERO_MONEY,
+    uncalledCapitalUsd: '1000000.000000',
+    netIrr: null,
+    inputHash: hex64(1),
+    assumptionsHash: hex64(2),
+    resultHash: null,
+    engineVersion: 'current-forecast-v2-engine/1.0.0' as const,
+    methodologyVersion: 'cohort-projection-v2/1.0.0' as const,
+    unavailableReasons: [],
+    warnings: [],
+  };
+}
+
+function goldenFundConfig() {
+  return {
+    fundName: 'Test Fund',
+    managementFeeRate: 0,
+    lpClasses: [],
+    fundExpenses: [],
+    feeProfiles: [
+      {
+        id: 'fp1',
+        name: 'Zero Profile',
+        feeTiers: [
+          {
+            id: 'ft1',
+            name: 'Zero Tier',
+            percentage: 0,
+            feeBasis: 'committed_capital',
+            startMonth: 0,
+          },
+        ],
+      },
+    ],
+    economicsAssumptions: {
+      version: 'v1',
+      feeModel: {
+        source: 'economics_override',
+        tiers: [{ id: 't1', name: 'Zero', rate: 0, basis: 'committed_capital', startYear: 1 }],
+        defaultRate: 0,
+      },
+      expenseModel: {
+        source: 'economics_override',
+        annualExpenses: [],
+        orgExpenseCap: 0,
+      },
+    },
+  };
+}
+
+function goldenPacingAssumptions() {
+  return {
+    contractVersion: 'current-plan-pacing-v1',
+    deploymentQuarters: 1,
+    quarterlyDeploymentPcts: [ONE_RATIO],
+    followOnReservePct: ZERO_RATIO,
+    annualFeeDragPct: ZERO_RATIO,
+  };
+}
+
+function goldenCohortAssumptions() {
+  return {
+    contractVersion: 'current-plan-cohort-v1',
+    averageInitialCheckUsd: ZERO_MONEY,
+    stageDistribution: [{ stage: 'seed', pct: ONE_RATIO }],
+    graduationMatrix: [],
+    exitAssumptions: [],
+  };
+}
+
+function goldenFactsPayload(openingAccountingState: unknown = resolvedOpeningAccountingStateRef()) {
+  return {
+    companyActuals: {
+      fundId: FUND_ID,
+      asOfDate: '2026-06-30',
+      facts: [],
+      inputHash: hex64(3),
+    },
+    sourceObservationIds: [],
+    workingValueSelectionIds: [],
+    cashFlowSeries: {
+      series: [],
+      totals: {
+        contributions: ZERO_MONEY,
+        distributions: ZERO_MONEY,
+        recallableDistributions: ZERO_MONEY,
+      },
+      warnings: [],
+    },
+    marksSeries: { marks: [], periodNav: [], warnings: [] },
+    vehicleRoster: [
+      {
+        vehicleId: 1,
+        vehicleType: 'main_fund',
+        vehicleSlug: 'main',
+        name: 'Main Fund',
+        currency: 'USD',
+      },
+    ],
+    positionRefs: [],
+    positionComponentRefs: [],
+    ownershipRefs: [],
+    valuationRefs: [],
+    participationTermRefs: [],
+    observationRefs: [],
+    openingAccountingState,
+  };
+}
+
+/** Seeds a fully eligible golden basis set into `fakeDb` and returns the row
+ * IDs. Every gate passes; the loop should execute successfully. */
+function seedGoldenFixture(fakeDb: FakeRunDb): GoldenFixtureIds {
+  const envelope = {
+    id: 1,
+    fundId: FUND_ID,
+    version: 1,
+    mainFundVehicleId: 1,
+    lpCommitmentUsd: '1000000.000000',
+    gpCommitmentUsd: ZERO_MONEY,
+    totalCommitmentUsd: '1000000.000000',
+    currency: 'USD',
+    effectiveAt: new Date('2026-01-01T00:00:00.000Z'),
+    sourceArtifactId: 1,
+    sourceConfigId: 1,
+    sourceConfigVersion: 1,
+    sourceConfigHash: hex64(4),
+    attestedBy: ACTOR_ID,
+    attestedAt: new Date('2026-01-01T00:00:00.000Z'),
+    envelopeHash: hex64(5),
+    parentEnvelopeVersionId: null,
+    idempotencyKey: 'envelope-golden',
+    requestHash: hex64(6),
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  };
+  fakeDb.envelopeRows.push(envelope);
+
+  const policy = {
+    id: 1,
+    fundId: FUND_ID,
+    version: 1,
+    policySchemaVersion: 'internal-economics-policy/1.0.0',
+    policyBody: {
+      waterfallTemplate: 'deal_by_deal',
+      carryPct: 0.2,
+      hurdle: { basis: 'none' },
+      managementFeesUsd: ZERO_MONEY,
+      fundExpenses: [],
+      cashBufferQuarters: 0,
+      terminalMode: 'hold_unrealized',
+      // resolveTerminalPeriodEndV1('2021-01-01', 5yr=60mo) -> 2026-01-01 ->
+      // containing quarter end 2026-03-31, matching PERIOD_END below (the
+      // gate-8 match-assert re-derives and compares this exactly).
+      termStartDate: '2021-01-01',
+      fundLifeYears: '5',
+    },
+    normalizationWarnings: [],
+    terminalPeriodEnd: PERIOD_END,
+    terminalResolutionMethodologyVersion: INTERNAL_ECONOMICS_TERMINAL_RESOLUTION_VERSION,
+    capitalEnvelopeVersionId: envelope.id,
+    assumptionsHash: hex64(7),
+    sourceConfigId: 1,
+    sourceConfigVersion: 1,
+    parentPolicyVersionId: null,
+    createdBy: ACTOR_ID,
+    idempotencyKey: 'policy-golden',
+    requestHash: hex64(8),
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  };
+  fakeDb.policyRows.push(policy);
+
+  const facts = {
+    id: 1,
+    fundId: FUND_ID,
+    policyVersion: 'financial-facts-policy/1.3.0',
+    payloadSchemaId: 'financial-facts-payload/4',
+    asOfDate: '2026-06-30',
+    knowledgeCutoff: new Date('2026-06-30T00:00:00.000Z'),
+    vehicleScope: 'fund_all',
+    vehicleIds: [1],
+    selectionSetHash: hex64(9),
+    sourceFactsInputHash: hex64(10),
+    snapshotInputHash: hex64(11),
+    payload: goldenFactsPayload(),
+    consumerEvaluations: [
+      { consumer: 'economics', status: 'accepted', reasons: [] },
+      { consumer: 'forecast', status: 'accepted', reasons: [] },
+    ],
+    actorId: ACTOR_ID,
+    idempotencyKey: 'facts-golden',
+    requestHash: hex64(12),
+    supersedesSnapshotId: null,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  };
+  fakeDb.factsRows.push(facts);
+
+  const plan = {
+    id: 1,
+    fundId: FUND_ID,
+    version: 1,
+    sourceConfigId: 1,
+    sourceConfigVersion: 1,
+    sourceFactsSnapshotId: facts.id,
+    deployableCapitalUsd: '1000000.000000',
+    planTransformationVersion: 'plan-transform/1.0.0',
+    allocations: [],
+    pacingAssumptions: goldenPacingAssumptions(),
+    cohortAssumptions: goldenCohortAssumptions(),
+    reservePolicyVersion: 'reserve-policy/1.0.0',
+    assumptionsHash: hex64(13),
+    supersedesVersionId: null,
+    supersededByVersionId: null,
+    idempotencyKey: 'plan-golden',
+    requestHash: hex64(14),
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  };
+  fakeDb.planRows.push(plan);
+
+  const forecastSnapshot = {
+    id: 1,
+    fundId: FUND_ID,
+    type: 'CURRENT_FORECAST_V2',
+    payload: goldenForecastPayload(),
+    calcVersion: 'current-forecast-v2-engine/1.0.0',
+    correlationId: randomUUID(),
+    metadata: null,
+    snapshotTime: new Date('2026-06-30T00:00:00.000Z'),
+    eventCount: 0,
+    stateHash: null,
+    state: null,
+    runId: null,
+    configId: null,
+    configVersion: null,
+    scenarioSetId: null,
+    h9MoicSourceInputHash: null,
+    h9RoundEvidenceInputHash: null,
+    h9RoundEvidenceAssumptionsHash: null,
+    h9FingerprintHash: null,
+    h9PolicyVersion: null,
+    h9ActionabilityStatus: null,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  };
+  fakeDb.fundSnapshotRows.push(forecastSnapshot);
+
+  const fundConfig = {
+    id: 1,
+    fundId: FUND_ID,
+    version: 1,
+    config: goldenFundConfig(),
+    isDraft: false,
+    isPublished: true,
+    publishedAt: new Date('2026-01-01T00:00:00.000Z'),
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+  };
+  fakeDb.fundConfigRows.push(fundConfig);
+
+  return {
+    policyId: policy.id,
+    envelopeId: envelope.id,
+    factsId: facts.id,
+    planId: plan.id,
+    forecastSnapshotId: forecastSnapshot.id,
+    fundConfigId: fundConfig.id,
+  };
+}
+
+function goldenRequest(overrides: Partial<LpEconomicsRunRequestV1> = {}): LpEconomicsRunRequestV1 {
+  return {
+    policyVersionId: 1,
+    factsSnapshotId: 1,
+    planVersionId: 1,
+    forecastSnapshotId: 1,
+    terminalMode: 'hold_unrealized',
+    clock: CLOCK,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// T-C1: completed-indicative happy path.
+// ---------------------------------------------------------------------------
+
+describe('executeLpEconomicsRun -- T-C1 indicative happy path', () => {
+  it('persists one run row + one snapshot in a single transaction, with a stable result_hash across replay', async () => {
+    const fakeDb = new FakeRunDb();
+    seedGoldenFixture(fakeDb);
+
+    const receipt = await executeLpEconomicsRun({
+      fundId: FUND_ID,
+      actorId: ACTOR_ID,
+      idempotencyKey: 'run-golden-1',
+      request: goldenRequest(),
+      database: fakeDb.asDatabase(),
+    });
+
+    expect(receipt.run.runState).toBe('completed');
+    expect(receipt.run.resultStatus).toBe('indicative');
+    expect(receipt.run.resultSnapshotId).not.toBeNull();
+    expect(receipt.run.failureCode).toBeNull();
+    expect(receipt.run.engineVersion).toBe(LP_ECONOMICS_RUN_ENGINE_VERSION);
+    expect(receipt.run.methodologyVersion).toBe(LP_ECONOMICS_RUN_METHODOLOGY_VERSION);
+    expect(receipt.result).not.toBeNull();
+    expect(receipt.result?.resultStatus).toBe('indicative');
+    expect(fakeDb.fundSnapshotRows).toHaveLength(2); // seeded forecast + persisted result
+    expect(fakeDb.runRows).toHaveLength(1);
+    expect(fakeDb.transactionAttempts).toBe(1);
+
+    const resultSnapshot = fakeDb.fundSnapshotRows.find(
+      (row) => row['type'] === 'INTERNAL_LP_ECONOMICS'
+    );
+    expect(resultSnapshot).toBeDefined();
+    expect(resultSnapshot?.['calcVersion']).toBe(LP_ECONOMICS_RESULT_CALC_VERSION);
+
+    const replay = await executeLpEconomicsRun({
+      fundId: FUND_ID,
+      actorId: ACTOR_ID,
+      idempotencyKey: 'run-golden-1',
+      request: goldenRequest(),
+      database: fakeDb.asDatabase(),
+    });
+
+    expect(replay.run.id).toBe(receipt.run.id);
+    expect(replay.run.resultHash).toBe(receipt.run.resultHash);
+    expect(replay.result).toEqual(receipt.result);
+    expect(fakeDb.runRows).toHaveLength(1);
+    expect(fakeDb.fundSnapshotRows).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-C2: every section 8 gate -> completed-unavailable, exactly one
+// persisted snapshot, reasons sorted/deduplicated, plus the defensive
+// loop-seam OPENING_STATE_INELIGIBLE injection.
+// ---------------------------------------------------------------------------
+
+function seededDb(mutate: (fakeDb: FakeRunDb) => void): FakeRunDb {
+  const fakeDb = new FakeRunDb();
+  seedGoldenFixture(fakeDb);
+  mutate(fakeDb);
+  return fakeDb;
+}
+
+async function expectUnavailable(
+  fakeDb: FakeRunDb,
+  idempotencyKey: string,
+  expectedCode: string,
+  requestOverrides: Partial<LpEconomicsRunRequestV1> = {}
+) {
+  const receipt = await executeLpEconomicsRun({
+    fundId: FUND_ID,
+    actorId: ACTOR_ID,
+    idempotencyKey,
+    request: goldenRequest(requestOverrides),
+    database: fakeDb.asDatabase(),
+  });
+  expect(receipt.run.runState).toBe('completed');
+  expect(receipt.run.resultStatus).toBe('unavailable');
+  expect(receipt.run.failureCode).toBeNull();
+  expect(receipt.result?.resultStatus).toBe('unavailable');
+  const reasons = receipt.result?.resultStatus === 'unavailable' ? receipt.result.reasons : [];
+  expect(reasons.map((reason) => reason.code)).toContain(expectedCode);
+  expect(
+    fakeDb.fundSnapshotRows.filter((row) => row['type'] === 'INTERNAL_LP_ECONOMICS')
+  ).toHaveLength(1);
+  return receipt;
+}
+
+describe('executeLpEconomicsRun -- T-C2 section 8 gates', () => {
+  it('gate 1: MAIN_FUND_VEHICLE_ABSENT when the pinned vehicle is reclassified', async () => {
+    const fakeDb = seededDb((db_) => {
+      const facts = db_.factsRows[0]!;
+      const payload = facts['payload'] as { vehicleRoster: Array<Record<string, unknown>> };
+      payload.vehicleRoster[0]!['vehicleType'] = 'spv';
+    });
+    await expectUnavailable(fakeDb, 'gate1-absent', 'MAIN_FUND_VEHICLE_ABSENT');
+  });
+
+  it('gate 1: MAIN_FUND_CURRENCY_UNSUPPORTED', async () => {
+    const fakeDb = seededDb((db_) => {
+      const facts = db_.factsRows[0]!;
+      const payload = facts['payload'] as { vehicleRoster: Array<Record<string, unknown>> };
+      payload.vehicleRoster[0]!['currency'] = 'EUR';
+    });
+    await expectUnavailable(fakeDb, 'gate1-currency', 'MAIN_FUND_CURRENCY_UNSUPPORTED');
+  });
+
+  it('gate 1: MAIN_FUND_SCOPED_FORECAST_UNAVAILABLE when an spv roster entry is present', async () => {
+    const fakeDb = seededDb((db_) => {
+      const facts = db_.factsRows[0]!;
+      const payload = facts['payload'] as { vehicleRoster: Array<Record<string, unknown>> };
+      payload.vehicleRoster.push({
+        vehicleId: 2,
+        vehicleType: 'spv',
+        vehicleSlug: 'spv-1',
+        name: 'SPV One',
+        currency: 'USD',
+      });
+    });
+    await expectUnavailable(fakeDb, 'gate1-spv', 'MAIN_FUND_SCOPED_FORECAST_UNAVAILABLE');
+  });
+
+  it('gate 2: CONFIG_LINEAGE_MISMATCH when policy/plan diverge on source config version', async () => {
+    const fakeDb = seededDb((db_) => {
+      db_.planRows[0]!['sourceConfigVersion'] = 2;
+    });
+    await expectUnavailable(fakeDb, 'gate2', 'CONFIG_LINEAGE_MISMATCH');
+  });
+
+  it.each(['unavailable', 'failed', 'held'] as const)(
+    'gate 3: forecast status %s maps to the matching registry code',
+    async (status) => {
+      const expectedCode =
+        status === 'unavailable'
+          ? 'FORECAST_UNAVAILABLE'
+          : status === 'failed'
+            ? 'FORECAST_FAILED'
+            : 'FORECAST_HELD_UNSUPPORTED';
+      const fakeDb = seededDb((db_) => {
+        const forecastRow = db_.fundSnapshotRows.find(
+          (row) => row['type'] === 'CURRENT_FORECAST_V2'
+        )!;
+        (forecastRow['payload'] as Record<string, unknown>)['status'] = status;
+      });
+      await expectUnavailable(fakeDb, `gate3-${status}`, expectedCode);
+    }
+  );
+
+  it('gate 4: FACTS_ECONOMICS_EVALUATION_BLOCKED when economics is blocked', async () => {
+    const fakeDb = seededDb((db_) => {
+      db_.factsRows[0]!['consumerEvaluations'] = [
+        { consumer: 'economics', status: 'blocked', reasons: [] },
+      ];
+    });
+    await expectUnavailable(fakeDb, 'gate4-blocked', 'FACTS_ECONOMICS_EVALUATION_BLOCKED');
+  });
+
+  it('gate 4: FACTS_ECONOMICS_EVALUATION_BLOCKED when the economics entry is missing', async () => {
+    const fakeDb = seededDb((db_) => {
+      db_.factsRows[0]!['consumerEvaluations'] = [
+        { consumer: 'forecast', status: 'accepted', reasons: [] },
+      ];
+    });
+    await expectUnavailable(fakeDb, 'gate4-missing', 'FACTS_ECONOMICS_EVALUATION_BLOCKED');
+  });
+
+  it('gate 4: FACTS_ECONOMICS_EVALUATION_BLOCKED when the economics entry is duplicated', async () => {
+    const fakeDb = seededDb((db_) => {
+      db_.factsRows[0]!['consumerEvaluations'] = [
+        { consumer: 'economics', status: 'accepted', reasons: [] },
+        { consumer: 'economics', status: 'accepted', reasons: [] },
+      ];
+    });
+    await expectUnavailable(fakeDb, 'gate4-duplicate', 'FACTS_ECONOMICS_EVALUATION_BLOCKED');
+  });
+
+  it('gate 5: OPENING_CASH_UNAVAILABLE when openingAccountingState is null', async () => {
+    const fakeDb = seededDb((db_) => {
+      (db_.factsRows[0]!['payload'] as Record<string, unknown>)['openingAccountingState'] = null;
+    });
+    await expectUnavailable(fakeDb, 'gate5-null', 'OPENING_CASH_UNAVAILABLE');
+  });
+
+  it('gate 5: OPENING_STATE_CONTRACT_INELIGIBLE for a v3/v1-ref payload', async () => {
+    const fakeDb = seededDb((db_) => {
+      const facts = db_.factsRows[0]!;
+      facts['policyVersion'] = 'financial-facts-policy/1.2.0';
+      facts['payloadSchemaId'] = 'financial-facts-payload/3';
+      (facts['payload'] as Record<string, unknown>)['openingAccountingState'] = {
+        sourceArtifactId: 1,
+        sourceArtifactSha256: hex64(16),
+        sourceArtifactCreatedAt: '2026-01-01T00:00:00.000Z',
+        attestedByActorId: ACTOR_ID,
+        observation: {
+          contractVersion: 'fund-accounting-state-observation/1.0.0',
+          cutoverInstant: CUTOVER_INSTANT,
+          currency: 'USD',
+          ...zeroOpeningStateFields(),
+          lpUnreturnedContributedCapitalUsd: ZERO_MONEY,
+          accruedPreferredReturnThroughInstant: CUTOVER_INSTANT,
+          methodologyVersion: 'opening-state-methodology/1.0.0',
+        },
+      };
+    });
+    await expectUnavailable(fakeDb, 'gate5-v1ref', 'OPENING_STATE_CONTRACT_INELIGIBLE');
+  });
+
+  it.each([
+    'cumulativeGpPaidInUsd',
+    'gpUnreturnedContributedCapitalUsd',
+    'gpInvestmentDistributionsPaidUsd',
+    'accruedPreferredReturnUsd',
+  ] as const)('gate 5: OPENING_STATE_INELIGIBLE on %s alone, loop never invoked', async (field) => {
+    const fakeDb = seededDb((db_) => {
+      (db_.factsRows[0]!['payload'] as Record<string, unknown>)['openingAccountingState'] =
+        resolvedOpeningAccountingStateRef({ [field]: '0.000001' });
+    });
+    const spy = vi.spyOn(cashAssemblyPeriodLoopModule, 'executeCashAssemblyPeriodLoopV1');
+    const receipt = await expectUnavailable(fakeDb, `gate5-${field}`, 'OPENING_STATE_INELIGIBLE');
+    expect(spy).not.toHaveBeenCalled();
+    const reasons = receipt.result?.resultStatus === 'unavailable' ? receipt.result.reasons : [];
+    const reason = reasons.find((entry) => entry.code === 'OPENING_STATE_INELIGIBLE');
+    expect(reason?.context).toMatchObject({ field, valueUsd: '0.000001' });
+    spy.mockRestore();
+  });
+
+  it('gate 5: OPENING_STATE_INELIGIBLE picks the first nonzero field in fixed order when several are nonzero', async () => {
+    const fakeDb = seededDb((db_) => {
+      (db_.factsRows[0]!['payload'] as Record<string, unknown>)['openingAccountingState'] =
+        resolvedOpeningAccountingStateRef({
+          gpUnreturnedContributedCapitalUsd: '0.000002',
+          accruedPreferredReturnUsd: '0.000003',
+        });
+    });
+    const spy = vi.spyOn(cashAssemblyPeriodLoopModule, 'executeCashAssemblyPeriodLoopV1');
+    const receipt = await expectUnavailable(fakeDb, 'gate5-multi', 'OPENING_STATE_INELIGIBLE');
+    expect(spy).not.toHaveBeenCalled();
+    const reasons = receipt.result?.resultStatus === 'unavailable' ? receipt.result.reasons : [];
+    const reason = reasons.find((entry) => entry.code === 'OPENING_STATE_INELIGIBLE');
+    // Fixed order: cumulativeGpPaidInUsd, gpUnreturnedContributedCapitalUsd,
+    // gpInvestmentDistributionsPaidUsd, accruedPreferredReturnUsd -- the
+    // second field in that order must win, not the third.
+    expect(reason?.context).toMatchObject({ field: 'gpUnreturnedContributedCapitalUsd' });
+    spy.mockRestore();
+  });
+
+  it('gate 6: GP_COMMITMENT_UNSUPPORTED when the envelope carries a nonzero GP commitment', async () => {
+    const fakeDb = seededDb((db_) => {
+      db_.envelopeRows[0]!['gpCommitmentUsd'] = '1.000000';
+    });
+    await expectUnavailable(fakeDb, 'gate6', 'GP_COMMITMENT_UNSUPPORTED');
+  });
+
+  it('gate 7: FORECAST_FEE_BASIS_INCOMPATIBLE when the source fund config is missing', async () => {
+    const fakeDb = seededDb((db_) => {
+      db_.fundConfigRows.length = 0;
+    });
+    await expectUnavailable(fakeDb, 'gate7-missing', 'FORECAST_FEE_BASIS_INCOMPATIBLE');
+  });
+
+  it('gate 7: FORECAST_FEE_BASIS_INCOMPATIBLE when the config carries a nonzero management fee', async () => {
+    const fakeDb = seededDb((db_) => {
+      (db_.fundConfigRows[0]!['config'] as Record<string, unknown>)['managementFeeRate'] = 0.02;
+    });
+    await expectUnavailable(fakeDb, 'gate7-nonzero', 'FORECAST_FEE_BASIS_INCOMPATIBLE');
+  });
+
+  it('gate 8: TERMINAL_RESOLUTION_METHODOLOGY_UNSUPPORTED for an unrecognized methodology version', async () => {
+    const fakeDb = seededDb((db_) => {
+      db_.policyRows[0]!['terminalResolutionMethodologyVersion'] = 'some-other-methodology/9.9.9';
+    });
+    await expectUnavailable(
+      fakeDb,
+      'gate8-methodology',
+      'TERMINAL_RESOLUTION_METHODOLOGY_UNSUPPORTED'
+    );
+  });
+
+  it('gate 8: TERMINAL_RESOLUTION_MISMATCH when the persisted period diverges from the policy-time resolution', async () => {
+    const fakeDb = seededDb((db_) => {
+      db_.policyRows[0]!['terminalPeriodEnd'] = '2026-06-30';
+      const forecastRow = db_.fundSnapshotRows.find(
+        (row) => row['type'] === 'CURRENT_FORECAST_V2'
+      )!;
+      const payload = forecastRow['payload'] as { series: Array<Record<string, unknown>> };
+      payload.series[0]!['periodEnd'] = '2026-06-30';
+      payload.series[0]!['periodStart'] = '2026-04-01';
+    });
+    await expectUnavailable(fakeDb, 'gate8-mismatch', 'TERMINAL_RESOLUTION_MISMATCH');
+  });
+
+  it('gate 8: TERMINAL_BEFORE_CUTOVER when the opening cutover is after the terminal instant', async () => {
+    const fakeDb = seededDb((db_) => {
+      (db_.factsRows[0]!['payload'] as Record<string, unknown>)['openingAccountingState'] =
+        resolvedOpeningAccountingStateRef();
+      const opening = (
+        (db_.factsRows[0]!['payload'] as Record<string, unknown>)[
+          'openingAccountingState'
+        ] as Record<string, unknown>
+      )['observation'] as Record<string, unknown>;
+      opening['cutoverInstant'] = '2026-12-31T23:59:59.999Z';
+      opening['accruedPreferredReturnThroughInstant'] = '2026-12-31T23:59:59.999Z';
+    });
+    await expectUnavailable(fakeDb, 'gate8-cutover', 'TERMINAL_BEFORE_CUTOVER');
+  });
+
+  it('gate 8: FORECAST_HORIZON_SHORT when the forecast never reaches the terminal period', async () => {
+    const fakeDb = seededDb((db_) => {
+      db_.policyRows[0]!['terminalPeriodEnd'] = '2030-03-31';
+      db_.policyRows[0]!['terminalResolutionMethodologyVersion'] =
+        INTERNAL_ECONOMICS_TERMINAL_RESOLUTION_VERSION;
+      // Keep the match-assert satisfied by aligning the term anchor with the
+      // new terminal period (2021-01-01 + 9yr = 2030-01-01 -> Q1 end 2030-03-31).
+      (db_.policyRows[0]!['policyBody'] as Record<string, unknown>)['fundLifeYears'] = '9';
+    });
+    await expectUnavailable(fakeDb, 'gate8-horizon', 'FORECAST_HORIZON_SHORT');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-C3: typed engine failure -> failed run, no snapshot, key consumed,
+// replay returns the same failure. Full seven-class, all-code dispatch
+// table sweep via loop-seam injection (P-D7 step 6, normative source).
+// ---------------------------------------------------------------------------
+
+interface DispatchCase {
+  readonly label: string;
+  readonly build: () => Error;
+  readonly disposition: 'failed' | 'unavailable';
+  readonly code: string;
+}
+
+const DISPATCH_TABLE: readonly DispatchCase[] = [
+  // CashAssemblyPeriodLoopV1Error -- mixed; every non-OPENING_STATE_INELIGIBLE code failed.
+  ...(
+    [
+      'FACT_AFTER_CUTOVER',
+      'PARTIAL_PROJECTED_PERIOD',
+      'SCHEDULE_GRID_MISMATCH',
+      'HISTORICAL_RECONCILIATION_MISMATCH',
+      'CORE_ROW_MAPPING_MISMATCH',
+      'TERMINAL_RECONCILIATION_FAILED',
+      'MONOTONICITY_VIOLATION',
+      'CARRY_PCT_INVALID',
+    ] as const
+  ).map((code): DispatchCase => ({
+    label: `CashAssemblyPeriodLoopV1Error/${code}`,
+    build: () => new CashAssemblyPeriodLoopV1Error(code, `${code} synthetic`),
+    disposition: 'failed',
+    code,
+  })),
+  {
+    label: 'CashAssemblyPeriodLoopV1Error/OPENING_STATE_INELIGIBLE',
+    build: () =>
+      new CashAssemblyPeriodLoopV1Error('OPENING_STATE_INELIGIBLE', 'synthetic', {
+        field: 'cumulativeGpPaidInUsd',
+        valueUsd: '0.000001',
+      }),
+    disposition: 'unavailable',
+    code: 'OPENING_STATE_INELIGIBLE',
+  },
+  // DecimalWaterfallCoreV1Error -- no registry codes, always failed.
+  ...(
+    [
+      'PREF_BEARING_UNSUPPORTED_V1',
+      'OPENING_STATE_INVALID',
+      'CARRY_RATIO_INVALID',
+      'EVENT_INPUT_INVALID',
+      'DUPLICATE_EVENT_ID',
+      'CONSERVATION_FAILED',
+      'UNRETURNED_CAPITAL_MONOTONICITY',
+    ] as const
+  ).map((code): DispatchCase => ({
+    label: `DecimalWaterfallCoreV1Error/${code}`,
+    build: () => new DecimalWaterfallCoreV1Error(code, `${code} synthetic`),
+    disposition: 'failed',
+    code,
+  })),
+  // TerminalPolicyV1Error -- registry codes unavailable, FUND_LIFE_GRID_UNREPRESENTABLE failed.
+  ...(
+    [
+      'TERMINAL_RESOLUTION_METHODOLOGY_UNSUPPORTED',
+      'TERMINAL_RESOLUTION_MISMATCH',
+      'TERMINAL_BEFORE_CUTOVER',
+      'FORECAST_HORIZON_SHORT',
+      'FORECAST_TERMINAL_PERIOD_UNREPRESENTABLE',
+      'NEGATIVE_SOURCE_MONEY',
+    ] as const
+  ).map((code): DispatchCase => ({
+    label: `TerminalPolicyV1Error/${code}`,
+    build: () => new TerminalPolicyV1Error(code, `${code} synthetic`),
+    disposition: 'unavailable',
+    code,
+  })),
+  {
+    label: 'TerminalPolicyV1Error/FUND_LIFE_GRID_UNREPRESENTABLE',
+    build: () => new TerminalPolicyV1Error('FUND_LIFE_GRID_UNREPRESENTABLE', 'synthetic'),
+    disposition: 'failed',
+    code: 'FUND_LIFE_GRID_UNREPRESENTABLE',
+  },
+  // CashAssemblyEventStreamV1Error -- all 3 codes are registry codes, unavailable.
+  ...(
+    [
+      'POST_TERM_ACTIVITY',
+      'NEGATIVE_SOURCE_MONEY',
+      'FORECAST_DEPLOYMENT_CUMULATIVE_DECREASE',
+    ] as const
+  ).map((code): DispatchCase => ({
+    label: `CashAssemblyEventStreamV1Error/${code}`,
+    build: () => new CashAssemblyEventStreamV1Error(code, `${code} synthetic`),
+    disposition: 'unavailable',
+    code,
+  })),
+  // CashAssemblyEventStreamInvariantError -- message-only, always failed.
+  {
+    label: 'CashAssemblyEventStreamInvariantError',
+    build: () => new CashAssemblyEventStreamInvariantError('invariant synthetic'),
+    disposition: 'failed',
+    code: 'INVARIANT_VIOLATION',
+  },
+  // CashAssemblyCallSizingV1Error -- mixed dispatch.
+  {
+    label: 'CashAssemblyCallSizingV1Error/OPENING_CASH_UNAVAILABLE',
+    build: () => new CashAssemblyCallSizingV1Error('OPENING_CASH_UNAVAILABLE', 'synthetic'),
+    disposition: 'unavailable',
+    code: 'OPENING_CASH_UNAVAILABLE',
+  },
+  {
+    label: 'CashAssemblyCallSizingV1Error/COMMITTED_CAPITAL_EXCEEDED',
+    build: () => new CashAssemblyCallSizingV1Error('COMMITTED_CAPITAL_EXCEEDED', 'synthetic'),
+    disposition: 'unavailable',
+    code: 'COMMITTED_CAPITAL_EXCEEDED',
+  },
+  {
+    label: 'CashAssemblyCallSizingV1Error/NEGATIVE_SCHEDULED_AMOUNT',
+    build: () => new CashAssemblyCallSizingV1Error('NEGATIVE_SCHEDULED_AMOUNT', 'synthetic'),
+    disposition: 'failed',
+    code: 'NEGATIVE_SCHEDULED_AMOUNT',
+  },
+  {
+    label: 'CashAssemblyCallSizingV1Error/NONZERO_FEE_EXPENSE_UNSUPPORTED_V1',
+    build: () =>
+      new CashAssemblyCallSizingV1Error('NONZERO_FEE_EXPENSE_UNSUPPORTED_V1', 'synthetic'),
+    disposition: 'failed',
+    code: 'NONZERO_FEE_EXPENSE_UNSUPPORTED_V1',
+  },
+  // PresentationRoundingError -- always failed (D9).
+  ...(
+    [
+      'INVALID_USD_AMOUNT',
+      'INVALID_TARGET_CENTS',
+      'INVALID_ENTITLEMENT',
+      'NEGATIVE_LRM_SHORTFALL',
+      'OUTPUT_CONSERVATION_FAILED',
+      'FULL_PRECISION_CONSERVATION_FAILED',
+    ] as const
+  ).map((code): DispatchCase => ({
+    label: `PresentationRoundingError/${code}`,
+    build: () => new PresentationRoundingError(code, `${code} synthetic`),
+    disposition: 'failed',
+    code,
+  })),
+];
+
+describe('executeLpEconomicsRun -- T-C3 typed engine failure dispatch (P-D7 step 6, full table)', () => {
+  it.each(DISPATCH_TABLE.map((entry) => [entry.label, entry] as const))(
+    '%s -> %s',
+    async (_label, entry) => {
+      const fakeDb = seededDb(() => {});
+      const spy = vi
+        .spyOn(cashAssemblyPeriodLoopModule, 'executeCashAssemblyPeriodLoopV1')
+        .mockImplementation(() => {
+          throw entry.build();
+        });
+
+      const receipt = await executeLpEconomicsRun({
+        fundId: FUND_ID,
+        actorId: ACTOR_ID,
+        idempotencyKey: `dispatch-${entry.label}`,
+        request: goldenRequest(),
+        database: fakeDb.asDatabase(),
+      });
+
+      if (entry.disposition === 'failed') {
+        expect(receipt.run.runState).toBe('failed');
+        expect(receipt.run.resultSnapshotId).toBeNull();
+        expect(receipt.run.failureCode).toBe(entry.code);
+        expect(receipt.result).toBeNull();
+        expect(
+          fakeDb.fundSnapshotRows.filter((row) => row['type'] === 'INTERNAL_LP_ECONOMICS')
+        ).toHaveLength(0);
+      } else {
+        expect(receipt.run.runState).toBe('completed');
+        expect(receipt.run.resultStatus).toBe('unavailable');
+        const reasons =
+          receipt.result?.resultStatus === 'unavailable' ? receipt.result.reasons : [];
+        expect(reasons.map((reason) => reason.code)).toContain(entry.code);
+      }
+
+      // Replay returns the identical persisted outcome; key is consumed
+      // either way (idempotency-key uniqueness on the run row).
+      const replay = await executeLpEconomicsRun({
+        fundId: FUND_ID,
+        actorId: ACTOR_ID,
+        idempotencyKey: `dispatch-${entry.label}`,
+        request: goldenRequest(),
+        database: fakeDb.asDatabase(),
+      });
+      expect(replay.run.id).toBe(receipt.run.id);
+      expect(fakeDb.runRows).toHaveLength(1);
+
+      spy.mockRestore();
+    }
+  );
+});
+
+// ---------------------------------------------------------------------------
+// T-C4: unexpected exception -> full rollback, no run row, no snapshot,
+// key NOT consumed.
+// ---------------------------------------------------------------------------
+
+describe('executeLpEconomicsRun -- T-C4 unexpected exception', () => {
+  it('an unrecognized error at the loop seam propagates uncaught and persists nothing', async () => {
+    const fakeDb = seededDb(() => {});
+    const spy = vi
+      .spyOn(cashAssemblyPeriodLoopModule, 'executeCashAssemblyPeriodLoopV1')
+      .mockImplementation(() => {
+        throw new Error('totally unexpected infrastructure failure');
+      });
+
+    await expect(
+      executeLpEconomicsRun({
+        fundId: FUND_ID,
+        actorId: ACTOR_ID,
+        idempotencyKey: 'unexpected-1',
+        request: goldenRequest(),
+        database: fakeDb.asDatabase(),
+      })
+    ).rejects.toThrow('totally unexpected infrastructure failure');
+
+    expect(fakeDb.runRows).toHaveLength(0);
+    expect(
+      fakeDb.fundSnapshotRows.filter((row) => row['type'] === 'INTERNAL_LP_ECONOMICS')
+    ).toHaveLength(0);
+
+    spy.mockRestore();
+
+    // Key not consumed: an identical retry with the SAME idempotency key
+    // (loop now behaving normally) succeeds fresh, not a replay of a
+    // nonexistent prior outcome.
+    const receipt = await executeLpEconomicsRun({
+      fundId: FUND_ID,
+      actorId: ACTOR_ID,
+      idempotencyKey: 'unexpected-1',
+      request: goldenRequest(),
+      database: fakeDb.asDatabase(),
+    });
+    expect(receipt.run.runState).toBe('completed');
+    expect(fakeDb.runRows).toHaveLength(1);
+  });
+
+  it('a persistence-seam failure (fund_snapshots insert throws) rolls back with nothing persisted', async () => {
+    const fakeDb = seededDb(() => {});
+    const originalInsert = fakeDb.insert.bind(fakeDb);
+    vi.spyOn(fakeDb, 'insert').mockImplementation((table: unknown) => {
+      if (table === fundSnapshots) {
+        return {
+          values: () => ({
+            returning: async () => {
+              throw new Error('simulated persistence-seam failure');
+            },
+          }),
+        } as ReturnType<typeof fakeDb.insert>;
+      }
+      return originalInsert(table);
+    });
+
+    await expect(
+      executeLpEconomicsRun({
+        fundId: FUND_ID,
+        actorId: ACTOR_ID,
+        idempotencyKey: 'unexpected-2',
+        request: goldenRequest(),
+        database: fakeDb.asDatabase(),
+      })
+    ).rejects.toThrow('simulated persistence-seam failure');
+
+    expect(fakeDb.runRows).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-C5: basis explicitness -- no latest-resolution anywhere. An absent
+// basis ID is a validation/not-found error, never a fallback read.
+// ---------------------------------------------------------------------------
+
+describe('executeLpEconomicsRun -- T-C5 no latest-resolution fallback', () => {
+  it('an unknown policyVersionId 404s rather than falling back to any "latest" policy', async () => {
+    const fakeDb = seededDb(() => {});
+    await expect(
+      executeLpEconomicsRun({
+        fundId: FUND_ID,
+        actorId: ACTOR_ID,
+        idempotencyKey: 'no-fallback-policy',
+        request: goldenRequest({ policyVersionId: 999 }),
+        database: fakeDb.asDatabase(),
+      })
+    ).rejects.toMatchObject({ code: 'FUND_SCOPE_NOT_FOUND' });
+    expect(fakeDb.runRows).toHaveLength(0);
+  });
+
+  it('an unknown forecastSnapshotId 404s rather than resolving the latest CURRENT_FORECAST_V2 snapshot', async () => {
+    const fakeDb = seededDb(() => {});
+    await expect(
+      executeLpEconomicsRun({
+        fundId: FUND_ID,
+        actorId: ACTOR_ID,
+        idempotencyKey: 'no-fallback-forecast',
+        request: goldenRequest({ forecastSnapshotId: 999 }),
+        database: fakeDb.asDatabase(),
+      })
+    ).rejects.toMatchObject({ code: 'FUND_SCOPE_NOT_FOUND' });
+    expect(fakeDb.runRows).toHaveLength(0);
+  });
+
+  it('the request schema requires every basis ID explicitly (no optional field admits a fallback)', () => {
+    const request = goldenRequest() as Record<string, unknown>;
+    delete request['factsSnapshotId'];
+    const parsed = LpEconomicsRunRequestV1Schema.safeParse(request);
+    expect(parsed.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-C6/T-C7: concurrency races, serialized by the advisory-lock mutex
+// (real Postgres semantics simulated by FakeRunDb's KeyedMutex).
+// ---------------------------------------------------------------------------
+
+describe('executeLpEconomicsRun -- T-C6/T-C7 concurrency races', () => {
+  it('T-C6: concurrent identical requests yield one execution and one replay', async () => {
+    const fakeDb = seededDb(() => {});
+    const input = {
+      fundId: FUND_ID,
+      actorId: ACTOR_ID,
+      idempotencyKey: 'race-identical',
+      request: goldenRequest(),
+      database: fakeDb.asDatabase(),
+    };
+
+    const [left, right] = await Promise.all([
+      executeLpEconomicsRun(input),
+      executeLpEconomicsRun(input),
+    ]);
+
+    expect(left.run.id).toBe(right.run.id);
+    expect(fakeDb.runRows).toHaveLength(1);
+    expect(
+      fakeDb.fundSnapshotRows.filter((row) => row['type'] === 'INTERNAL_LP_ECONOMICS')
+    ).toHaveLength(1);
+  });
+
+  it('T-C7: concurrent changed-preimage requests yield one success and one 409', async () => {
+    const fakeDb = seededDb(() => {});
+    const results = await Promise.allSettled([
+      executeLpEconomicsRun({
+        fundId: FUND_ID,
+        actorId: ACTOR_ID,
+        idempotencyKey: 'race-changed',
+        request: goldenRequest(),
+        database: fakeDb.asDatabase(),
+      }),
+      executeLpEconomicsRun({
+        fundId: FUND_ID,
+        actorId: ACTOR_ID,
+        idempotencyKey: 'race-changed',
+        request: goldenRequest({ clock: '2026-07-31T23:59:59.000Z' }),
+        database: fakeDb.asDatabase(),
+      }),
+    ]);
+
+    const fulfilled = results.filter((result) => result.status === 'fulfilled');
+    const rejected = results.filter((result) => result.status === 'rejected');
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect((rejected[0] as PromiseRejectedResult).reason).toBeInstanceOf(IdempotentCommandError);
+    expect((rejected[0] as PromiseRejectedResult).reason).toMatchObject({ status: 409 });
+    expect(fakeDb.runRows).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-C9: getRunWithResult joins the result snapshot and validates
+// type/ownership.
+// ---------------------------------------------------------------------------
+
+describe('getRunWithResult -- T-C9 lineage read joins + type/ownership', () => {
+  it('joins the persisted result snapshot for a completed run', async () => {
+    const fakeDb = seededDb(() => {});
+    const receipt = await executeLpEconomicsRun({
+      fundId: FUND_ID,
+      actorId: ACTOR_ID,
+      idempotencyKey: 'lineage-1',
+      request: goldenRequest(),
+      database: fakeDb.asDatabase(),
+    });
+
+    const read = await getRunWithResult({
+      fundId: FUND_ID,
+      runId: receipt.run.id,
+      database: fakeDb.asDatabase(),
+    });
+    expect(read.run.id).toBe(receipt.run.id);
+    expect(read.result).toEqual(receipt.result);
+  });
+
+  it('rejects a cross-fund read with a fund-scope 404', async () => {
+    const fakeDb = seededDb(() => {});
+    const receipt = await executeLpEconomicsRun({
+      fundId: FUND_ID,
+      actorId: ACTOR_ID,
+      idempotencyKey: 'lineage-2',
+      request: goldenRequest(),
+      database: fakeDb.asDatabase(),
+    });
+
+    await expect(
+      getRunWithResult({
+        fundId: FUND_ID + 1,
+        runId: receipt.run.id,
+        database: fakeDb.asDatabase(),
+      })
+    ).rejects.toMatchObject({ code: 'FUND_SCOPE_NOT_FOUND' });
+  });
+
+  it('returns a null result for a failed run', async () => {
+    const fakeDb = seededDb(() => {});
+    const spy = vi
+      .spyOn(cashAssemblyPeriodLoopModule, 'executeCashAssemblyPeriodLoopV1')
+      .mockImplementation(() => {
+        throw new CashAssemblyPeriodLoopV1Error('CARRY_PCT_INVALID', 'synthetic');
+      });
+    const receipt = await executeLpEconomicsRun({
+      fundId: FUND_ID,
+      actorId: ACTOR_ID,
+      idempotencyKey: 'lineage-3',
+      request: goldenRequest(),
+      database: fakeDb.asDatabase(),
+    });
+    spy.mockRestore();
+
+    const read = await getRunWithResult({
+      fundId: FUND_ID,
+      runId: receipt.run.id,
+      database: fakeDb.asDatabase(),
+    });
+    expect(read.run.runState).toBe('failed');
+    expect(read.result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-C10 (P-D8 amendment): replaying under a bumped engine/methodology
+// version returns 409, never a silent replay of the prior engine's result.
+// ---------------------------------------------------------------------------
+
+describe('executeLpEconomicsRun -- T-C10 engine/methodology version bump', () => {
+  it('a prior run persisted under an older engine version 409s rather than replaying silently', async () => {
+    const fakeDb = seededDb(() => {});
+    const request = goldenRequest();
+    const staleRequestHash = canonicalSha256({
+      fundId: FUND_ID,
+      contractVersion: LP_ECONOMICS_RUN_CONTRACT_VERSION,
+      request,
+      engineVersion: 'cash-assembly-period-loop-v1/0.9.0',
+      methodologyVersion: 'cash-assembly-period-loop-methodology/0.9.0',
+    });
+    fakeDb.runRows.push({
+      id: 1,
+      fundId: FUND_ID,
+      policyVersionId: 1,
+      factsSnapshotId: 1,
+      planVersionId: 1,
+      forecastSnapshotId: 1,
+      forecastSnapshotType: 'CURRENT_FORECAST_V2',
+      resultSnapshotId: null,
+      resultSnapshotType: null,
+      runState: 'failed',
+      resultStatus: null,
+      failureCode: 'SOME_OLD_FAILURE',
+      failureContext: {},
+      evaluationClock: new Date(request.clock),
+      terminalMode: request.terminalMode,
+      engineVersion: 'cash-assembly-period-loop-v1/0.9.0',
+      methodologyVersion: 'cash-assembly-period-loop-methodology/0.9.0',
+      inputHash: hex64(17),
+      resultHash: null,
+      createdBy: ACTOR_ID,
+      idempotencyKey: 'version-bump',
+      requestHash: staleRequestHash,
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+
+    await expect(
+      executeLpEconomicsRun({
+        fundId: FUND_ID,
+        actorId: ACTOR_ID,
+        idempotencyKey: 'version-bump',
+        request,
+        database: fakeDb.asDatabase(),
+      })
+    ).rejects.toMatchObject({ status: 409, code: 'IDEMPOTENCY_KEY_REUSE' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-C11 (P-D10 amendment): the service never touches source_artifacts.
+// Statically proven (the service module imports no source_artifacts
+// schema/table at all) and behaviorally proven (the happy path succeeds
+// with no source_artifacts row modeled anywhere in the mock database).
+// ---------------------------------------------------------------------------
+
+describe('executeLpEconomicsRun -- T-C11 no source_artifacts touch', () => {
+  it('the service module source never references source_artifacts', async () => {
+    // tests/setup/node-setup.ts stubs the NAMED `fs.readFileSync` export
+    // globally (returns undefined by default); `default` stays real, so a
+    // genuine file read here must go through vi.importActual (repo lesson).
+    const realFs = await vi.importActual<typeof import('node:fs')>('node:fs');
+    const source = realFs.readFileSync(
+      resolve(
+        dirname(fileURLToPath(import.meta.url)),
+        '../../../../server/services/internal-economics/lp-economics-run-service.ts'
+      ),
+      'utf8'
+    );
+    const codeOnly = source.replace(/\/\*[\s\S]*?\*\/|\/\/.*$/gm, '');
+    expect(codeOnly).not.toMatch(/sourceArtifacts|source_artifacts/);
+  });
+
+  it('a run executes successfully against an eligible v4 snapshot with no source_artifacts row modeled at all', async () => {
+    const fakeDb = seededDb(() => {});
+    const receipt = await executeLpEconomicsRun({
+      fundId: FUND_ID,
+      actorId: ACTOR_ID,
+      idempotencyKey: 'no-source-artifacts',
+      request: goldenRequest(),
+      database: fakeDb.asDatabase(),
+    });
+    expect(receipt.run.runState).toBe('completed');
+    expect(receipt.result?.resultStatus).toBe('indicative');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-C12 (G6/gate-1 amendment, corrected R3): gate 1 reads the PINNED facts
+// snapshot roster, never a live `vehicles` table (which this service does
+// not even query).
+// ---------------------------------------------------------------------------
+
+describe('executeLpEconomicsRun -- T-C12 basis-purity of the vehicle-type re-check', () => {
+  it('(a) a facts snapshot taken AFTER reclassification refuses via the pinned roster', async () => {
+    const fakeDb = seededDb((db_) => {
+      const laterFacts = structuredClone(db_.factsRows[0]!);
+      laterFacts['id'] = 2;
+      laterFacts['idempotencyKey'] = 'facts-later';
+      (
+        laterFacts['payload'] as { vehicleRoster: Array<Record<string, unknown>> }
+      ).vehicleRoster[0]!['vehicleType'] = 'spv';
+      db_.factsRows.push(laterFacts);
+    });
+    await expectUnavailable(fakeDb, 'tc12a', 'MAIN_FUND_VEHICLE_ABSENT', { factsSnapshotId: 2 });
+  });
+
+  it('(b) a facts snapshot taken WHILE main_fund stays eligible even after a later live reclassification', async () => {
+    // Basis purity: this service never reads a live `vehicles` table at
+    // all, so there is no "later reclassification" code path that could
+    // affect an already-pinned facts snapshot's roster state.
+    const fakeDb = seededDb(() => {});
+    const receipt = await executeLpEconomicsRun({
+      fundId: FUND_ID,
+      actorId: ACTOR_ID,
+      idempotencyKey: 'tc12b',
+      request: goldenRequest({ factsSnapshotId: 1 }),
+      database: fakeDb.asDatabase(),
+    });
+    expect(receipt.run.runState).toBe('completed');
+    expect(receipt.run.resultStatus).toBe('indicative');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-C13 (section 6 amendment): event rows carry correct
+// eventSequence/eventId/eventKind, derived from array position plus the
+// frozen loop's own literal `:terminal_liquidation` sourceId suffix — never
+// by interpreting any other part of the opaque sourceId string. The
+// "ordinary" case below proves position alone is insufficient (a lone
+// non-terminal event at the last index must not be misclassified).
+// ---------------------------------------------------------------------------
+
+describe('executeLpEconomicsRun -- T-C13 event enrichment structural correctness', () => {
+  it('an ordinary distribution event gets eventSequence 0 and forecast_quarterly_distribution', async () => {
+    const fakeDb = seededDb((db_) => {
+      const forecastRow = db_.fundSnapshotRows.find(
+        (row) => row['type'] === 'CURRENT_FORECAST_V2'
+      )!;
+      const payload = forecastRow['payload'] as { series: Array<Record<string, unknown>> };
+      payload.series[0]!['distributionsUsd'] = '100.000000';
+      payload.series[0]!['navUsd'] = ZERO_MONEY;
+    });
+
+    const receipt = await executeLpEconomicsRun({
+      fundId: FUND_ID,
+      actorId: ACTOR_ID,
+      idempotencyKey: 'tc13-ordinary',
+      request: goldenRequest(),
+      database: fakeDb.asDatabase(),
+    });
+
+    expect(receipt.result?.resultStatus).toBe('indicative');
+    const events =
+      receipt.result?.resultStatus === 'indicative' ? receipt.result.waterfallEvents : [];
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      eventSequence: 0,
+      eventKind: 'forecast_quarterly_distribution',
+      sourceRefs: [{ sourceId: events[0]!.sourceId }],
+    });
+    expect(events[0]!.eventId).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('a terminal liquidation event is always last and carries terminal_realization', async () => {
+    const fakeDb = seededDb((db_) => {
+      const forecastRow = db_.fundSnapshotRows.find(
+        (row) => row['type'] === 'CURRENT_FORECAST_V2'
+      )!;
+      const payload = forecastRow['payload'] as { series: Array<Record<string, unknown>> };
+      payload.series[0]!['distributionsUsd'] = '100.000000';
+      payload.series[0]!['navUsd'] = '500.000000';
+      const policy = db_.policyRows[0]!;
+      (policy['policyBody'] as Record<string, unknown>)['terminalMode'] = 'liquidate_at_horizon';
+    });
+
+    const receipt = await executeLpEconomicsRun({
+      fundId: FUND_ID,
+      actorId: ACTOR_ID,
+      idempotencyKey: 'tc13-terminal',
+      request: goldenRequest({ terminalMode: 'liquidate_at_horizon' }),
+      database: fakeDb.asDatabase(),
+    });
+
+    expect(receipt.result?.resultStatus).toBe('indicative');
+    const events =
+      receipt.result?.resultStatus === 'indicative' ? receipt.result.waterfallEvents : [];
+    expect(events.length).toBeGreaterThanOrEqual(1);
+    const lastEvent = events.at(-1);
+    expect(lastEvent?.eventKind).toBe('terminal_realization');
+    expect(lastEvent?.sourceId).toMatch(/:terminal_liquidation$/);
+    expect(lastEvent?.eventSequence).toBe(events.length - 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-C14 (section 6 amendment): reason-array ORDER differences produce
+// identical persisted payloads and identical result_hash.
+// ---------------------------------------------------------------------------
+
+describe('executeLpEconomicsRun -- T-C14 reason order does not affect result_hash', () => {
+  it('two runs whose loop reasons differ only in array order hash identically', async () => {
+    const fakeDbA = seededDb(() => {});
+    const fakeDbB = seededDb(() => {});
+    const baseline = executeCashAssemblyPeriodLoopV1({
+      factsSnapshotId: 1,
+      forecastSnapshotId: 1,
+      economicsPolicyVersion: 'internal-economics-policy/1.0.0',
+      engineVersion: LP_ECONOMICS_RUN_ENGINE_VERSION,
+      methodologyVersion: LP_ECONOMICS_RUN_METHODOLOGY_VERSION,
+      factsEvents: [],
+      factsNavMarks: [],
+      factsPeriodNav: [],
+      openingState: resolvedOpeningState(),
+      forecastSeries: goldenForecastSeries(),
+      scheduledNeeds: [
+        {
+          period: { periodStart: PERIOD_START, periodEnd: PERIOD_END, source: 'projected' },
+          scheduledDeploymentUsd: new Decimal(0),
+          scheduledFeeUsd: new Decimal(0),
+          scheduledExpenseUsd: new Decimal(0),
+        },
+      ],
+      cashBufferQuarters: 0,
+      unfundedEnvelopeRemainingUsd: new Decimal('1000000'),
+      persistedTerminalResolution: {
+        terminalPeriodEnd: PERIOD_END,
+        terminalResolutionMethodologyVersion: INTERNAL_ECONOMICS_TERMINAL_RESOLUTION_VERSION,
+      },
+      terminalMode: 'hold_unrealized',
+      carryPct: 0.2,
+    });
+
+    const spyA = vi
+      .spyOn(cashAssemblyPeriodLoopModule, 'executeCashAssemblyPeriodLoopV1')
+      .mockReturnValueOnce({
+        ...baseline,
+        resultStatusReasons: ['DECIMAL_CORE_UNCERTIFIED', 'LP_NET_NAV_FLAT_SHARE_APPROXIMATION'],
+      });
+    const receiptA = await executeLpEconomicsRun({
+      fundId: FUND_ID,
+      actorId: ACTOR_ID,
+      idempotencyKey: 'tc14-a',
+      request: goldenRequest(),
+      database: fakeDbA.asDatabase(),
+    });
+    spyA.mockRestore();
+
+    const spyB = vi
+      .spyOn(cashAssemblyPeriodLoopModule, 'executeCashAssemblyPeriodLoopV1')
+      .mockReturnValueOnce({
+        ...baseline,
+        resultStatusReasons: ['LP_NET_NAV_FLAT_SHARE_APPROXIMATION', 'DECIMAL_CORE_UNCERTIFIED'],
+      });
+    const receiptB = await executeLpEconomicsRun({
+      fundId: FUND_ID,
+      actorId: ACTOR_ID,
+      idempotencyKey: 'tc14-b',
+      request: goldenRequest(),
+      database: fakeDbB.asDatabase(),
+    });
+    spyB.mockRestore();
+
+    expect(receiptA.run.resultHash).toBe(receiptB.run.resultHash);
+    expect(receiptA.result).toEqual(receiptB.result);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-C15 (P-D4 mapping amendment): the persisted result fund_snapshots row
+// carries exactly the normative column mapping, direct row readback.
+// ---------------------------------------------------------------------------
+
+describe('executeLpEconomicsRun -- T-C15 fund_snapshots column mapping', () => {
+  it('state IS NULL, snapshot_time = pinned clock, calc_version/correlation_id set correctly', async () => {
+    const fakeDb = seededDb(() => {});
+    const receipt = await executeLpEconomicsRun({
+      fundId: FUND_ID,
+      actorId: ACTOR_ID,
+      idempotencyKey: 'tc15',
+      request: goldenRequest(),
+      database: fakeDb.asDatabase(),
+    });
+
+    const row = fakeDb.fundSnapshotRows.find(
+      (entry) => entry['id'] === receipt.run.resultSnapshotId
+    )!;
+    expect(row['state']).toBeNull();
+    expect(row['runId']).toBeNull();
+    expect(row['type']).toBe('INTERNAL_LP_ECONOMICS');
+    expect((row['snapshotTime'] as Date).toISOString()).toBe(CLOCK);
+    expect(row['calcVersion']).toBe(LP_ECONOMICS_RESULT_CALC_VERSION);
+    expect(row['correlationId']).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    );
+    expect(row['configId']).toBeNull();
+    expect(row['configVersion']).toBeNull();
+    expect(row['scenarioSetId']).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-C16 (P-D7 isolation/retry amendment): 40001 retry-then-succeed within
+// the 3-attempt bound; persistent failure falls through to the unexpected-
+// exception path.
+// ---------------------------------------------------------------------------
+
+describe('executeLpEconomicsRun -- T-C16 SQLSTATE 40001 retry', () => {
+  it('succeeds on the second attempt after one simulated 40001', async () => {
+    const fakeDb = seededDb(() => {});
+    fakeDb.insertSerializationFailuresRemaining = 1;
+
+    const receipt = await executeLpEconomicsRun({
+      fundId: FUND_ID,
+      actorId: ACTOR_ID,
+      idempotencyKey: 'tc16-retry',
+      request: goldenRequest(),
+      database: fakeDb.asDatabase(),
+    });
+
+    expect(receipt.run.runState).toBe('completed');
+    expect(fakeDb.transactionAttempts).toBe(2);
+    expect(fakeDb.transactionConfigs).toEqual([
+      { isolationLevel: 'repeatable read', accessMode: 'read write' },
+      { isolationLevel: 'repeatable read', accessMode: 'read write' },
+    ]);
+    expect(fakeDb.runRows).toHaveLength(1);
+  });
+
+  it('a persistent 40001 past the 3-attempt bound surfaces as an unexpected exception', async () => {
+    const fakeDb = seededDb(() => {});
+    fakeDb.insertSerializationFailuresRemaining = 3;
+
+    await expect(
+      executeLpEconomicsRun({
+        fundId: FUND_ID,
+        actorId: ACTOR_ID,
+        idempotencyKey: 'tc16-exhausted',
+        request: goldenRequest(),
+        database: fakeDb.asDatabase(),
+      })
+    ).rejects.toMatchObject({ code: '40001' });
+
+    expect(fakeDb.transactionAttempts).toBe(3);
+    expect(fakeDb.runRows).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-C19/T-C20 (P-D7 R5-R7 amendments): pre-invocation admission-control
+// guards persist a FAILED run row, no snapshot, key consumed, replay
+// returns the same persisted failure.
+// ---------------------------------------------------------------------------
+
+function manyForecastPoints(count: number) {
+  return Array.from({ length: count }, (_unused, index) => {
+    const quarterIndex = index + 1;
+    const year = 2026 + Math.floor((quarterIndex - 1) / 4);
+    const quarterInYear = ((quarterIndex - 1) % 4) + 1;
+    const startMonth = (quarterInYear - 1) * 3 + 1;
+    const endMonth = startMonth + 2;
+    const periodStart = `${year}-${String(startMonth).padStart(2, '0')}-01`;
+    const lastDay = endMonth === 3 || endMonth === 12 ? 31 : endMonth === 6 ? 30 : 30;
+    const periodEnd = `${year}-${String(endMonth).padStart(2, '0')}-${endMonth === 3 ? 31 : lastDay}`;
+    return {
+      periodStart,
+      periodEnd,
+      source: 'projected' as const,
+      deployedUsd: ZERO_MONEY,
+      contributionsUsd: ZERO_MONEY,
+      distributionsUsd: ZERO_MONEY,
+      navUsd: ZERO_MONEY,
+      tvpi: ZERO_RATIO,
+      dpi: ZERO_RATIO,
+      activeCompanyCount: 0,
+      projectedCohortCount: 0,
+    };
+  });
+}
+
+describe('executeLpEconomicsRun -- T-C19/T-C20 admission-control bounds', () => {
+  it('T-C19: 201 forecast periods refuses pre-invocation as a persisted failed run', async () => {
+    const fakeDb = seededDb((db_) => {
+      const forecastRow = db_.fundSnapshotRows.find(
+        (row) => row['type'] === 'CURRENT_FORECAST_V2'
+      )!;
+      const series = manyForecastPoints(201);
+      (forecastRow['payload'] as Record<string, unknown>)['series'] = series;
+      // Gate 8's match-assert re-derives terminalPeriodEnd from
+      // termStartDate/fundLifeYears and compares it against the persisted
+      // value, so both must be updated together: 2021-01-01 + 55yr(220
+      // quarters) -> 2076-01-01 -> containing quarter end 2076-03-31, the
+      // series' natural 201st point (same formula as PERIOD_END's own
+      // 5yr/60mo derivation above).
+      db_.policyRows[0]!['terminalPeriodEnd'] = series.at(-1)!.periodEnd;
+      (db_.policyRows[0]!['policyBody'] as Record<string, unknown>)['fundLifeYears'] = '55';
+    });
+
+    const receipt = await executeLpEconomicsRun({
+      fundId: FUND_ID,
+      actorId: ACTOR_ID,
+      idempotencyKey: 'tc19',
+      request: goldenRequest(),
+      database: fakeDb.asDatabase(),
+    });
+
+    expect(receipt.run.runState).toBe('failed');
+    expect(receipt.run.failureCode).toBe('CASH_ASSEMBLY_PERIOD_COUNT_EXCEEDED');
+    expect(receipt.run.failureContext).toMatchObject({
+      bound: MAX_CASH_ASSEMBLY_PERIOD_COUNT,
+      observed: 201,
+    });
+    expect(receipt.result).toBeNull();
+    expect(
+      fakeDb.fundSnapshotRows.filter((row) => row['type'] === 'INTERNAL_LP_ECONOMICS')
+    ).toHaveLength(0);
+
+    const replay = await executeLpEconomicsRun({
+      fundId: FUND_ID,
+      actorId: ACTOR_ID,
+      idempotencyKey: 'tc19',
+      request: goldenRequest(),
+      database: fakeDb.asDatabase(),
+    });
+    expect(replay.run.id).toBe(receipt.run.id);
+    expect(fakeDb.runRows).toHaveLength(1);
+  });
+
+  it('T-C20: total event count above the bound refuses pre-invocation as a persisted failed run', async () => {
+    const fakeDb = seededDb((db_) => {
+      const facts = db_.factsRows[0]!;
+      const payload = facts['payload'] as { cashFlowSeries: Record<string, unknown> };
+      payload.cashFlowSeries = {
+        series: [
+          {
+            eventType: 'lp_capital_call',
+            vehicleId: null,
+            perspective: 'lp_net',
+            points: Array.from({ length: 10001 }, (_unused, index) => ({
+              eventId: index + 1,
+              effectiveAt: '2025-06-30T00:00:00.000Z',
+              amount: ZERO_MONEY,
+            })),
+          },
+        ],
+        totals: {
+          contributions: ZERO_MONEY,
+          distributions: ZERO_MONEY,
+          recallableDistributions: ZERO_MONEY,
+        },
+        warnings: [],
+      };
+    });
+
+    const receipt = await executeLpEconomicsRun({
+      fundId: FUND_ID,
+      actorId: ACTOR_ID,
+      idempotencyKey: 'tc20',
+      request: goldenRequest(),
+      database: fakeDb.asDatabase(),
+    });
+
+    expect(receipt.run.runState).toBe('failed');
+    expect(receipt.run.failureCode).toBe('CASH_ASSEMBLY_TOTAL_EVENT_COUNT_EXCEEDED');
+    expect(receipt.run.failureContext).toMatchObject({
+      bound: MAX_CASH_ASSEMBLY_TOTAL_EVENT_COUNT,
+    });
+    expect(receipt.result).toBeNull();
+
+    const replay = await executeLpEconomicsRun({
+      fundId: FUND_ID,
+      actorId: ACTOR_ID,
+      idempotencyKey: 'tc20',
+      request: goldenRequest(),
+      database: fakeDb.asDatabase(),
+    });
+    expect(replay.run.id).toBe(receipt.run.id);
+    expect(fakeDb.runRows).toHaveLength(1);
+  });
+});

--- a/tests/unit/services/internal-lp-economics-snapshot-invisibility.test.ts
+++ b/tests/unit/services/internal-lp-economics-snapshot-invisibility.test.ts
@@ -1,0 +1,242 @@
+/**
+ * T-A6 (WP-L3 Phase A): `'INTERNAL_LP_ECONOMICS'` enrollment in
+ * `NON_TIMELINE_SNAPSHOT_TYPES` plus regression coverage over BOTH fail-open
+ * readers (G3): `fund-state-read-service.ts` and `time-travel-analytics.ts`
+ * exclude non-timeline types via a `notInArray` denylist, so a type that is
+ * not enrolled silently leaks into timeline reconstruction. These fixtures
+ * prove the new result-snapshot type is invisible to both readers and that
+ * the pre-existing timeline output is byte-identical before and after an
+ * INTERNAL_LP_ECONOMICS snapshot exists.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as schema from '@shared/schema';
+import { fundConfigs, fundSnapshots } from '@shared/schema';
+import { NON_TIMELINE_SNAPSHOT_TYPES } from '@shared/schema/fund';
+import type { SQL } from 'drizzle-orm';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { TimeTravelAnalyticsService } from '../../../server/services/time-travel-analytics';
+import { fundStateReadService } from '../../../server/services/fund-state-read-service';
+import { AUTHORITATIVE_SNAPSHOT_TYPES } from '../../../shared/contracts/fund-authoritative-calculations.contract';
+import { EXPECTED_SNAPSHOT_TYPES } from '../../../shared/contracts/fund-state-read-v1.contract';
+
+const mockDb = vi.hoisted(() => ({
+  query: {
+    funds: { findFirst: vi.fn() },
+    fundConfigs: { findFirst: vi.fn() },
+    calcRuns: { findFirst: vi.fn() },
+  },
+  select: vi.fn(),
+}));
+
+vi.mock('../../../server/db', () => ({ db: mockDb }));
+
+interface SnapshotSeed {
+  id: number;
+  fundId: number;
+  type: string;
+  snapshotTime: Date;
+  createdAt: Date;
+  eventCount: number;
+  stateHash: string;
+  state: Record<string, unknown> | null;
+  configVersion: number | null;
+  scenarioSetId: string | null;
+}
+
+interface QueryState {
+  table?: unknown;
+  where?: unknown;
+  limit?: number;
+}
+
+interface QueryChain extends PromiseLike<unknown[]> {
+  from(table: unknown): QueryChain;
+  where(clause: unknown): QueryChain;
+  orderBy(...clauses: unknown[]): QueryChain;
+  limit(value: number): QueryChain;
+  offset(value: number): QueryChain;
+}
+
+const dialect = new PgDialect();
+const snapshotQuerySql: Array<{ sql: string; params: unknown[] }> = [];
+
+const reserveSnapshot: SnapshotSeed = {
+  id: 201,
+  fundId: 1,
+  type: 'RESERVE',
+  snapshotTime: new Date('2026-07-30T12:00:00.000Z'),
+  createdAt: new Date('2026-07-30T12:00:00.000Z'),
+  eventCount: 5,
+  stateHash: 'reserve-state-hash',
+  state: {
+    totalValue: 2_000_000,
+    deployedCapital: 1_250_000,
+    portfolioCount: 3,
+    companies: [],
+    sectorBreakdown: {},
+    stageBreakdown: {},
+  },
+  configVersion: 4,
+  scenarioSetId: null,
+};
+
+const internalLpEconomicsSnapshot: SnapshotSeed = {
+  id: 202,
+  fundId: 1,
+  type: 'INTERNAL_LP_ECONOMICS',
+  snapshotTime: new Date('2026-07-31T12:00:00.000Z'),
+  createdAt: new Date('2026-07-31T12:00:00.000Z'),
+  eventCount: 0,
+  stateHash: 'internal-lp-economics-payload-hash',
+  state: null,
+  configVersion: null,
+  scenarioSetId: null,
+};
+
+let seededSnapshots: SnapshotSeed[] = [];
+
+function executeQuery(state: QueryState): unknown[] {
+  if (state.table === fundConfigs) {
+    return [{ maxVersion: 4 }];
+  }
+
+  if (state.table !== fundSnapshots) {
+    return [];
+  }
+
+  let rows = [...seededSnapshots];
+  if (state.where) {
+    const rendered = dialect.sqlToQuery(state.where as SQL<unknown>);
+    snapshotQuerySql.push(rendered);
+
+    if (rendered.sql.includes('"fund_snapshots"."type" not in')) {
+      const excludedTypes = new Set(
+        rendered.params.filter((param): param is string => typeof param === 'string')
+      );
+      rows = rows.filter((row) => !excludedTypes.has(row.type));
+    }
+  }
+
+  rows.sort((left, right) => right.snapshotTime.getTime() - left.snapshotTime.getTime());
+  return state.limit === undefined ? rows : rows.slice(0, state.limit);
+}
+
+function createQueryChain(): QueryChain {
+  const state: QueryState = {};
+  const chain: QueryChain = {
+    from(table) {
+      state.table = table;
+      return chain;
+    },
+    where(clause) {
+      state.where = clause;
+      return chain;
+    },
+    orderBy() {
+      return chain;
+    },
+    limit(value) {
+      state.limit = value;
+      return chain;
+    },
+    offset() {
+      return chain;
+    },
+    then(onfulfilled, onrejected) {
+      return Promise.resolve(executeQuery(state)).then(onfulfilled, onrejected);
+    },
+  };
+  return chain;
+}
+
+function expectInternalLpEconomicsDenylisted(queryCount: number): void {
+  expect(snapshotQuerySql).toHaveLength(queryCount);
+  for (const query of snapshotQuerySql) {
+    expect(query.sql).toContain('"fund_snapshots"."type" not in');
+    expect(query.params).toContain('INTERNAL_LP_ECONOMICS');
+  }
+}
+
+describe('INTERNAL_LP_ECONOMICS snapshot invisibility (T-A6)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    seededSnapshots = [reserveSnapshot];
+    snapshotQuerySql.length = 0;
+    mockDb.select.mockImplementation(() => createQueryChain());
+  });
+
+  it('enrolls INTERNAL_LP_ECONOMICS in NON_TIMELINE_SNAPSHOT_TYPES', () => {
+    expect(NON_TIMELINE_SNAPSHOT_TYPES).toContain('INTERNAL_LP_ECONOMICS');
+    expect(NON_TIMELINE_SNAPSHOT_TYPES).toContain('CURRENT_FORECAST_V2');
+    expect(NON_TIMELINE_SNAPSHOT_TYPES).toContain('RESERVE_INTELLIGENCE');
+  });
+
+  it('keeps time-travel reconstruction unchanged when an INTERNAL_LP_ECONOMICS row exists', async () => {
+    const service = new TimeTravelAnalyticsService(
+      mockDb as unknown as NodePgDatabase<typeof schema>
+    );
+    const targetTime = new Date('2026-08-01T12:00:00.000Z');
+
+    const reserveOnly = await service.getStateAtTime(1, targetTime);
+    seededSnapshots = [reserveSnapshot, internalLpEconomicsSnapshot];
+    const withEconomicsResult = await service.getStateAtTime(1, targetTime);
+
+    expect(JSON.stringify(withEconomicsResult)).toBe(JSON.stringify(reserveOnly));
+    expect(withEconomicsResult.snapshot.id).toBe(String(reserveSnapshot.id));
+    expect(withEconomicsResult.state).toEqual(reserveSnapshot.state);
+    expectInternalLpEconomicsDenylisted(2);
+  });
+
+  it('keeps fund-state read output unchanged when an INTERNAL_LP_ECONOMICS row exists', async () => {
+    mockDb.query.funds.findFirst.mockResolvedValue({ id: 1, engineResults: null });
+    mockDb.query.fundConfigs.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        version: 4,
+        publishedAt: new Date('2026-07-29T12:00:00.000Z'),
+        updatedAt: new Date('2026-07-29T12:00:00.000Z'),
+      })
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        version: 4,
+        publishedAt: new Date('2026-07-29T12:00:00.000Z'),
+        updatedAt: new Date('2026-07-29T12:00:00.000Z'),
+      });
+    mockDb.query.calcRuns.findFirst.mockResolvedValue({
+      id: 21,
+      configVersion: 4,
+      correlationId: 'wp-l3-phase-a-regression',
+      dispatchState: 'dispatched',
+      lastError: null,
+    });
+
+    const reserveOnly = await fundStateReadService.getState(1);
+    seededSnapshots = [reserveSnapshot, internalLpEconomicsSnapshot];
+    const withEconomicsResult = await fundStateReadService.getState(1);
+
+    expect(JSON.stringify(withEconomicsResult)).toBe(JSON.stringify(reserveOnly));
+    expect(withEconomicsResult?.calculationState.availableSnapshotTypes).toEqual(['RESERVE']);
+    expectInternalLpEconomicsDenylisted(2);
+  });
+
+  it('omits INTERNAL_LP_ECONOMICS from timeline snapshot listings', async () => {
+    const service = new TimeTravelAnalyticsService(
+      mockDb as unknown as NodePgDatabase<typeof schema>
+    );
+    const reserveOnly = await service.getTimelineEvents(1);
+    seededSnapshots = [reserveSnapshot, internalLpEconomicsSnapshot];
+    const withEconomicsResult = await service.getTimelineEvents(1);
+
+    expect(JSON.stringify(withEconomicsResult)).toBe(JSON.stringify(reserveOnly));
+    expect(withEconomicsResult.snapshots.map((snapshot) => snapshot.id)).toEqual([
+      reserveSnapshot.id,
+    ]);
+    expectInternalLpEconomicsDenylisted(2);
+  });
+
+  it('does not promote INTERNAL_LP_ECONOMICS into authoritative readiness types', () => {
+    expect(AUTHORITATIVE_SNAPSHOT_TYPES).not.toContain('INTERNAL_LP_ECONOMICS');
+    expect(EXPECTED_SNAPSHOT_TYPES).not.toContain('INTERNAL_LP_ECONOMICS');
+  });
+});

--- a/tests/unit/services/reserves/dynamic-reserve-intelligence-service.test.ts
+++ b/tests/unit/services/reserves/dynamic-reserve-intelligence-service.test.ts
@@ -261,11 +261,13 @@ function factsRow(snapshot = factsSnapshot()): FactsRow {
     fundId: snapshot.fundId,
     policyVersion: snapshot.policyVersion,
     payloadSchemaId:
-      snapshot.policyVersion === 'financial-facts-policy/1.2.0'
-        ? 'financial-facts-payload/3'
-        : snapshot.policyVersion === 'financial-facts-policy/1.1.0'
-          ? 'financial-facts-payload/2'
-          : 'financial-facts-payload/1',
+      snapshot.policyVersion === 'financial-facts-policy/1.3.0'
+        ? 'financial-facts-payload/4'
+        : snapshot.policyVersion === 'financial-facts-policy/1.2.0'
+          ? 'financial-facts-payload/3'
+          : snapshot.policyVersion === 'financial-facts-policy/1.1.0'
+            ? 'financial-facts-payload/2'
+            : 'financial-facts-payload/1',
     asOfDate: snapshot.asOfDate,
     knowledgeCutoff: new Date(snapshot.knowledgeCutoff),
     vehicleScope: snapshot.vehicleScope,
@@ -476,9 +478,10 @@ describe('dynamic reserve intelligence service', () => {
   it.each([
     ['financial-facts-policy/1.1.0', 'financial-facts-payload/2', false],
     ['financial-facts-policy/1.2.0', 'financial-facts-payload/3', true],
+    ['financial-facts-policy/1.3.0', 'financial-facts-payload/4', true],
   ] as const)(
     'pins %s into reserve provenance',
-    async (policyVersion, payloadSchemaId, isPayload3) => {
+    async (policyVersion, payloadSchemaId, hasOpeningState) => {
       const database = new FakeDatabase();
       const legacy = factsSnapshot();
       const snapshot = PersistedFinancialFactsSnapshotV1Schema.parse({
@@ -492,7 +495,7 @@ describe('dynamic reserve intelligence service', () => {
           ownershipRefs: [],
           valuationRefs: [],
           observationRefs: [],
-          ...(isPayload3 ? { openingAccountingState: null } : {}),
+          ...(hasOpeningState ? { openingAccountingState: null } : {}),
         },
       });
       database.facts = factsRow(snapshot);
@@ -503,7 +506,7 @@ describe('dynamic reserve intelligence service', () => {
       expect(response.result.provenance.factsSnapshot).toMatchObject({
         policyVersion,
         payloadSchemaId,
-        ...(isPayload3 ? { payload: { openingAccountingState: null } } : {}),
+        ...(hasOpeningState ? { payload: { openingAccountingState: null } } : {}),
       });
     }
   );


### PR DESCRIPTION
## Summary
- Migration 0045 (three tables: capital envelope, economics policy, LP economics runs) + manifest 22, with DB-enforced immutability triggers and additive `fund_snapshots` type-scoped constraint.
- Three contracts (`capital-envelope-v1`, `economics-policy-v1`, `lp-economics-run-v1`) and three services (`capital-envelope-service`, `economics-policy-service`, `lp-economics-run-service`) implementing the P-D7 atomicity protocol, the nine-gate eligibility registry, and the seven-class frozen-loop error dispatch table.
- Financial-facts producer/embedder migrated to payload v4 (`financial-facts-policy/1.3.0`) with an idempotent embedded observation-ref adapter over the frozen v1.1 observation contract.
- Governed by a 10-round specialist-gated plan (`docs/superpowers/plans/2026-07-31-task163-wp-l3-service-persistence-plan.md`, kept untracked per repo convention for plan docs).

## Post-implementation specialist re-sign
Ran waterfall-specialist, phoenix-precision-guardian, and Codex against the integrated code (not just the plan doc). Codex found 4 BLOCKER + 3 MAJOR findings sharply contradicting the other two lanes' near-clean reads. Independently adjudicated every finding against live code before acting on any of them:
- **3 real, fixed**: the run service's `fundConfigs` read never checked `sourceConfigVersion` (a mutable-basis leak into the zero-fee-bridge gate — the policy-seed service already guarded this, the run service didn't); admission-control guards ran before the nine eligibility gates (misclassifying a doubly-invalid basis as `failed` instead of the required completed-`unavailable`); the period-count guard measured the raw forecast series instead of the terminal-truncated assembled grid (risking false rejection of legitimately small runs).
- **2 comment-fidelity fixes**: `eventKind`'s `sourceId`-suffix check is necessary (pure position misclassifies a run with zero terminal events) — code was correct, comments overclaimed "never parses"; `result_hash`'s basis coverage is satisfied by the separate `input_hash` column, not by duplicating basis IDs into the value hash.
- **2 rejected as overclaims**: cited the pre-WP-L3 D9 source spec instead of the ratified WP-L3 plan text (`MAIN_FUND_COMMITMENT_ABSENT` unreachability — structurally dead given the envelope table's own DB CHECK; a per-vehicle exclusion summary the ratified plan never actually requires, and gate 1 makes moot for this single-vehicle-only slice).

## Test plan
- [x] `npm run check` — 0 TypeScript errors (client/server/shared)
- [x] `npm run lint` — 0 ESLint warnings, all 9 guardrails pass
- [x] `npm run phoenix:truth` — 336/336, zero drift
- [x] Full suite, sharded — server 9604 passed / 76 skipped / 0 failed; client 1570 passed / 14 skipped / 0 failed
- [x] Frozen modules (both observation contracts, terminal-policy, event-ordering, all of `shared/lib/internal-economics/` + `shared/lib/waterfall/`) — 0 bytes diff vs `main`
- [x] Diff audit — every touched file traces to the plan's declared scope or a documented CI-wiring consequence

Migration 0045 is dormant (no application code paths write to the new tables outside these services yet); WP-L4 (routes) is separate follow-on work per the plan.