### PR TITLE
refactor(economics): use .lt(0) comparator idiom in call-sizing guard

### DIFF
--- a/.claude/hermes/briefs/2026-08-01-cash-assembly-lt-comparator-idiom.md
+++ b/.claude/hermes/briefs/2026-08-01-cash-assembly-lt-comparator-idiom.md
@@ -1,0 +1,70 @@
+# cash-assembly-call-sizing-v1.ts:167 — isNegative() -> lt(0) idiom nit
+
+Frozen spec for this dispatch. No filed issue (carried as a working note from
+the WP-L3 session, never formally written up). Do not re-derive scope from
+anywhere else.
+
+## Scope
+
+Single file: `shared/lib/internal-economics/cash-assembly-call-sizing-v1.ts`,
+function `assertNonNegativeScheduledAmounts` (currently line 167):
+
+```ts
+if (value.isNegative()) {
+```
+
+Decimal.js's `.isNegative()` and `.lt(0)` are behaviorally equivalent for every
+real Decimal value this codebase produces. This is a pure idiom-consistency
+change, not a behavior fix.
+
+## Why this is worth doing (idiom precedent already checked)
+
+Module-wide (`shared/lib/internal-economics/`), `.lt(0)` is the dominant
+comparator idiom — used in 3 files:
+
+- `cash-assembly-event-stream-v1.ts:102`
+- `presentation-rounding-v1.ts:50,64,72,89`
+- `cash-assembly-period-loop-v1.ts:476`
+
+`.isNegative()` appears in exactly 1 file (this one, this one call site). Align
+it with the dominant local idiom.
+
+## Fix
+
+```ts
+if (value.lt(0)) {
+```
+
+That is the entire change. Do not touch the error-throwing block, the message
+text, the `NEGATIVE_SCHEDULED_AMOUNT_FIELDS` loop, or anything else in the file.
+
+## Tests
+
+This is a behavior-preserving rename of a comparator, not new behavior — do not
+add a new test case. Confirm the EXISTING test(s) covering
+`assertNonNegativeScheduledAmounts` / `NEGATIVE_SCHEDULED_AMOUNT` still pass
+unmodified (grep the test suite for `NEGATIVE_SCHEDULED_AMOUNT` or
+`assertNonNegativeScheduledAmounts` to find them first — do not guess the file
+name).
+
+## Constraints (non-negotiable)
+
+- Frozen module (Phoenix protected path: `shared/lib/internal-economics/`). This
+  dispatch implements the change; it does NOT merge it — a separate
+  `phoenix-precision-guardian` specialist review happens after this dispatch
+  returns, before any commit/PR.
+- Do not touch `shared/lib/finance/xirr.ts` or anything related to issue #1256 —
+  that is a separate, already-committed fix on a different branch.
+- Single-line change. If you find yourself editing more than the one `if`
+  condition, stop and report rather than proceeding.
+
+## Verification (must all pass before returning)
+
+```
+TZ=UTC npm run check
+npm run lint
+TZ=UTC npm run phoenix:truth
+```
+
+Phoenix truth cases must show zero drift (frozen-module edit — any movement is a
+stop-and-report, not a proceed).

--- a/shared/lib/internal-economics/cash-assembly-call-sizing-v1.ts
+++ b/shared/lib/internal-economics/cash-assembly-call-sizing-v1.ts
@@ -164,7 +164,7 @@ function assertNonNegativeScheduledAmounts(
   for (const quarterInput of quarters) {
     for (const field of NEGATIVE_SCHEDULED_AMOUNT_FIELDS) {
       const value = quarterInput[field];
-      if (value.isNegative()) {
+      if (value.lt(0)) {
         throw new CashAssemblyCallSizingV1Error(
           'NEGATIVE_SCHEDULED_AMOUNT',
           `${field} at quarter ending ${quarterInput.period.periodEnd} is negative ` +


### PR DESCRIPTION
## Summary
- `assertNonNegativeScheduledAmounts` in `shared/lib/internal-economics/cash-assembly-call-sizing-v1.ts:167` used `.isNegative()`; every other comparator in the module (`cash-assembly-event-stream-v1.ts`, `presentation-rounding-v1.ts`, `cash-assembly-period-loop-v1.ts`) uses `.lt(0)`. Pure idiom-consistency swap, no filed issue -- carried as a working note from a prior session, no behavior change intended.
- Same-behavior for every real Decimal value this codebase produces.

## Specialist sign-off
`phoenix-precision-guardian`: **GO**. Traced the full call graph feeding this guard and confirmed a `Decimal(-0)` value -- the one case where `.isNegative()` and `.lt(0)` diverge -- is not reachable via any in-repo producer (every zero-producing arithmetic path in this codebase normalizes to positive-signed zero; -0 would require an out-of-band, non-Decimal-discipline producer). Independently re-ran the targeted suite pre/post diff via stash/pop A-B comparison.

## Test plan
- [x] Targeted test: `tests/unit/internal-economics/cash-assembly-call-sizing-v1.test.ts` 21/21 pass (unmodified -- behavior-preserving change)
- [x] `TZ=UTC npm run check` -- 0 errors
- [x] `npm run lint` -- clean (incl. `decimal-string-laundering` guardrail)
- [x] `TZ=UTC npm run calc-gate` / `phoenix:truth` -- 336/336, zero drift
- [x] `phoenix-precision-guardian` specialist review -- GO (Phoenix protected-path sign-off)