### PR TITLE
fix(finance): serialDayUtc use UTC getters, not local-time (#1256)

### DIFF
--- a/.claude/hermes/briefs/2026-08-01-issue-1256-xirr-utc-getters.md
+++ b/.claude/hermes/briefs/2026-08-01-issue-1256-xirr-utc-getters.md
@@ -1,0 +1,115 @@
+# Issue #1256 — safeXIRR day-count depends on process timezone
+
+Frozen spec for this dispatch. GitHub issue (canonical defect description):
+https://github.com/nikhillinit/Updog_restore/issues/1256 — do not re-derive
+scope from anywhere else.
+
+## Scope
+
+Single file: `shared/lib/finance/xirr.ts`, function `serialDayUtc` (currently
+lines 70-72):
+
+```ts
+function serialDayUtc(date: Date): number {
+  return (
+    Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()) / MS_PER_DAY
+  );
+}
+```
+
+`getFullYear()/getMonth()/getDate()` are local-time getters. The docstring above
+it (lines 66-69) claims UTC-normalized purity; that only holds when the process
+runs with `TZ=UTC`. Confirmed by grep of the whole file: this is the ONLY
+local-time getter site (`getFullYear|getMonth|getDate|getHours` etc. without a
+`UTC` prefix) — no sibling occurrences to fix.
+
+## Fix
+
+Swap to UTC getters:
+
+```ts
+function serialDayUtc(date: Date): number {
+  return (
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()) /
+    MS_PER_DAY
+  );
+}
+```
+
+Behavior-identical to current output under `TZ=UTC` (the only sanctioned runtime
+for this repo) — zero parity risk against Phoenix truth cases.
+
+Also add `export` to `function serialDayUtc` (visibility change only, no logic
+change) so it can be unit-tested directly. It is currently module-private and
+only reachable indirectly via `yearFraction` ->
+`xirrNewtonBisection`/`safeXIRR`/`calculateCanonicalIrr`.
+
+## TDD (write failing test first)
+
+Target file: `tests/unit/xirr-edge-cases.test.ts` (existing file, single
+`describe('xirr edge cases', ...)` block already imports `xirrNewtonBisection`
+from `@/lib/finance/xirr` — add `serialDayUtc` to that same import and add new
+`it(...)` cases inside the existing describe block, matching its established
+`date: new Date('...Z')` style).
+
+Do NOT try to prove this bug by spawning a child process with a different `TZ`
+env var, and do NOT try to mutate `process.env.TZ` mid-test (V8 caches timezone
+state per-process; this is unreliable and would be the first flaky-test source
+in a suite that pins `TZ=UTC` repo-wide). Instead, mock `Date.prototype`'s local
+getters directly with `vi.spyOn` to prove the function's output is independent
+of them:
+
+```ts
+it('serialDayUtc is pure w.r.t. local Date getters (regression for #1256)', () => {
+  const date = new Date('2024-01-01T00:00:00.000Z');
+  const fy = vi.spyOn(Date.prototype, 'getFullYear').mockReturnValue(1999);
+  const mo = vi.spyOn(Date.prototype, 'getMonth').mockReturnValue(0);
+  const da = vi.spyOn(Date.prototype, 'getDate').mockReturnValue(1);
+
+  const result = serialDayUtc(date);
+
+  fy.mockRestore();
+  mo.mockRestore();
+  da.mockRestore();
+
+  expect(result).toBe(Date.UTC(2024, 0, 1) / (24 * 60 * 60 * 1000));
+});
+```
+
+This must FAIL against the current implementation (which would pick up the
+mocked-to-1999 local getters and return the wrong serial day) and PASS after the
+fix (which ignores local getters entirely). Add a second, non-mocked sanity test
+confirming ordinary UTC-date input still produces the expected serial day (no
+regression on the happy path).
+
+## Constraints (non-negotiable)
+
+- Frozen module under ADR-010 (`docs/adr/ADR-010-xirr-day-count-and-bounds.md`).
+  This dispatch implements + tests the fix; it does NOT merge it — a separate
+  `xirr-fees-validator` specialist review happens after this dispatch returns,
+  before any commit/PR.
+- Do not touch anything outside `shared/lib/finance/xirr.ts` and the one test
+  file. Not in scope: `shared/lib/internal-economics/*` (separate, unrelated fix
+  — different dispatch), WP-2b-4 files, WP-L3 files.
+- No behavior change under `TZ=UTC`. Do not change `MS_PER_DAY`, `yearFraction`,
+  rate bounds, or any other function in the file.
+
+## Verification (must all pass before returning)
+
+```
+TZ=UTC npx vitest run tests/unit/xirr-edge-cases.test.ts --configLoader native --project=server
+TZ=UTC npm run check
+npm run lint
+TZ=UTC npm run phoenix:truth
+```
+
+Phoenix truth cases must show zero drift (this is a frozen-module edit — any
+movement is a stop-and-report, not a proceed).
+
+## Explicitly out of scope for this dispatch
+
+- Task 2 from the handoff (`isNegative()` -> `.lt(0)` nit in
+  `shared/lib/internal-economics/cash-assembly-call-sizing-v1.ts:167`) —
+  separate file, separate specialist lane, separate dispatch.
+- Any WP-2b-4 or WP-L3 work — issue #1256 is explicitly confirmed out of WP-2b-4
+  scope.

--- a/shared/lib/finance/xirr.ts
+++ b/shared/lib/finance/xirr.ts
@@ -67,8 +67,8 @@ const MAX_RATE = 200;
  * Normalize a JS Date to UTC midnight and return the corresponding
  * "Excel-style" serial day number (days since epoch).
  */
-function serialDayUtc(date: Date): number {
-  return Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()) / MS_PER_DAY;
+export function serialDayUtc(date: Date): number {
+  return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()) / MS_PER_DAY;
 }
 
 /**

--- a/tests/unit/xirr-edge-cases.test.ts
+++ b/tests/unit/xirr-edge-cases.test.ts
@@ -1,7 +1,26 @@
-import { describe, expect, it } from 'vitest';
-import { xirrNewtonBisection } from '@/lib/finance/xirr';
+import { describe, expect, it, vi } from 'vitest';
+import { serialDayUtc, xirrNewtonBisection } from '@shared/lib/finance/xirr';
 
 describe('xirr edge cases', () => {
+  it('serialDayUtc is pure w.r.t. local Date getters (regression for #1256)', () => {
+    const date = new Date('2024-01-01T00:00:00.000Z');
+    const fy = vi.spyOn(Date.prototype, 'getFullYear').mockReturnValue(1999);
+    const mo = vi.spyOn(Date.prototype, 'getMonth').mockReturnValue(0);
+    const da = vi.spyOn(Date.prototype, 'getDate').mockReturnValue(1);
+
+    const result = serialDayUtc(date);
+
+    fy.mockRestore();
+    mo.mockRestore();
+    da.mockRestore();
+
+    expect(result).toBe(Date.UTC(2024, 0, 1) / (24 * 60 * 60 * 1000));
+  });
+
+  it('returns the expected serial day for an ordinary UTC date', () => {
+    expect(serialDayUtc(new Date('2024-01-01T00:00:00.000Z'))).toBe(19_723);
+  });
+
   it('clamps guesses below -100% and still converges to the valid root', () => {
     const result = xirrNewtonBisection(
       [


### PR DESCRIPTION
## Summary
- `serialDayUtc()` in `shared/lib/finance/xirr.ts` claimed UTC-normalized purity but called local-time `Date` getters (`getFullYear/getMonth/getDate`) -- correct only under the repo's `TZ=UTC` convention; a local run without it silently produced a different, wrong XIRR near a local-midnight boundary.
- Swapped to `getUTCFullYear/getUTCMonth/getUTCDate`; exported the function for direct unit testing.
- Regression test mocks `Date.prototype`'s local getters via `vi.spyOn` to prove the function's output no longer depends on them.

Fixes #1256

## Specialist sign-off
`xirr-fees-validator`: **GO**. Independently reproduced the pre-fix off-by-one-day bug under `TZ=America/Los_Angeles` (external repro, no working-tree risk) and confirmed zero diff under `TZ=UTC`. Confirmed ADR-010's locked invariants (`MIN_RATE`/`MAX_RATE`, the 365.25 divisor, `clampRate()`) are untouched by this diff.

## Test plan
- [x] Targeted test: `tests/unit/xirr-edge-cases.test.ts` 4/4 pass
- [x] `TZ=UTC npm run check` -- 0 errors
- [x] `npm run lint` -- clean
- [x] `TZ=UTC npm run phoenix:truth` -- 336/336, zero drift
- [x] Full suite sharded (server 3-way, client 2-way) -- all green, ~11,176 tests, no regressions
- [x] `xirr-fees-validator` specialist review -- GO (ADR-010 frozen-module sign-off)