### PR TITLE
feat(economics): certify exact V1.1 trust spine

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -31,18 +31,6 @@ paths = [
 ]
 
 [[allowlists]]
-description = "Allow deterministic WP-L3 idempotency fixtures"
-targetRules = ["generic-api-key"]
-condition = "AND"
-regexTarget = "line"
-regexes = [
-  '''^\s*idempotencyKey:\s*'(?:tc13-ordinary|tc16-exhausted)',$'''
-]
-paths = [
-  '''^tests/unit/services/internal-economics/lp-economics-run-service\.test\.ts$'''
-]
-
-[[allowlists]]
 description = "Allow historical negative-control fixture template from blocking repo-history scans"
 targetRules = ["updog-negative-control-token"]
 condition = "AND"

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,5 +1,13 @@
 # Existing-history baseline captured by Gitleaks v8.30.1 on 2026-07-12.
 # Each entry is an exact commit:file:rule:line fingerprint. New findings still fail.
+# Reviewed synthetic internal-economics fixtures added after the baseline.
+# Keep these fingerprint-scoped so future findings in the same files still fail.
+52eccafefe313dd5053492df35b29c9d7f9c2dd9:tests/unit/services/internal-economics/lp-economics-run-service.test.ts:generic-api-key:1548
+52eccafefe313dd5053492df35b29c9d7f9c2dd9:tests/unit/services/internal-economics/lp-economics-run-service.test.ts:generic-api-key:1738
+f847ed987a620f194cdd52ecd5b1ae81a0faff10:tests/unit/services/internal-economics/lp-economics-run-service.test.ts:generic-api-key:1548
+f847ed987a620f194cdd52ecd5b1ae81a0faff10:tests/unit/services/internal-economics/lp-economics-run-service.test.ts:generic-api-key:1738
+ae497aedd948f8d3f8502577df0a4d0ad3c49cc0:tests/unit/services/internal-economics/lp-economics-run-service.test.ts:generic-api-key:1562
+cfbf32d1c019b3c3acf6bedbb356dc583f9ee851:tests/fixtures/internal-economics/vitest.config.ts:generic-api-key:36
 007f8762376db33c28a7bf310aede9cf2c0c31b0:server/routes/reserve-engine.md:generic-api-key:45
 0911c51546496d8bd43e2c8bd31fba3724ef48f2:tests/unit/routes/portfolio-overview-makeapp-surface.contract.test.ts:generic-api-key:69
 0a54e4a036372c02bc935d156e52367056bd626b:tests/unit/routes/capital-allocation-makeapp-surface.contract.test.ts:generic-api-key:69

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -9499,3 +9499,63 @@ in that plan's section 14 gate history). Two amendments to Decision item 4
    the WP-2b-4 plan's scope; the separate certification act (plan section 12)
    will be recorded in its own later addendum covering only the certification
    itself.
+
+Addendum (2026-08-01, Trust-Spine PR1 ADR-065/D-11 certification): the
+numerical-certification condition in Decision item 4 is fulfilled. SafeXIRR's
+UTC-normalization prerequisite shipped in `ef96c931`; Trust-Spine PR1 changes
+neither SafeXIRR nor its sanctioned Float64 XIRR boundary. The final-SHA
+attestation and complete gate evidence live at the immutable external locus
+[issue #1266](https://github.com/nikhillinit/Updog_restore/issues/1266). That
+record binds one full, unchanged PR1 candidate SHA to environment versions,
+commands, counts, hashes, failure classifications, and independent PASS verdicts
+from waterfall-specialist, phoenix-precision-guardian, and xirr-fees-validator.
+A later calculation, certification-proof, live-comment, or ADR commit
+invalidates all three verdicts and requires the complete gate and attestation
+sequence again; tracked prose therefore does not embed a self-referential final
+commit hash.
+
+The exact final-candidate command ledger is:
+
+1. Focused contract/core/certification/service/schema/manifest proof:
+
+   ```text
+   TZ=UTC npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/contract/internal-economics/lp-economics-run-v1.contract.test.ts tests/unit/contract/internal-economics/lp-economics-run-v1.1.contract.test.ts tests/unit/internal-economics/decimal-waterfall-core-v1.test.ts tests/unit/internal-economics/decimal-waterfall-core-v1.property.test.ts tests/unit/internal-economics/cash-assembly-period-loop-v1.test.ts tests/unit/internal-economics/lp-economics-v1.1-timezone-certification.test.ts tests/unit/truth-cases/waterfall-corrected-capital-account.test.ts tests/unit/truth-cases/waterfall-decimal-core.test.ts tests/unit/truth-cases/waterfall-dual-pin.test.ts tests/unit/services/internal-economics/lp-economics-run-service.test.ts tests/unit/schema/internal-economics-schema.test.ts tests/unit/prod-schema-manifest-coverage.test.ts tests/unit/prod-schema-manifest-sentinels.test.ts tests/unit/prod-schema-manifest-trigger-audit.test.ts
+   ```
+
+   Result: 264/264 tests. This includes pinned fast-check seed 1263, 500
+   generated cases with shrinking and retained examples, and fresh UTC,
+   America/New_York, and Asia/Kolkata subprocesses producing the same 4,591-byte
+   canonical result,
+   `inputHash=95753293e0bb10c38c3e78d9e6ffdd72f194278d646bec73c65af82ae8b0811b`,
+   and
+   `resultHash=d646867ffa1c1eb73ad36d607463748d8500bcd49d07ebb8e4dc96ae67447cd6`.
+
+2. `TZ=UTC npm run phoenix:truth` — 336/336 tests.
+3. `npm run calc-gate` — 587/587 tests, including Phoenix truth.
+4. `npm run validate:schema-drift` — no drift; `TZ=UTC npm run check` — no type
+   errors; `npm run lint` — no lint or guardrail errors.
+5. `TZ=UTC npm test` — expected aggregate: 11,192 non-skipped tests; the
+   external final-SHA record carries actual pass count and any fresh failure
+   classification.
+6. `DOCKER_HOST=unix://$HOME/.colima/default/docker.sock TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock NODE_OPTIONS=--dns-result-order=ipv4first TZ=UTC npx vitest run -c vitest.config.testcontainers.ts tests/integration/internal-economics/economics-schema.pg.test.ts tests/integration/prod-schema-clone.test.ts`
+   — 12/12 tests against fresh PostgreSQL.
+7. `npm run build` and `git diff --check` — PASS.
+
+Certification retires `DECIMAL_CORE_UNCERTIFIED` from new V1.1 emission while
+the immutable V1.0 parser continues to accept that historical reason.
+`available` is now representable in both the V1.1 contract and database, but the
+current Decimal path still emits `LP_NET_NAV_FLAT_SHARE_APPROXIMATION`, so
+current value-bearing results remain `indicative`. Five version axes remain
+independent: calculation contract `lp-economics/1.1.0`, engine
+`cash-assembly-period-loop-v1/1.1.0`, methodology
+`cash-assembly-period-loop-methodology/1.1.0`, result calculation
+`lp-economics/1.1.0`, and receipt `internal-lp-economics-run-receipt/1.0.0`
+(allocated here but introduced by PR2, not exposed by PR1).
+
+A null `calculation_contract_version` is legacy-only. It maps to V1.0 only when
+engine is `cash-assembly-period-loop-v1/1.0.0`, methodology is
+`cash-assembly-period-loop-methodology/1.0.0`, and either a completed row's
+result snapshot has `calc_version=lp-economics/1.0.0` or a failed row has no
+result snapshot. Every other null tuple fails closed with
+`UNSUPPORTED_CALCULATION_CONTRACT_VERSION`. This addendum fulfills ADR-065/D-11;
+it does not reverse P-D5.

--- a/migrations/0046_internal_economics_certification.sql
+++ b/migrations/0046_internal_economics_certification.sql
@@ -1,0 +1,24 @@
+-- @drift-patch
+-- Reason: Trust-Spine PR1 issue #1264 widens internal LP economics persistence
+-- for versioned calculation contracts and the certified three-state result union.
+-- Historical rows remain untouched; nullable contract identity is legacy-only.
+
+DO $$
+BEGIN
+  ALTER TABLE "internal_lp_economics_runs"
+    ADD COLUMN IF NOT EXISTS "calculation_contract_version" text;
+
+  COMMENT ON COLUMN "internal_lp_economics_runs"."calculation_contract_version"
+    IS 'null is legacy-only and requires registry verification';
+
+  ALTER TABLE "internal_lp_economics_runs"
+    DROP CONSTRAINT IF EXISTS "internal_lp_economics_runs_result_status_check";
+
+  ALTER TABLE "internal_lp_economics_runs"
+    ADD CONSTRAINT "internal_lp_economics_runs_result_status_check"
+    CHECK (
+      "result_status" IS NULL
+      OR "result_status" IN ('available','indicative','unavailable')
+    );
+END $$;
+--> statement-breakpoint

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -330,6 +330,13 @@
       "when": 1785368400000,
       "tag": "0045_internal_economics_policy_runs",
       "breakpoints": true
+    },
+    {
+      "idx": 47,
+      "version": "7",
+      "when": 1785454800000,
+      "tag": "0046_internal_economics_certification",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/prod-schema-manifests/23-internal-economics-certification.json
+++ b/scripts/prod-schema-manifests/23-internal-economics-certification.json
@@ -1,0 +1,34 @@
+{
+  "name": "internal-economics-certification",
+  "order": 23,
+  "description": "Trust-Spine PR1 migration 0046: add nullable calculation-contract identity to existing internal LP economics runs and widen result status to available, indicative, or unavailable without rewriting historical rows.",
+  "missingTablePolicy": "existing_table_required",
+  "sqlFiles": ["migrations/0046_internal_economics_certification.sql"],
+  "allowedCreateTables": [],
+  "applyPolicy": {
+    "allowConstraintReplacements": [
+      {
+        "table": "internal_lp_economics_runs",
+        "name": "internal_lp_economics_runs_result_status_check",
+        "expectedDefinition": {
+          "requiredFragments": ["result_status"],
+          "stringLiterals": ["available", "indicative", "unavailable"]
+        }
+      }
+    ]
+  },
+  "expectedTables": [
+    {
+      "name": "internal_lp_economics_runs",
+      "sharedTable": true,
+      "columns": [
+        {
+          "name": "calculation_contract_version",
+          "type": "text",
+          "nullable": true
+        }
+      ],
+      "constraints": ["internal_lp_economics_runs_result_status_check"]
+    }
+  ]
+}

--- a/server/services/internal-economics/lp-economics-run-service.ts
+++ b/server/services/internal-economics/lp-economics-run-service.ts
@@ -118,21 +118,28 @@ import {
   type EconomicsPolicyBodyV1,
 } from '../../../shared/contracts/internal-economics/economics-policy-v1.contract';
 import {
-  LP_ECONOMICS_RUN_CONTRACT_VERSION,
   LpEconomicsResultV1Schema,
   OPENING_STATE_CONTRACT_V1_INELIGIBLE_DETAIL,
   OPENING_STATE_INELIGIBLE_FIELDS_V1,
   buildLpEconomicsEventIdV1,
-  buildLpEconomicsRunIdempotencyPreimageV1,
   sortAndDedupeLpEconomicsReasonsV1,
-  type LpEconomicsIndicativeReasonV1,
   type LpEconomicsIrrBasisV1,
   type LpEconomicsResultV1,
-  type LpEconomicsRunRequestV1,
   type LpEconomicsRunUnavailabilityReasonV1,
   type LpEconomicsTotalsV1,
   type LpEconomicsWaterfallEventV1,
 } from '../../../shared/contracts/internal-economics/lp-economics-run-v1.contract';
+import {
+  LP_ECONOMICS_RUN_CONTRACT_VERSION_V1_1,
+  LpEconomicsIndicativeReasonV1_1Schema,
+  LpEconomicsResultV1_1Schema,
+  buildLpEconomicsRunIdempotencyPreimageV1_1,
+  type LpEconomicsAvailableResultV1_1,
+  type LpEconomicsIndicativeReasonV1_1,
+  type LpEconomicsIndicativeResultV1_1,
+  type LpEconomicsResultV1_1,
+  type LpEconomicsRunRequestV1_1,
+} from '../../../shared/contracts/internal-economics/lp-economics-run-v1.1.contract';
 import {
   PersistedFinancialFactsSnapshotV1Schema,
   type PersistedFinancialFactsSnapshotV1,
@@ -162,11 +169,16 @@ type RunDatabase = typeof db;
 // ---------------------------------------------------------------------------
 
 /** The engine identity stamped on every run row and fed to the frozen loop. */
-export const LP_ECONOMICS_RUN_ENGINE_VERSION = 'cash-assembly-period-loop-v1/1.0.0' as const;
+export const LP_ECONOMICS_RUN_ENGINE_VERSION = 'cash-assembly-period-loop-v1/1.1.0' as const;
 export const LP_ECONOMICS_RUN_METHODOLOGY_VERSION =
-  'cash-assembly-period-loop-methodology/1.0.0' as const;
+  'cash-assembly-period-loop-methodology/1.1.0' as const;
 /** P-D4: 18 chars, fits the journaled `fund_snapshots.calc_version varchar(20)`. */
-export const LP_ECONOMICS_RESULT_CALC_VERSION = 'lp-economics/1.0.0' as const;
+export const LP_ECONOMICS_RESULT_CALC_VERSION = 'lp-economics/1.1.0' as const;
+
+const LEGACY_LP_ECONOMICS_RUN_ENGINE_VERSION = 'cash-assembly-period-loop-v1/1.0.0' as const;
+const LEGACY_LP_ECONOMICS_RUN_METHODOLOGY_VERSION =
+  'cash-assembly-period-loop-methodology/1.0.0' as const;
+const LEGACY_LP_ECONOMICS_RESULT_CALC_VERSION = 'lp-economics/1.0.0' as const;
 
 /** P-D7 R5: firm service constant, not an example — pre-invocation guard. */
 export const MAX_CASH_ASSEMBLY_PERIOD_COUNT = 200;
@@ -192,7 +204,8 @@ export type LpEconomicsRunServiceErrorCode =
   | 'FORECAST_SNAPSHOT_NOT_FOUND'
   | 'RUN_NOT_FOUND'
   | 'RUN_RESULT_SNAPSHOT_MISSING'
-  | 'SOURCE_CONFIG_VERSION_DRIFTED';
+  | 'SOURCE_CONFIG_VERSION_DRIFTED'
+  | 'UNSUPPORTED_CALCULATION_CONTRACT_VERSION';
 
 export class LpEconomicsRunServiceError extends Error {
   readonly statusCode: number;
@@ -411,13 +424,13 @@ export interface ExecuteLpEconomicsRunOptions {
   readonly fundId: number;
   readonly actorId: number | null;
   readonly idempotencyKey: string;
-  readonly request: LpEconomicsRunRequestV1;
+  readonly request: LpEconomicsRunRequestV1_1;
   readonly database?: RunDatabase;
 }
 
 export interface LpEconomicsRunReceipt {
   readonly run: InternalLpEconomicsRunRow;
-  readonly result: LpEconomicsResultV1 | null;
+  readonly result: LpEconomicsResultV1 | LpEconomicsResultV1_1 | null;
 }
 
 export async function executeLpEconomicsRun(
@@ -759,9 +772,7 @@ function readOpeningStateFromFacts(
  * invoking the loop on a doomed input. `OPENING_STATE_INELIGIBLE_FIELDS_V1`
  * (the contract's read-only mirror of the loop's own list) pins the order.
  */
-function firstNonzeroOpeningBalanceField(
-  observation: FundAccountingStateObservationV1_1
-): {
+function firstNonzeroOpeningBalanceField(observation: FundAccountingStateObservationV1_1): {
   readonly field: (typeof OPENING_STATE_INELIGIBLE_FIELDS_V1)[number];
   readonly valueUsd: string;
 } | null {
@@ -1171,10 +1182,10 @@ function assembleTotals(
 
 function buildIndicativeReasons(
   resultStatusReasons: readonly string[]
-): LpEconomicsIndicativeReasonV1[] {
-  const reasons = resultStatusReasons.map((code) => ({
-    code: code as LpEconomicsIndicativeReasonV1['code'],
-  }));
+): LpEconomicsIndicativeReasonV1_1[] {
+  const reasons = resultStatusReasons.map((code) =>
+    LpEconomicsIndicativeReasonV1_1Schema.parse({ code })
+  );
   return [...sortAndDedupeLpEconomicsReasonsV1(reasons)];
 }
 
@@ -1190,7 +1201,7 @@ interface CommonRunFields {
   readonly planVersionId: number;
   readonly forecastSnapshotId: number;
   readonly evaluationClock: Date;
-  readonly terminalMode: LpEconomicsRunRequestV1['terminalMode'];
+  readonly terminalMode: LpEconomicsRunRequestV1_1['terminalMode'];
   readonly engineVersion: string;
   readonly methodologyVersion: string;
   readonly inputHash: string;
@@ -1230,7 +1241,7 @@ async function insertRunRow(
     readonly runState: 'completed' | 'failed';
     readonly resultSnapshotId: number | null;
     readonly resultSnapshotType: 'INTERNAL_LP_ECONOMICS' | null;
-    readonly resultStatus: 'indicative' | 'unavailable' | null;
+    readonly resultStatus: 'available' | 'indicative' | 'unavailable' | null;
     readonly resultHash: string | null;
     readonly failureCode: string | null;
     readonly failureContext: Record<string, unknown> | null;
@@ -1257,7 +1268,7 @@ async function insertRunRow(
     db: database,
     fundId: common.fundId,
     idempotencyKey: common.idempotencyKey,
-    contractVersion: LP_ECONOMICS_RUN_CONTRACT_VERSION,
+    contractVersion: LP_ECONOMICS_RUN_CONTRACT_VERSION_V1_1,
     request: common.preimagePlain,
     loadExisting: loadExistingRun,
     insert: async (requestHash) => {
@@ -1273,6 +1284,7 @@ async function insertRunRow(
           resultSnapshotId: stateFields.resultSnapshotId,
           resultSnapshotType: stateFields.resultSnapshotType,
           runState: stateFields.runState,
+          calculationContractVersion: LP_ECONOMICS_RUN_CONTRACT_VERSION_V1_1,
           resultStatus: stateFields.resultStatus,
           failureCode: stateFields.failureCode,
           failureContext: stateFields.failureContext,
@@ -1301,7 +1313,7 @@ async function insertResultSnapshot(
   input: {
     readonly fundId: number;
     readonly clock: string;
-    readonly payload: LpEconomicsResultV1;
+    readonly payload: LpEconomicsResultV1_1;
   }
 ): Promise<number> {
   const [inserted] = await database
@@ -1356,7 +1368,7 @@ async function persistUnavailableRun(
   reasons: readonly LpEconomicsRunUnavailabilityReasonV1[]
 ): Promise<LpEconomicsRunReceipt> {
   const sortedReasons = sortAndDedupeLpEconomicsReasonsV1(reasons);
-  const payload = LpEconomicsResultV1Schema.parse({
+  const payload = LpEconomicsResultV1_1Schema.parse({
     waterfallTemplate: 'deal_by_deal',
     resultStatus: 'unavailable',
     clock,
@@ -1386,7 +1398,7 @@ async function persistCompletedRun(
   database: RunDatabase,
   common: CommonRunFields,
   clock: string,
-  payload: LpEconomicsResultV1
+  payload: LpEconomicsAvailableResultV1_1 | LpEconomicsIndicativeResultV1_1
 ): Promise<LpEconomicsRunReceipt> {
   const resultSnapshotId = await insertResultSnapshot(database, {
     fundId: common.fundId,
@@ -1397,7 +1409,7 @@ async function persistCompletedRun(
     runState: 'completed',
     resultSnapshotId,
     resultSnapshotType: 'INTERNAL_LP_ECONOMICS',
-    resultStatus: 'indicative',
+    resultStatus: payload.resultStatus,
     resultHash: canonicalSha256(payload),
     failureCode: null,
     failureContext: null,
@@ -1409,8 +1421,16 @@ async function buildReceiptFromRunRow(
   run: InternalLpEconomicsRunRow,
   database: RunDatabase
 ): Promise<LpEconomicsRunReceipt> {
-  if (run.runState === 'failed' || run.resultSnapshotId === null) {
+  if (run.runState === 'failed') {
+    resolvePersistedCalculationContract(run, null);
     return { run, result: null };
+  }
+  if (run.resultSnapshotId === null) {
+    throw new LpEconomicsRunServiceError(
+      500,
+      'RUN_RESULT_SNAPSHOT_MISSING',
+      'The completed run does not carry a result snapshot identity.'
+    );
   }
   const [snapshotRow] = await database
     .select()
@@ -1430,7 +1450,59 @@ async function buildReceiptFromRunRow(
       'The run result snapshot could not be read back by (id, fund, type).'
     );
   }
-  return { run, result: LpEconomicsResultV1Schema.parse(snapshotRow.payload) };
+  const calculationContract = resolvePersistedCalculationContract(run, snapshotRow.calcVersion);
+  return {
+    run,
+    result:
+      calculationContract === 'v1.0'
+        ? LpEconomicsResultV1Schema.parse(snapshotRow.payload)
+        : LpEconomicsResultV1_1Schema.parse(snapshotRow.payload),
+  };
+}
+
+function resolvePersistedCalculationContract(
+  run: InternalLpEconomicsRunRow,
+  resultCalculationVersion: string | null
+): 'v1.0' | 'v1.1' {
+  const isFailedWithoutResult = run.runState === 'failed' && resultCalculationVersion === null;
+  const isCompletedV1Result =
+    run.runState === 'completed' &&
+    resultCalculationVersion === LEGACY_LP_ECONOMICS_RESULT_CALC_VERSION;
+  const isCompletedV1_1Result =
+    run.runState === 'completed' && resultCalculationVersion === LP_ECONOMICS_RESULT_CALC_VERSION;
+
+  const hasLegacyRuntimeIdentity =
+    run.engineVersion === LEGACY_LP_ECONOMICS_RUN_ENGINE_VERSION &&
+    run.methodologyVersion === LEGACY_LP_ECONOMICS_RUN_METHODOLOGY_VERSION;
+  if (
+    hasLegacyRuntimeIdentity &&
+    run.calculationContractVersion === null &&
+    (isFailedWithoutResult || isCompletedV1Result)
+  ) {
+    return 'v1.0';
+  }
+
+  if (
+    run.calculationContractVersion === LP_ECONOMICS_RUN_CONTRACT_VERSION_V1_1 &&
+    run.engineVersion === LP_ECONOMICS_RUN_ENGINE_VERSION &&
+    run.methodologyVersion === LP_ECONOMICS_RUN_METHODOLOGY_VERSION &&
+    (isFailedWithoutResult || isCompletedV1_1Result)
+  ) {
+    return 'v1.1';
+  }
+
+  throw new LpEconomicsRunServiceError(
+    500,
+    'UNSUPPORTED_CALCULATION_CONTRACT_VERSION',
+    'The persisted LP economics calculation identity tuple is unsupported.',
+    {
+      calculationContractVersion: run.calculationContractVersion,
+      engineVersion: run.engineVersion,
+      methodologyVersion: run.methodologyVersion,
+      resultCalculationVersion,
+      runState: run.runState,
+    }
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -1450,7 +1522,7 @@ async function executeLpEconomicsRunInTransaction(params: {
   // Step 2: early idempotent replay, before ANY basis read (G16 fail-closed
   // lesson). The preimage already carries fundId + contractVersion at its
   // top level (P-D8), so it doubles directly as the replay request.
-  const preimage = buildLpEconomicsRunIdempotencyPreimageV1({
+  const preimage = buildLpEconomicsRunIdempotencyPreimageV1_1({
     fundId,
     request,
     engineVersion: LP_ECONOMICS_RUN_ENGINE_VERSION,
@@ -1462,7 +1534,7 @@ async function executeLpEconomicsRunInTransaction(params: {
     db: database,
     fundId,
     idempotencyKey: opts.idempotencyKey,
-    contractVersion: LP_ECONOMICS_RUN_CONTRACT_VERSION,
+    contractVersion: LP_ECONOMICS_RUN_CONTRACT_VERSION_V1_1,
     request: preimagePlain,
     loadExisting: async () => {
       const [existing] = await database
@@ -1715,9 +1787,9 @@ async function executeLpEconomicsRunInTransaction(params: {
   const enrichedEvents = enrichWaterfallEvents(loopResult.waterfallEvents);
   const totals = assembleTotals(loopResult.quarters, enrichedEvents);
   const reasons = buildIndicativeReasons(loopResult.resultStatusReasons);
-  const resultEnvelope = LpEconomicsResultV1Schema.parse({
+  const resultEnvelope = LpEconomicsResultV1_1Schema.parse({
     waterfallTemplate: 'deal_by_deal',
-    resultStatus: 'indicative',
+    resultStatus: loopResult.resultStatus,
     clock: request.clock,
     currency: 'USD',
     perspective: 'lp_net',
@@ -1731,6 +1803,9 @@ async function executeLpEconomicsRunInTransaction(params: {
     lpNetIrrDiagnostic: loopResult.xirrDiagnostic,
     reasons,
   });
+  if (resultEnvelope.resultStatus === 'unavailable') {
+    throw new Error('Successful loop output cannot assemble an unavailable result payload.');
+  }
 
   return persistCompletedRun(database, common, request.clock, resultEnvelope);
 }

--- a/shared/contracts/internal-economics/lp-economics-run-v1.1.contract.ts
+++ b/shared/contracts/internal-economics/lp-economics-run-v1.1.contract.ts
@@ -1,3 +1,12 @@
+/**
+ * Certified Internal LP Economics V1.1 calculation contract.
+ *
+ * `DECIMAL_CORE_UNCERTIFIED` is retired from new V1.1 emission (the frozen
+ * V1.0 parser retains it for historical payloads). `available` is a reachable
+ * contract state only when no trust-cap reason remains; the current period
+ * loop still emits `LP_NET_NAV_FLAT_SHARE_APPROXIMATION`, so current successful
+ * results remain `indicative`.
+ */
 import { z } from 'zod';
 
 import {

--- a/shared/contracts/internal-economics/lp-economics-run-v1.1.contract.ts
+++ b/shared/contracts/internal-economics/lp-economics-run-v1.1.contract.ts
@@ -1,0 +1,142 @@
+import { z } from 'zod';
+
+import {
+  LpEconomicsIrrBasisV1Schema,
+  LpEconomicsQuarterRowV1Schema,
+  LpEconomicsRunUnavailabilityReasonV1Schema,
+  LpEconomicsTotalsV1Schema,
+  LpEconomicsWaterfallEventV1Schema,
+} from './lp-economics-run-v1.contract';
+import { TerminalModeV1Schema } from './terminal-policy-v1.contract';
+import { XirrDiagnosticSchema } from '../lp-reporting/lp-metric-run.contract';
+import { MoneyDecimalStringSchema, RatioDecimalStringSchema } from '../../lib/decimal-string';
+
+export const LP_ECONOMICS_RUN_CONTRACT_VERSION_V1_1 = 'lp-economics/1.1.0' as const;
+export const LP_ECONOMICS_RUN_COMMAND_KIND_V1_1 = 'internal-economics-run:create' as const;
+
+export const LpEconomicsRunRequestV1_1Schema = z
+  .object({
+    policyVersionId: z.number().int().positive(),
+    factsSnapshotId: z.number().int().positive(),
+    planVersionId: z.number().int().positive(),
+    forecastSnapshotId: z.number().int().positive(),
+    terminalMode: TerminalModeV1Schema,
+    clock: z.string().datetime(),
+  })
+  .strict();
+export type LpEconomicsRunRequestV1_1 = Readonly<z.infer<typeof LpEconomicsRunRequestV1_1Schema>>;
+
+export const LpEconomicsRunIdempotencyPreimageV1_1Schema = z
+  .object({
+    commandKind: z.literal(LP_ECONOMICS_RUN_COMMAND_KIND_V1_1),
+    fundId: z.number().int().positive(),
+    contractVersion: z.literal(LP_ECONOMICS_RUN_CONTRACT_VERSION_V1_1),
+    request: LpEconomicsRunRequestV1_1Schema,
+    engineVersion: z.string().min(1),
+    methodologyVersion: z.string().min(1),
+  })
+  .strict();
+export type LpEconomicsRunIdempotencyPreimageV1_1 = Readonly<
+  z.infer<typeof LpEconomicsRunIdempotencyPreimageV1_1Schema>
+>;
+
+export function buildLpEconomicsRunIdempotencyPreimageV1_1(input: {
+  readonly fundId: number;
+  readonly request: LpEconomicsRunRequestV1_1;
+  readonly engineVersion: string;
+  readonly methodologyVersion: string;
+}): LpEconomicsRunIdempotencyPreimageV1_1 {
+  return LpEconomicsRunIdempotencyPreimageV1_1Schema.parse({
+    commandKind: LP_ECONOMICS_RUN_COMMAND_KIND_V1_1,
+    fundId: input.fundId,
+    contractVersion: LP_ECONOMICS_RUN_CONTRACT_VERSION_V1_1,
+    request: input.request,
+    engineVersion: input.engineVersion,
+    methodologyVersion: input.methodologyVersion,
+  });
+}
+
+export const LP_ECONOMICS_INDICATIVE_REASON_CODES_V1_1 = [
+  'FLOAT64_WATERFALL_PATH',
+  'LP_NET_NAV_FLAT_SHARE_APPROXIMATION',
+] as const;
+
+export const LpEconomicsIndicativeReasonCodeV1_1Schema = z.enum(
+  LP_ECONOMICS_INDICATIVE_REASON_CODES_V1_1
+);
+export type LpEconomicsIndicativeReasonCodeV1_1 = z.infer<
+  typeof LpEconomicsIndicativeReasonCodeV1_1Schema
+>;
+
+const LpEconomicsReasonContextV1_1Schema = z.record(z.string(), z.string());
+
+export const LpEconomicsIndicativeReasonV1_1Schema = z
+  .object({
+    code: LpEconomicsIndicativeReasonCodeV1_1Schema,
+    detail: z.string().min(1).optional(),
+    context: LpEconomicsReasonContextV1_1Schema.optional(),
+  })
+  .strict();
+export type LpEconomicsIndicativeReasonV1_1 = Readonly<
+  z.infer<typeof LpEconomicsIndicativeReasonV1_1Schema>
+>;
+
+const LpEconomicsResultEnvelopeCommonV1_1 = {
+  waterfallTemplate: z.literal('deal_by_deal'),
+  clock: z.string().datetime(),
+  currency: z.literal('USD'),
+  perspective: z.literal('lp_net'),
+  precisionMode: z.literal('decimal_native_with_float64_xirr'),
+} as const;
+
+const LpEconomicsValueResultFieldsV1_1 = {
+  quarters: z.array(LpEconomicsQuarterRowV1Schema),
+  waterfallEvents: z.array(LpEconomicsWaterfallEventV1Schema),
+  totals: LpEconomicsTotalsV1Schema,
+  terminalNavBeforeRealizationUsd: MoneyDecimalStringSchema,
+  lpNetIrr: RatioDecimalStringSchema.nullable(),
+  lpNetIrrBasis: LpEconomicsIrrBasisV1Schema,
+  lpNetIrrDiagnostic: XirrDiagnosticSchema,
+} as const;
+
+export const LpEconomicsAvailableResultV1_1Schema = z
+  .object({
+    ...LpEconomicsResultEnvelopeCommonV1_1,
+    resultStatus: z.literal('available'),
+    ...LpEconomicsValueResultFieldsV1_1,
+    reasons: z.tuple([]),
+  })
+  .strict();
+export type LpEconomicsAvailableResultV1_1 = Readonly<
+  z.infer<typeof LpEconomicsAvailableResultV1_1Schema>
+>;
+
+export const LpEconomicsIndicativeResultV1_1Schema = z
+  .object({
+    ...LpEconomicsResultEnvelopeCommonV1_1,
+    resultStatus: z.literal('indicative'),
+    ...LpEconomicsValueResultFieldsV1_1,
+    reasons: z.array(LpEconomicsIndicativeReasonV1_1Schema).min(1),
+  })
+  .strict();
+export type LpEconomicsIndicativeResultV1_1 = Readonly<
+  z.infer<typeof LpEconomicsIndicativeResultV1_1Schema>
+>;
+
+export const LpEconomicsUnavailableResultV1_1Schema = z
+  .object({
+    ...LpEconomicsResultEnvelopeCommonV1_1,
+    resultStatus: z.literal('unavailable'),
+    reasons: z.array(LpEconomicsRunUnavailabilityReasonV1Schema).min(1),
+  })
+  .strict();
+export type LpEconomicsUnavailableResultV1_1 = Readonly<
+  z.infer<typeof LpEconomicsUnavailableResultV1_1Schema>
+>;
+
+export const LpEconomicsResultV1_1Schema = z.discriminatedUnion('resultStatus', [
+  LpEconomicsAvailableResultV1_1Schema,
+  LpEconomicsIndicativeResultV1_1Schema,
+  LpEconomicsUnavailableResultV1_1Schema,
+]);
+export type LpEconomicsResultV1_1 = Readonly<z.infer<typeof LpEconomicsResultV1_1Schema>>;

--- a/shared/lib/internal-economics/cash-assembly-period-loop-v1.ts
+++ b/shared/lib/internal-economics/cash-assembly-period-loop-v1.ts
@@ -61,10 +61,7 @@ import {
 
 const ZERO = new Decimal(0);
 const ZERO_MONEY = '0.000000';
-const RESULT_STATUS_REASONS = [
-  'DECIMAL_CORE_UNCERTIFIED',
-  'LP_NET_NAV_FLAT_SHARE_APPROXIMATION',
-] as const;
+const RESULT_STATUS_REASONS = ['LP_NET_NAV_FLAT_SHARE_APPROXIMATION'] as const;
 
 const XIRR_MIN_RATE = -0.999999;
 const XIRR_MAX_RATE = 200;
@@ -104,11 +101,19 @@ export interface ExecuteCashAssemblyPeriodLoopV1Result {
   readonly terminalNavBeforeRealizationUsd: string;
   readonly lpNetIrr: string | null;
   readonly xirrDiagnostic: XirrDiagnostic;
-  readonly resultStatus: 'indicative';
+  readonly resultStatus: 'available' | 'indicative' | 'unavailable';
   readonly resultStatusReasons: readonly string[];
   readonly terminalMode: TerminalModeV1;
   readonly engineVersion: string;
   readonly methodologyVersion: string;
+}
+
+export function foldCashAssemblyResultStatusV1(input: {
+  readonly eligibilityRefused: boolean;
+  readonly trustCapReasons: readonly string[];
+}): 'available' | 'indicative' | 'unavailable' {
+  if (input.eligibilityRefused) return 'unavailable';
+  return input.trustCapReasons.length > 0 ? 'indicative' : 'available';
 }
 
 export type CashAssemblyPeriodLoopV1ErrorCode =
@@ -971,7 +976,10 @@ export function executeCashAssemblyPeriodLoopV1(
     terminalNavBeforeRealizationUsd: terminalNavBeforeRealization.toFixed(6),
     lpNetIrr: xirrResult.lpNetIrr,
     xirrDiagnostic: xirrResult.xirrDiagnostic,
-    resultStatus: 'indicative',
+    resultStatus: foldCashAssemblyResultStatusV1({
+      eligibilityRefused: false,
+      trustCapReasons: RESULT_STATUS_REASONS,
+    }),
     resultStatusReasons: RESULT_STATUS_REASONS,
     terminalMode: input.terminalMode,
     engineVersion: input.engineVersion,

--- a/shared/lib/internal-economics/cash-assembly-period-loop-v1.ts
+++ b/shared/lib/internal-economics/cash-assembly-period-loop-v1.ts
@@ -9,9 +9,11 @@
  * recurrence in its required order; resolve terminal realization; and compute
  * LP-net XIRR.
  *
- * D-5 timezone disclosure: XIRR determinism is conditional on running with
- * TZ=UTC because the frozen upstream safeXIRR date normalization uses local-time
- * getters (tracked by issue #1256). The rest of this loop is timezone-pure.
+ * Timezone disclosure: SafeXIRR has normalized dates with UTC getters since
+ * `ef96c931` (#1256). Trust-Spine certification executes the same representative
+ * V1.1 result in fresh UTC, America/New_York, and Asia/Kolkata processes and
+ * requires byte-identical canonical results and hashes. Existing `TZ=UTC`
+ * runtime and CI pins remain defense in depth.
  *
  * Phase 1 invariants:
  * - opening cash threads from each emitted quarter into the next;

--- a/shared/schema/internal-economics.ts
+++ b/shared/schema/internal-economics.ts
@@ -232,11 +232,19 @@ export const internalLpEconomicsRuns = pgTable(
       length: 50,
     }).$type<'INTERNAL_LP_ECONOMICS'>(),
     runState: varchar('run_state', { length: 16 }).notNull().$type<'completed' | 'failed'>(),
-    /** Null is legacy-only and requires calculation-contract registry verification. */
+    /**
+     * Null is legacy-only: readers accept V1.0 engine/methodology only with
+     * either a completed V1.0 result or a failed row with no result snapshot;
+     * every V1.1 writer persists 1.1.0.
+     */
     calculationContractVersion: text('calculation_contract_version').$type<
       'lp-economics/1.0.0' | 'lp-economics/1.1.0'
     >(),
-    /** Trust-Spine PR1: all certified V1.1 trust states are representable. */
+    /**
+     * Certified V1.1 trust-state vocabulary. `available` is structurally
+     * reachable, while the current flat-share LP NAV cap keeps emitted value
+     * results `indicative`.
+     */
     resultStatus: varchar('result_status', { length: 16 }).$type<
       'available' | 'indicative' | 'unavailable'
     >(),

--- a/shared/schema/internal-economics.ts
+++ b/shared/schema/internal-economics.ts
@@ -232,8 +232,14 @@ export const internalLpEconomicsRuns = pgTable(
       length: 50,
     }).$type<'INTERNAL_LP_ECONOMICS'>(),
     runState: varchar('run_state', { length: 16 }).notNull().$type<'completed' | 'failed'>(),
-    /** P-D5: `available` is DB-unreachable until the certification act. */
-    resultStatus: varchar('result_status', { length: 16 }).$type<'indicative' | 'unavailable'>(),
+    /** Null is legacy-only and requires calculation-contract registry verification. */
+    calculationContractVersion: text('calculation_contract_version').$type<
+      'lp-economics/1.0.0' | 'lp-economics/1.1.0'
+    >(),
+    /** Trust-Spine PR1: all certified V1.1 trust states are representable. */
+    resultStatus: varchar('result_status', { length: 16 }).$type<
+      'available' | 'indicative' | 'unavailable'
+    >(),
     failureCode: text('failure_code'),
     failureContext: jsonb('failure_context').$type<Record<string, unknown>>(),
     /** Pinned basis clock (D9): evaluation time is basis, never now(). */
@@ -300,7 +306,7 @@ export const internalLpEconomicsRuns = pgTable(
     ),
     resultStatusCheck: check(
       'internal_lp_economics_runs_result_status_check',
-      sql`${table.resultStatus} IS NULL OR ${table.resultStatus} IN ('indicative','unavailable')`
+      sql`${table.resultStatus} IS NULL OR ${table.resultStatus} IN ('available','indicative','unavailable')`
     ),
     terminalModeCheck: check(
       'internal_lp_economics_runs_terminal_mode_check',

--- a/tests/fixtures/internal-economics/vitest.config.ts
+++ b/tests/fixtures/internal-economics/vitest.config.ts
@@ -1,0 +1,43 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { defineConfig } from 'vitest/config';
+
+import { createVitestAlias } from '../../../vitest.config.shared.mjs';
+
+const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const alias = createVitestAlias(projectRoot, {
+  includeAppServer: true,
+  includeAssets: true,
+  includeTestMocks: true,
+  includeUpstashRedisMock: true,
+});
+
+export default defineConfig({
+  root: projectRoot,
+  resolve: { alias },
+  test: {
+    environment: 'node',
+    globals: true,
+    isolate: true,
+    pool: 'forks',
+    maxWorkers: 1,
+    include: ['tests/unit/services/internal-economics/lp-economics-run-service.test.ts'],
+    setupFiles: [
+      resolve(projectRoot, 'tests/setup/node-setup-redis.ts'),
+      resolve(projectRoot, 'tests/setup/db-delegate-link.ts'),
+      resolve(projectRoot, 'tests/setup/test-infrastructure.ts'),
+    ],
+    env: {
+      NODE_ENV: 'test',
+      _EXPLICIT_NODE_ENV: 'test',
+      TZ: process.env['TZ'] ?? 'UTC',
+      REDIS_URL: 'memory://',
+      JWT_SECRET: 'test-jwt-secret-must-be-at-least-32-characters-long-for-hs256-validation',
+      JWT_ALG: 'HS256',
+      JWT_ISSUER: 'updog',
+      JWT_AUDIENCE: 'updog-app',
+      ALERTMANAGER_WEBHOOK_SECRET: 'test-alertmanager-webhook-secret-minimum-32-characters-long',
+    },
+  },
+});

--- a/tests/fixtures/internal-economics/vitest.config.ts
+++ b/tests/fixtures/internal-economics/vitest.config.ts
@@ -6,6 +6,7 @@ import { defineConfig } from 'vitest/config';
 import { createVitestAlias } from '../../../vitest.config.shared.mjs';
 
 const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const testSecret = 'test-secret-'.repeat(4);
 const alias = createVitestAlias(projectRoot, {
   includeAppServer: true,
   includeAssets: true,
@@ -33,11 +34,11 @@ export default defineConfig({
       _EXPLICIT_NODE_ENV: 'test',
       TZ: process.env['TZ'] ?? 'UTC',
       REDIS_URL: 'memory://',
-      JWT_SECRET: 'test-jwt-secret-must-be-at-least-32-characters-long-for-hs256-validation',
+      JWT_SECRET: testSecret,
       JWT_ALG: 'HS256',
       JWT_ISSUER: 'updog',
       JWT_AUDIENCE: 'updog-app',
-      ALERTMANAGER_WEBHOOK_SECRET: 'test-alertmanager-webhook-secret-minimum-32-characters-long',
+      ALERTMANAGER_WEBHOOK_SECRET: testSecret,
     },
   },
 });

--- a/tests/integration/internal-economics/economics-schema.pg.test.ts
+++ b/tests/integration/internal-economics/economics-schema.pg.test.ts
@@ -1,9 +1,9 @@
 /**
- * PostgreSQL proofs for migration 0045 (WP-L3 Phase A, T-A1/T-A2/T-A3/T-A5).
+ * PostgreSQL proofs for migrations 0045/0046 (WP-L3 Phase A + Trust-Spine PR1).
  *
  * These assert the invariants only a real database can demonstrate:
- * - T-A1: the migration applies clean through the drizzle migrator (journal
- *   entry asserted by its OWN tag) and the raw file replays without error.
+ * - T-A1: both migrations apply clean through the drizzle migrator (journal
+ *   entries asserted by their OWN tags) and raw files replay without error.
  * - T-A2: the internal_economics_forbid_update() trigger web forbids every
  *   UPDATE on the three new tables, forbids UPDATE of INTERNAL_LP_ECONOMICS
  *   fund_snapshots rows in BOTH directions (including laundering another
@@ -11,8 +11,8 @@
  *   admits child-version corrections, and `DELETE FROM funds` fails on the
  *   FK web (L3-Q2: RESTRICT posture, no live fund-deletion cascade exists).
  * - T-A3: envelope arithmetic CHECKs (exact numeric equality incl. the
- *   trailing-zeros pre-mortem case), runs state-coupling CHECKs
- *   ('available' DB-unreachable), typed snapshot composite FKs, wrong-fund
+ *   trailing-zeros pre-mortem case), runs state-coupling CHECKs, all three
+ *   certified trust states, typed snapshot composite FKs, wrong-fund
  *   composite FK rejection, and the one-result-snapshot-per-run partial
  *   unique.
  * - T-A5: manifest 22 audits ACTION_REFUSE_FOR_HUMAN before manual
@@ -27,6 +27,7 @@ import { Pool } from 'pg';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import {
+  ACTION_APPLY_MISSING_DDL,
   ACTION_REFUSE_FOR_HUMAN,
   ACTION_SKIP,
   auditManifest,
@@ -43,8 +44,14 @@ const skipIfNoDocker =
   !process.env.TEST_DATABASE_URL && !process.env.CI && process.platform === 'win32';
 const createdDatabases: string[] = [];
 
-const MIGRATION_TAG = '0045_internal_economics_policy_runs';
-const MIGRATION_FILE = path.join(process.cwd(), 'migrations', `${MIGRATION_TAG}.sql`);
+const BASE_MIGRATION_TAG = '0045_internal_economics_policy_runs';
+const BASE_MIGRATION_FILE = path.join(process.cwd(), 'migrations', `${BASE_MIGRATION_TAG}.sql`);
+const CERTIFICATION_MIGRATION_TAG = '0046_internal_economics_certification';
+const CERTIFICATION_MIGRATION_FILE = path.join(
+  process.cwd(),
+  'migrations',
+  `${CERTIFICATION_MIGRATION_TAG}.sql`
+);
 const TRIGGER_NAMES = [
   'internal_capital_envelope_versions_forbid_update_trigger',
   'internal_economics_policy_versions_forbid_update_trigger',
@@ -77,16 +84,18 @@ describe.skipIf(skipIfNoDocker)('internal economics schema PostgreSQL proof', ()
     }
   });
 
-  it('applies migration 0045 through the migrator and replays the raw file (T-A1)', async () => {
+  it('applies migrations 0045/0046 through the migrator and replays both raw files', async () => {
     const { connectionString, state } = await createMigratedDatabase('replay');
 
     // Journal entry asserted by its OWN tag, never entries.at(-1).
-    expect(state.applied.map((entry) => entry.name)).toContain(MIGRATION_TAG);
+    expect(state.applied.map((entry) => entry.name)).toEqual(
+      expect.arrayContaining([BASE_MIGRATION_TAG, CERTIFICATION_MIGRATION_TAG])
+    );
 
     await withPool(connectionString, async (pool) => {
       // Raw replay: every statement is replay-safe by construction.
-      const migrationSql = await readFile(MIGRATION_FILE, 'utf8');
-      await pool.query(migrationSql);
+      await pool.query(await readFile(BASE_MIGRATION_FILE, 'utf8'));
+      await pool.query(await readFile(CERTIFICATION_MIGRATION_FILE, 'utf8'));
 
       const triggers = await pool.query<{ tgname: string; tgenabled: string }>(
         `
@@ -122,6 +131,61 @@ describe.skipIf(skipIfNoDocker)('internal economics schema PostgreSQL proof', ()
         `
       );
       expect(functions.rowCount).toBe(1);
+    });
+  });
+
+  it('rolls back every 0046 catalog change and preserves rows when migration fails', async () => {
+    const { connectionString } = await createMigratedDatabase('atomic-failure', BASE_MIGRATION_TAG);
+
+    await withPool(connectionString, async (pool) => {
+      const basis = await seedRunBasis(pool);
+      const runId = await insertRun(pool, basis, {
+        idempotencyKey: 'pre-certification-failed-run',
+        runState: 'failed',
+        resultSnapshotId: null,
+        resultSnapshotType: null,
+        resultStatus: null,
+        resultHash: null,
+        failureCode: 'CORE_ROW_MAPPING_MISMATCH',
+        failureContext: '{}',
+      });
+
+      const migrationSql = await readFile(CERTIFICATION_MIGRATION_FILE, 'utf8');
+      const failingMigrationSql = migrationSql.replace(
+        'END $$;',
+        "RAISE EXCEPTION 'forced_0046_failure';\nEND $$;"
+      );
+      expect(failingMigrationSql).not.toBe(migrationSql);
+      await expect(pool.query(failingMigrationSql)).rejects.toThrow(/forced_0046_failure/);
+
+      const column = await pool.query(
+        `
+          SELECT 1
+          FROM information_schema.columns
+          WHERE table_schema = 'public'
+            AND table_name = 'internal_lp_economics_runs'
+            AND column_name = 'calculation_contract_version'
+        `
+      );
+      expect(column.rowCount).toBe(0);
+
+      const constraint = await pool.query<{ definition: string }>(
+        `
+          SELECT pg_get_constraintdef(oid) AS definition
+          FROM pg_constraint
+          WHERE conname = 'internal_lp_economics_runs_result_status_check'
+            AND conrelid = 'public.internal_lp_economics_runs'::regclass
+        `
+      );
+      expect(constraint.rows[0]?.definition).not.toContain("'available'");
+
+      const preserved = await pool.query<{ run_state: string; failure_code: string }>(
+        `SELECT run_state, failure_code FROM internal_lp_economics_runs WHERE id = $1`,
+        [runId]
+      );
+      expect(preserved.rows).toEqual([
+        { run_state: 'failed', failure_code: 'CORE_ROW_MAPPING_MISMATCH' },
+      ]);
     });
   });
 
@@ -323,19 +387,21 @@ describe.skipIf(skipIfNoDocker)('internal economics schema PostgreSQL proof', ()
         })
       ).rejects.toThrow(/internal_lp_economics_runs_state_coupling_check/);
 
-      // ...and 'available' is DB-unreachable until the certification act.
+      // Certification migration makes 'available' and contract identity representable.
+      const availableBasis = await seedRunBasis(pool);
       await expect(
-        insertRun(pool, basis, {
-          idempotencyKey: 'available-unreachable',
+        insertRun(pool, availableBasis, {
+          idempotencyKey: 'available-certified',
+          calculationContractVersion: 'lp-economics/1.1.0',
           runState: 'completed',
-          resultSnapshotId: basis.resultSnapshotId,
+          resultSnapshotId: availableBasis.resultSnapshotId,
           resultSnapshotType: 'INTERNAL_LP_ECONOMICS',
           resultStatus: 'available',
           resultHash: hex64('r'),
           failureCode: null,
           failureContext: null,
         })
-      ).rejects.toThrow(/internal_lp_economics_runs_result_status_check/);
+      ).resolves.toEqual(expect.any(Number));
 
       // Typed snapshot composite FK: a RESERVE row cannot satisfy the
       // CURRENT_FORECAST_V2 pin even when the type literal is asserted.
@@ -418,7 +484,7 @@ describe.skipIf(skipIfNoDocker)('internal economics schema PostgreSQL proof', ()
       expect(beforeKinds).toContain('missing-function');
 
       // Manual reconciliation: the operator applies the journaled migration.
-      const migrationSql = await readFile(MIGRATION_FILE, 'utf8');
+      const migrationSql = await readFile(BASE_MIGRATION_FILE, 'utf8');
       await pool.query(migrationSql);
 
       const after = await auditManifest(pool, manifest);
@@ -474,6 +540,48 @@ describe.skipIf(skipIfNoDocker)('internal economics schema PostgreSQL proof', ()
       expect((await auditManifest(pool, manifest)).action).toBe(ACTION_SKIP);
     });
   }, 120_000);
+
+  it('manifest 23 applies additive certification DDL and audits the widened contract', async () => {
+    const { connectionString } = await createMigratedDatabase(
+      'certification-manifest',
+      BASE_MIGRATION_TAG
+    );
+    const manifests = await loadManifests();
+    const manifest = manifests.find(
+      (candidate: { name: string }) => candidate.name === 'internal-economics-certification'
+    );
+    expect(manifest).toBeDefined();
+
+    await withPool(connectionString, async (pool) => {
+      const before = await auditManifest(pool, manifest);
+      expect(before.action).toBe(ACTION_APPLY_MISSING_DDL);
+
+      await pool.query(await readFile(CERTIFICATION_MIGRATION_FILE, 'utf8'));
+
+      const after = await auditManifest(pool, manifest);
+      expect(after.action).toBe(ACTION_SKIP);
+      expect(after.objects).toEqual([
+        expect.objectContaining({
+          table: 'internal_lp_economics_runs',
+          deltas: [],
+          action: ACTION_SKIP,
+        }),
+      ]);
+
+      const comment = await pool.query<{ description: string }>(
+        `
+          SELECT col_description('public.internal_lp_economics_runs'::regclass, ordinal_position) AS description
+          FROM information_schema.columns
+          WHERE table_schema = 'public'
+            AND table_name = 'internal_lp_economics_runs'
+            AND column_name = 'calculation_contract_version'
+        `
+      );
+      expect(comment.rows[0]?.description).toBe(
+        'null is legacy-only and requires registry verification'
+      );
+    });
+  }, 120_000);
 });
 
 interface RunBasis {
@@ -506,6 +614,7 @@ interface EnvelopeInput {
 
 interface RunOverrides {
   idempotencyKey: string;
+  calculationContractVersion?: 'lp-economics/1.0.0' | 'lp-economics/1.1.0';
   policyVersionId?: number;
   forecastSnapshotId?: number;
   runState?: 'completed' | 'failed';
@@ -671,6 +780,9 @@ function insertEnvelope(pool: Pool, input: EnvelopeInput): Promise<number> {
 
 function insertRun(pool: Pool, basis: RunBasis, overrides: RunOverrides): Promise<number> {
   const runState = overrides.runState ?? 'completed';
+  const contractColumn =
+    overrides.calculationContractVersion === undefined ? '' : ', calculation_contract_version';
+  const contractValue = overrides.calculationContractVersion === undefined ? '' : ', $17';
   return insertedId(
     pool,
     `
@@ -680,11 +792,11 @@ function insertRun(pool: Pool, basis: RunBasis, overrides: RunOverrides): Promis
         result_snapshot_type, run_state, result_status, failure_code,
         failure_context, evaluation_clock, terminal_mode, engine_version,
         methodology_version, input_hash, result_hash, created_by,
-        idempotency_key, request_hash
+        idempotency_key, request_hash${contractColumn}
       ) VALUES (
         $1, $2, $3, $4, $5, 'CURRENT_FORECAST_V2', $6, $7, $8, $9, $10,
         $11::jsonb, NOW(), 'liquidate_at_horizon', 'cash-assembly-period-loop/1.0.0',
-        'lp-economics/1.0.0', $12, $13, $14, $15, $16
+        'lp-economics/1.0.0', $12, $13, $14, $15, $16${contractValue}
       )
       RETURNING id
     `,
@@ -705,6 +817,9 @@ function insertRun(pool: Pool, basis: RunBasis, overrides: RunOverrides): Promis
       basis.userId,
       overrides.idempotencyKey,
       hex64(overrides.idempotencyKey),
+      ...(overrides.calculationContractVersion === undefined
+        ? []
+        : [overrides.calculationContractVersion]),
     ]
   );
 }
@@ -728,7 +843,7 @@ async function seedFundSnapshot(pool: Pool, fundId: number, type: string): Promi
 
 async function createMigratedDatabase(
   suffix: string,
-  targetVersion: string = MIGRATION_TAG
+  targetVersion: string = CERTIFICATION_MIGRATION_TAG
 ): Promise<{ connectionString: string; state: { applied: Array<{ name: string }> } }> {
   if (!adminPool) throw new Error('Admin pool not initialized.');
   const databaseName = `wp_l3_${suffix}_${process.pid}_${Date.now()}`.toLowerCase();

--- a/tests/integration/migration-drift.test.ts
+++ b/tests/integration/migration-drift.test.ts
@@ -122,14 +122,16 @@ async function publicColumns(
 
 describe.skipIf(skipIfNoDocker)('migration drift guard', () => {
   beforeAll(async () => {
-    postgres = await new PostgreSqlContainer('pgvector/pgvector:pg16')
-      .withDatabase('test_db')
-      .withUsername('test_user')
-      .withPassword('test_password')
-      .withStartupTimeout(STARTUP_TIMEOUT_MS)
-      .start();
-
-    const connectionString = postgres.getConnectionUri();
+    let connectionString = process.env.TEST_DATABASE_URL;
+    if (!connectionString) {
+      postgres = await new PostgreSqlContainer('pgvector/pgvector:pg16')
+        .withDatabase('test_db')
+        .withUsername('test_user')
+        .withPassword('test_password')
+        .withStartupTimeout(STARTUP_TIMEOUT_MS)
+        .start();
+      connectionString = postgres.getConnectionUri();
+    }
     await runMigrationsWithConnectionString(connectionString);
     pool = new Pool({ connectionString, max: 1 });
   }, STARTUP_TIMEOUT_MS * 2);

--- a/tests/integration/prod-schema-clone.test.ts
+++ b/tests/integration/prod-schema-clone.test.ts
@@ -23,6 +23,7 @@ const skipIfNoDocker = !process.env.CI && process.platform === 'win32';
 const execFileAsync = promisify(execFile);
 
 let postgres: StartedPostgreSqlContainer | undefined;
+let baseConnectionString: string | undefined;
 let pool: Pool | undefined;
 let shapePool: Pool | undefined;
 
@@ -182,6 +183,7 @@ const EXPECTED_PRODUCTION_MANIFEST_NAMES = [
   'company-scenario-create-requests',
   'business-time-comparison-lineage',
   'internal-economics-policy-runs',
+  'internal-economics-certification',
 ] as const;
 const SHAPE_ONLY_NOT_JOURNALED = [
   'flag_changes',
@@ -433,11 +435,11 @@ function shapeValueForMismatchKey(catalog: CatalogSnapshot, key: string): ShapeD
 }
 
 function connectionUriForDatabase(databaseName: string): string {
-  if (!postgres) {
-    throw new Error('Postgres container has not started');
+  if (!baseConnectionString) {
+    throw new Error('Postgres connection has not been initialized');
   }
 
-  const url = new URL(postgres.getConnectionUri());
+  const url = new URL(baseConnectionString);
   url.pathname = `/${databaseName}`;
   return url.toString();
 }
@@ -752,14 +754,17 @@ async function publicConstraints(activePool: Pool, constraintNames: readonly str
 
 describe.skipIf(skipIfNoDocker)('prod schema synthetic clone', () => {
   beforeAll(async () => {
-    postgres = await new PostgreSqlContainer('pgvector/pgvector:pg16')
-      .withDatabase('test_db')
-      .withUsername('test_user')
-      .withPassword('test_password')
-      .withStartupTimeout(STARTUP_TIMEOUT_MS)
-      .start();
-
-    const connectionString = postgres.getConnectionUri();
+    let connectionString = process.env.TEST_DATABASE_URL;
+    if (!connectionString) {
+      postgres = await new PostgreSqlContainer('pgvector/pgvector:pg16')
+        .withDatabase('test_db')
+        .withUsername('test_user')
+        .withPassword('test_password')
+        .withStartupTimeout(STARTUP_TIMEOUT_MS)
+        .start();
+      connectionString = postgres.getConnectionUri();
+    }
+    baseConnectionString = connectionString;
     await runMigrationsWithConnectionString(connectionString);
     pool = new Pool({ connectionString, max: 1 });
   }, STARTUP_TIMEOUT_MS * 2);
@@ -1020,12 +1025,12 @@ describe.skipIf(skipIfNoDocker)('prod schema synthetic clone', () => {
   });
 
   it('smoke-runs the s8.1 operator-seam audit script against the journal clone', async () => {
-    expect(postgres).toBeDefined();
+    expect(baseConnectionString).toBeDefined();
     const outPath = path.join(os.tmpdir(), `s81-audit-smoke-${process.pid}-${Date.now()}.json`);
 
     await execFileAsync('node', ['scripts/audit-prod-operator-seam.mjs', '--out', outPath], {
       cwd: process.cwd(),
-      env: { ...process.env, DATABASE_URL: postgres!.getConnectionUri() },
+      env: { ...process.env, DATABASE_URL: baseConnectionString! },
     });
 
     const artifact = JSON.parse(await readFile(outPath, 'utf8')) as {
@@ -1125,12 +1130,12 @@ describe.skipIf(skipIfNoDocker)('prod schema synthetic clone', () => {
     'recovers a production-shaped database with no investment_rounds and replays cleanly',
     async () => {
       expect(pool).toBeDefined();
-      expect(postgres).toBeDefined();
+      expect(baseConnectionString).toBeDefined();
 
       await pool!.query(`DROP DATABASE IF EXISTS "${INVESTMENT_ROUNDS_RECOVERY_DATABASE}"`);
       await pool!.query(`CREATE DATABASE "${INVESTMENT_ROUNDS_RECOVERY_DATABASE}"`);
 
-      const recoveryUrl = new URL(postgres!.getConnectionUri());
+      const recoveryUrl = new URL(baseConnectionString!);
       recoveryUrl.pathname = `/${INVESTMENT_ROUNDS_RECOVERY_DATABASE}`;
       let recoveryPool: Pool | undefined;
 

--- a/tests/unit/contract/internal-economics/lp-economics-run-v1.1.contract.test.ts
+++ b/tests/unit/contract/internal-economics/lp-economics-run-v1.1.contract.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  LpEconomicsIndicativeReasonV1Schema,
+  LpEconomicsResultV1Schema,
+} from '../../../../shared/contracts/internal-economics/lp-economics-run-v1.contract';
+import {
+  LP_ECONOMICS_INDICATIVE_REASON_CODES_V1_1,
+  LP_ECONOMICS_RUN_CONTRACT_VERSION_V1_1,
+  LpEconomicsIndicativeReasonV1_1Schema,
+  LpEconomicsResultV1_1Schema,
+  buildLpEconomicsRunIdempotencyPreimageV1_1,
+  type LpEconomicsRunRequestV1_1,
+} from '../../../../shared/contracts/internal-economics/lp-economics-run-v1.1.contract';
+
+const request = {
+  policyVersionId: 11,
+  factsSnapshotId: 22,
+  planVersionId: 33,
+  forecastSnapshotId: 44,
+  terminalMode: 'hold_unrealized',
+  clock: '2026-06-30T23:59:59.000Z',
+} satisfies LpEconomicsRunRequestV1_1;
+
+const common = {
+  waterfallTemplate: 'deal_by_deal',
+  clock: request.clock,
+  currency: 'USD',
+  perspective: 'lp_net',
+  precisionMode: 'decimal_native_with_float64_xirr',
+} as const;
+
+const zeroTotals = {
+  lpCapitalCallUsd: '0.000000',
+  gpCommitmentCallUsd: '0.000000',
+  portfolioDeploymentUsd: '0.000000',
+  managementFeesUsd: '0.000000',
+  fundExpensesUsd: '0.000000',
+  grossRealizedProceedsUsd: '0.000000',
+  lpCapitalReturnUsd: '0.000000',
+  lpProfitUsd: '0.000000',
+  lpDistributionUsd: '0.000000',
+  gpInvestmentDistributionUsd: '0.000000',
+  gpCarryDistributedUsd: '0.000000',
+  endingCashUsd: '0.000000',
+  grossNavUsd: '0.000000',
+  lpNetNavUsd: '0.000000',
+  dpi: null,
+  rvpi: null,
+  tvpi: null,
+} as const;
+
+const availableResult = {
+  ...common,
+  resultStatus: 'available',
+  quarters: [],
+  waterfallEvents: [],
+  totals: zeroTotals,
+  terminalNavBeforeRealizationUsd: '0.000000',
+  lpNetIrr: null,
+  lpNetIrrBasis: 'cash_only',
+  lpNetIrrDiagnostic: {
+    convergence: 'failed',
+    iterations: 0,
+    method: 'none',
+    boundHit: null,
+    failureReason: 'NO_SIGN_CHANGE',
+  },
+  reasons: [],
+} as const;
+
+describe('lp-economics run V1.1 contract', () => {
+  it('accepts available only through the separate V1.1 result parser', () => {
+    expect(LP_ECONOMICS_RUN_CONTRACT_VERSION_V1_1).toBe('lp-economics/1.1.0');
+    expect(LpEconomicsResultV1_1Schema.safeParse(availableResult).success).toBe(true);
+    expect(LpEconomicsResultV1Schema.safeParse(availableResult).success).toBe(false);
+  });
+
+  it('excludes DECIMAL_CORE_UNCERTIFIED from V1.1 new-emission vocabulary', () => {
+    expect(LP_ECONOMICS_INDICATIVE_REASON_CODES_V1_1).toEqual([
+      'FLOAT64_WATERFALL_PATH',
+      'LP_NET_NAV_FLAT_SHARE_APPROXIMATION',
+    ]);
+    expect(
+      LpEconomicsIndicativeReasonV1_1Schema.safeParse({
+        code: 'DECIMAL_CORE_UNCERTIFIED',
+      }).success
+    ).toBe(false);
+    expect(
+      LpEconomicsIndicativeReasonV1Schema.safeParse({ code: 'DECIMAL_CORE_UNCERTIFIED' }).success
+    ).toBe(true);
+  });
+
+  it('builds the exact V1.1 command preimage from six explicit basis fields', () => {
+    expect(
+      buildLpEconomicsRunIdempotencyPreimageV1_1({
+        fundId: 5,
+        request,
+        engineVersion: 'cash-assembly-period-loop-v1/1.1.0',
+        methodologyVersion: 'cash-assembly-period-loop-methodology/1.1.0',
+      })
+    ).toEqual({
+      commandKind: 'internal-economics-run:create',
+      fundId: 5,
+      contractVersion: 'lp-economics/1.1.0',
+      request,
+      engineVersion: 'cash-assembly-period-loop-v1/1.1.0',
+      methodologyVersion: 'cash-assembly-period-loop-methodology/1.1.0',
+    });
+  });
+});

--- a/tests/unit/internal-economics/cash-assembly-period-loop-v1.test.ts
+++ b/tests/unit/internal-economics/cash-assembly-period-loop-v1.test.ts
@@ -31,6 +31,7 @@ import {
 import {
   CashAssemblyPeriodLoopV1Error,
   executeCashAssemblyPeriodLoopV1,
+  foldCashAssemblyResultStatusV1,
   type ExecuteCashAssemblyPeriodLoopV1Input,
 } from '../../../shared/lib/internal-economics/cash-assembly-period-loop-v1';
 import * as decimalWaterfallCore from '../../../shared/lib/internal-economics/decimal-waterfall-core-v1';
@@ -180,10 +181,7 @@ describe('cash assembly period loop v1 Phase 1', () => {
     expect(result.quarters.every((quarter) => quarter.rvpi === null)).toBe(true);
     expect(result.quarters.every((quarter) => quarter.tvpi === null)).toBe(true);
     expect(result.resultStatus).toBe('indicative');
-    expect(result.resultStatusReasons).toEqual([
-      'DECIMAL_CORE_UNCERTIFIED',
-      'LP_NET_NAV_FLAT_SHARE_APPROXIMATION',
-    ]);
+    expect(result.resultStatusReasons).toEqual(['LP_NET_NAV_FLAT_SHARE_APPROXIMATION']);
   });
 
   it('T1.2 applies every single-quarter recurrence term in the required order', () => {
@@ -1777,7 +1775,25 @@ describe('cash assembly period loop v1 Phase 6', () => {
     expect(forbiddenPaths).toEqual([]);
   });
 
-  it('T6.3 never raises resultStatus above indicative in either terminal mode', () => {
+  it('T6.3 folds eligibility refusal before trust caps, then admits cap-free availability', () => {
+    expect(
+      foldCashAssemblyResultStatusV1({
+        eligibilityRefused: true,
+        trustCapReasons: ['LP_NET_NAV_FLAT_SHARE_APPROXIMATION'],
+      })
+    ).toBe('unavailable');
+    expect(
+      foldCashAssemblyResultStatusV1({
+        eligibilityRefused: false,
+        trustCapReasons: ['LP_NET_NAV_FLAT_SHARE_APPROXIMATION'],
+      })
+    ).toBe('indicative');
+    expect(foldCashAssemblyResultStatusV1({ eligibilityRefused: false, trustCapReasons: [] })).toBe(
+      'available'
+    );
+  });
+
+  it('T6.4 current producer stays indicative in either terminal mode', () => {
     const terminal = forecastPoint('2026-01-01', '2026-03-31', { navUsd: '5.000000' });
     const statuses = (['hold_unrealized', 'liquidate_at_horizon'] as const).map(
       (terminalMode) =>
@@ -1791,7 +1807,7 @@ describe('cash assembly period loop v1 Phase 6', () => {
     expect(statuses).toEqual(['indicative', 'indicative']);
   });
 
-  it('T6.4 keeps loop and core deterministic and free of ambient effects', () => {
+  it('T6.5 keeps loop and core deterministic and free of ambient effects', () => {
     const fixture = permutationFixture();
     const loopInput = {
       forecastSeries: [fixture.actual, fixture.projected],
@@ -1843,16 +1859,13 @@ describe('cash assembly period loop v1 Phase 6', () => {
     }
   });
 
-  it('T6.5 emits exactly the frozen indicative reason pair', () => {
+  it('T6.6 emits only the active flat-share trust cap', () => {
     const terminal = forecastPoint('2026-01-01', '2026-03-31');
     const result = execute({
       forecastSeries: [terminal],
       scheduledNeeds: [scheduledNeed(terminal, ZERO_MONEY)],
     });
 
-    expect(result.resultStatusReasons).toEqual([
-      'DECIMAL_CORE_UNCERTIFIED',
-      'LP_NET_NAV_FLAT_SHARE_APPROXIMATION',
-    ]);
+    expect(result.resultStatusReasons).toEqual(['LP_NET_NAV_FLAT_SHARE_APPROXIMATION']);
   });
 });

--- a/tests/unit/internal-economics/decimal-waterfall-core-v1.property.test.ts
+++ b/tests/unit/internal-economics/decimal-waterfall-core-v1.property.test.ts
@@ -1,0 +1,164 @@
+import fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+
+import type { FundAccountingStateObservationV1_1 } from '../../../shared/contracts/internal-economics/fund-accounting-state-observation-v1.1.contract';
+import { Decimal } from '../../../shared/lib/decimal-config';
+import { computeDecimalWaterfallAllocationV1 } from '../../../shared/lib/internal-economics/decimal-waterfall-core-v1';
+
+const MAX_SUPPORTED_MONEY_MICROS = 9_999_999_999_999_999n;
+
+interface GeneratedCase {
+  readonly openingMicros: bigint;
+  readonly carryUnits: bigint;
+  readonly contributions: readonly {
+    readonly periodIndex: number;
+    readonly amountMicros: bigint;
+  }[];
+  readonly distributions: readonly { readonly periodIndex: number; readonly grossMicros: bigint }[];
+}
+
+function fixedUnsigned(value: bigint, scale: number): string {
+  const divisor = 10n ** BigInt(scale);
+  const whole = value / divisor;
+  const fraction = (value % divisor).toString().padStart(scale, '0');
+  return `${whole}.${fraction}`;
+}
+
+function openingState(openingMicros: bigint): FundAccountingStateObservationV1_1 {
+  const openingMoney = fixedUnsigned(openingMicros, 6);
+  return {
+    contractVersion: 'fund-accounting-state-observation/1.1.0',
+    cutoverInstant: '2026-06-30T23:59:59.000Z',
+    currency: 'USD',
+    cashBalanceUsd: '0.000000',
+    cumulativeLpPaidInUsd: openingMoney,
+    cumulativeGpPaidInUsd: '0.000000',
+    gpUnreturnedContributedCapitalUsd: '0.000000',
+    lpDistributionsReturnOfCapitalUsd: '0.000000',
+    lpDistributionsProfitUsd: '0.000000',
+    actualLpDistributionsCumulativeUsd: '0.000000',
+    gpInvestmentDistributionsPaidUsd: '0.000000',
+    gpCarryPaidUsd: '0.000000',
+    accruedPreferredReturnUsd: '0.000000',
+    accruedPreferredReturnThroughInstant: '2026-06-30T23:59:59.000Z',
+    recallableDistributionsCumulativeUsd: '0.000000',
+    recallableDistributionsOutstandingUsd: '0.000000',
+    recycledProceedsCumulativeUsd: '0.000000',
+    realizedProceedsCumulativeUsd: '0.000000',
+    methodologyVersion: 'opening-state-methodology/1.0.0',
+    lpUnreturnedContributedCapitalUsd: openingMoney,
+  };
+}
+
+const generatedCaseArbitrary: fc.Arbitrary<GeneratedCase> = fc.record({
+  openingMicros: fc.bigInt({ min: 0n, max: MAX_SUPPORTED_MONEY_MICROS }),
+  carryUnits: fc.bigInt({ min: 0n, max: 1_000_000_000_000n }),
+  contributions: fc.array(
+    fc.record({
+      periodIndex: fc.integer({ min: 0, max: 12 }),
+      amountMicros: fc.bigInt({ min: 0n, max: MAX_SUPPORTED_MONEY_MICROS }),
+    }),
+    { maxLength: 6 }
+  ),
+  distributions: fc.array(
+    fc.record({
+      periodIndex: fc.integer({ min: 0, max: 12 }),
+      grossMicros: fc.bigInt({ min: 0n, max: MAX_SUPPORTED_MONEY_MICROS }),
+    }),
+    { maxLength: 6 }
+  ),
+});
+
+const RETAINED_COUNTEREXAMPLES: readonly GeneratedCase[] = [
+  {
+    openingMicros: 0n,
+    carryUnits: 200_000_000_000n,
+    contributions: [
+      { periodIndex: 1, amountMicros: 100_000_000n },
+      { periodIndex: 3, amountMicros: 50_000_000n },
+    ],
+    distributions: [
+      { periodIndex: 2, grossMicros: 200_000_000n },
+      { periodIndex: 4, grossMicros: 50_000_000n },
+    ],
+  },
+  {
+    openingMicros: MAX_SUPPORTED_MONEY_MICROS,
+    carryUnits: 1n,
+    contributions: [{ periodIndex: 1, amountMicros: 1n }],
+    distributions: [{ periodIndex: 1, grossMicros: MAX_SUPPORTED_MONEY_MICROS }],
+  },
+];
+
+describe('Decimal waterfall V1 property certification', () => {
+  it('conserves all generated money with pinned seed, domain, shrinking, and counterexamples', () => {
+    const ReferenceDecimal = Decimal.clone({ precision: 100 });
+
+    fc.assert(
+      fc.property(generatedCaseArbitrary, (generated) => {
+        const contributions = generated.contributions.map((event, index) => ({
+          sourceId: `contribution-${index}`,
+          periodIndex: event.periodIndex,
+          amountUsd: fixedUnsigned(event.amountMicros, 6),
+        }));
+        const distributions = generated.distributions.map((event, index) => ({
+          sourceId: `distribution-${index}`,
+          periodIndex: event.periodIndex,
+          grossUsd: fixedUnsigned(event.grossMicros, 6),
+          isTerminal: false,
+        }));
+        const result = computeDecimalWaterfallAllocationV1({
+          carryRatio: fixedUnsigned(generated.carryUnits, 12),
+          hurdle: { basis: 'none' },
+          openingState: openingState(generated.openingMicros),
+          contributions,
+          distributions,
+        });
+
+        for (const row of result.rows) {
+          expect(row.roc.plus(row.lpProfit).plus(row.gpCarry).eq(row.gross)).toBe(true);
+          expect(row.unreturnedCapitalAfter.gte(0)).toBe(true);
+        }
+
+        const totalContributions = contributions.reduce(
+          (sum, event) => sum.plus(event.amountUsd),
+          new Decimal(0)
+        );
+        const expectedDistributionIds = distributions
+          .map(({ sourceId }) => sourceId)
+          .sort((left, right) => left.localeCompare(right));
+        const actualDistributionIds = result.rows
+          .map(({ sourceId }) => sourceId)
+          .sort((left, right) => left.localeCompare(right));
+        const totalInputGross = distributions.reduce(
+          (sum, event) => sum.plus(event.grossUsd),
+          new ReferenceDecimal(0)
+        );
+        expect(actualDistributionIds).toEqual(expectedDistributionIds);
+        expect(new ReferenceDecimal(result.totals.gross.toFixed()).eq(totalInputGross)).toBe(true);
+        expect(
+          new ReferenceDecimal(result.totals.roc.toFixed())
+            .plus(result.totals.lpProfit.toFixed())
+            .plus(result.totals.gpCarry.toFixed())
+            .eq(result.totals.gross.toFixed())
+        ).toBe(true);
+        expect(
+          result.totals.endingUnreturnedCapital.eq(
+            result.totals.openingUnreturnedCapital.plus(totalContributions).minus(result.totals.roc)
+          )
+        ).toBe(true);
+        expect(
+          result.totals.paidIn.eq(
+            new Decimal(fixedUnsigned(generated.openingMicros, 6)).plus(totalContributions)
+          )
+        ).toBe(true);
+      }),
+      {
+        seed: 1263,
+        numRuns: 500,
+        endOnFailure: false,
+        examples: RETAINED_COUNTEREXAMPLES.map((example) => [example]),
+      }
+    );
+  });
+});

--- a/tests/unit/internal-economics/lp-economics-v1.1-timezone-certification.test.ts
+++ b/tests/unit/internal-economics/lp-economics-v1.1-timezone-certification.test.ts
@@ -1,0 +1,82 @@
+import { execFile } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+import { describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+const TIMEZONES = ['UTC', 'America/New_York', 'Asia/Kolkata'] as const;
+const CERTIFICATION_OUTPUT_PREFIX = 'LP_ECONOMICS_V1_1_CERTIFICATION:';
+
+interface CertificationEvidence {
+  readonly timezone: (typeof TIMEZONES)[number];
+  readonly canonicalResultBytes: string;
+  readonly inputHash: string;
+  readonly resultHash: string;
+}
+
+async function runInFreshProcess(timezone: (typeof TIMEZONES)[number]) {
+  const vitestCli = path.join(process.cwd(), 'node_modules/vitest/vitest.mjs');
+  const config = path.join(process.cwd(), 'tests/fixtures/internal-economics/vitest.config.ts');
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    [
+      vitestCli,
+      'run',
+      '--config',
+      config,
+      '--testNamePattern',
+      'emits representative final V1.1 bytes and hashes',
+    ],
+    {
+      cwd: process.cwd(),
+      env: { ...process.env, TZ: timezone, LP_ECONOMICS_CERTIFICATION_OUTPUT: '1' },
+      maxBuffer: 10 * 1024 * 1024,
+      windowsHide: true,
+    }
+  );
+  const evidenceLine = stdout
+    .split(/\r?\n/u)
+    .find((line) => line.startsWith(CERTIFICATION_OUTPUT_PREFIX));
+  if (evidenceLine === undefined) {
+    throw new Error(`Certification subprocess for ${timezone} emitted no evidence.`);
+  }
+  return JSON.parse(
+    evidenceLine.slice(CERTIFICATION_OUTPUT_PREFIX.length)
+  ) as CertificationEvidence;
+}
+
+describe('V1.1 full-result timezone certification', () => {
+  it('pins identical canonical bytes and hashes from fresh UTC, New York, and Kolkata processes', async () => {
+    const evidence = await Promise.all(TIMEZONES.map(runInFreshProcess));
+    expect(evidence.map(({ timezone }) => timezone)).toEqual(TIMEZONES);
+
+    const [reference, ...comparisons] = evidence;
+    expect(reference).toBeDefined();
+    for (const comparison of comparisons) {
+      expect(Buffer.from(comparison.canonicalResultBytes)).toEqual(
+        Buffer.from(reference!.canonicalResultBytes)
+      );
+      expect(comparison.inputHash).toBe(reference!.inputHash);
+      expect(comparison.resultHash).toBe(reference!.resultHash);
+    }
+
+    expect(createHash('sha256').update(reference!.canonicalResultBytes, 'utf8').digest('hex')).toBe(
+      reference!.resultHash
+    );
+    expect(reference).toMatchObject({
+      inputHash: '95753293e0bb10c38c3e78d9e6ffdd72f194278d646bec73c65af82ae8b0811b',
+      resultHash: 'd646867ffa1c1eb73ad36d607463748d8500bcd49d07ebb8e4dc96ae67447cd6',
+    });
+
+    const result = JSON.parse(reference!.canonicalResultBytes) as Record<string, unknown>;
+    expect(result).toMatchObject({
+      clock: '2026-12-31T23:59:59.000Z',
+      precisionMode: 'decimal_native_with_float64_xirr',
+      resultStatus: 'indicative',
+      reasons: [{ code: 'LP_NET_NAV_FLAT_SHARE_APPROXIMATION' }],
+      terminalNavBeforeRealizationUsd: '20.000000',
+    });
+  });
+});

--- a/tests/unit/migration-ledger.test.ts
+++ b/tests/unit/migration-ledger.test.ts
@@ -56,6 +56,7 @@ const expectedJournaledDriftPatchFiles = [
   '0043_position_source_basis_reliefs.sql',
   '0044_internal_analysis.sql',
   '0045_internal_economics_policy_runs.sql',
+  '0046_internal_economics_certification.sql',
 ].sort();
 
 afterEach(() => {
@@ -166,6 +167,18 @@ describe('migration ledger helpers', () => {
     expect(entry).toMatchObject({
       idx: 46,
       tag: '0045_internal_economics_policy_runs',
+      breakpoints: true,
+    });
+  });
+
+  it('pins internal economics certification migration to its own journal index 47 entry', () => {
+    const entry = readDrizzleJournal(repoRoot).entries.find(
+      (candidate) => candidate.tag === '0046_internal_economics_certification'
+    );
+
+    expect(entry).toMatchObject({
+      idx: 47,
+      tag: '0046_internal_economics_certification',
       breakpoints: true,
     });
   });

--- a/tests/unit/prod-schema-manifest-sentinels.test.ts
+++ b/tests/unit/prod-schema-manifest-sentinels.test.ts
@@ -41,6 +41,8 @@ interface DropObject {
 
 interface Manifest {
   name: string;
+  order?: number;
+  missingTablePolicy?: 'create_or_repair' | 'existing_table_required';
   sqlFiles?: string[];
   allowedCreateTables?: string[];
   expectedTables?: ManifestTable[];
@@ -140,6 +142,39 @@ describe('prod-schema manifest sentinels', () => {
       '20-company-scenario-create-requests.json',
       '21-business-time-comparison-lineage.json',
       '22-internal-economics-policy-runs.json',
+      '23-internal-economics-certification.json',
+    ]);
+  });
+
+  it('pins manifest 23 to additive certification DDL on the existing run table', () => {
+    const certification = manifests.find(
+      (entry) => entry.file === '23-internal-economics-certification.json'
+    );
+    expect(certification).toBeDefined();
+    expect(certification!.manifest).toMatchObject({
+      name: 'internal-economics-certification',
+      order: 23,
+      missingTablePolicy: 'existing_table_required',
+      sqlFiles: ['migrations/0046_internal_economics_certification.sql'],
+      allowedCreateTables: [],
+    });
+
+    const runTable = certification!.manifest.expectedTables?.find(
+      (table) => table.name === 'internal_lp_economics_runs'
+    );
+    expect(runTable).toMatchObject({
+      columns: [{ name: 'calculation_contract_version', type: 'text', nullable: true }],
+      constraints: ['internal_lp_economics_runs_result_status_check'],
+    });
+
+    const replacement = certification!.manifest.applyPolicy?.allowConstraintReplacements?.find(
+      (candidate) => candidate.name === 'internal_lp_economics_runs_result_status_check'
+    );
+    expect(replacement?.table).toBe('internal_lp_economics_runs');
+    expect(replacement?.expectedDefinition.stringLiterals).toEqual([
+      'available',
+      'indicative',
+      'unavailable',
     ]);
   });
 

--- a/tests/unit/schema/internal-economics-schema.test.ts
+++ b/tests/unit/schema/internal-economics-schema.test.ts
@@ -1,10 +1,11 @@
 /**
- * T-A4 (WP-L3 Phase A): Drizzle parity for migration 0045.
+ * T-A4 (WP-L3 Phase A + Trust-Spine PR1): Drizzle parity for migrations 0045/0046.
  *
  * The schema module `shared/schema/internal-economics.ts` must match
- * `migrations/0045_internal_economics_policy_runs.sql` name-for-name so the
- * journaled migration and a Drizzle push produce byte-identical catalogs (G5
- * idiom). Composite-FK targets are declared as plain `unique()` constraints,
+ * `migrations/0045_internal_economics_policy_runs.sql` plus the additive 0046
+ * certification migration name-for-name so the journaled migrations and a
+ * Drizzle push produce catalog-equivalent schemas (G5 idiom). Composite-FK
+ * targets are declared as plain `unique()` constraints,
  * never `uniqueIndex` (drizzle-kit 42830 lesson); the ONE partial unique
  * (`internal_lp_economics_runs_result_snapshot_unique`) is correctly a
  * `uniqueIndex().where(...)` because nothing FKs it.
@@ -29,6 +30,11 @@ const MIGRATION_PATH = path.join(
   process.cwd(),
   'migrations',
   '0045_internal_economics_policy_runs.sql'
+);
+const CERTIFICATION_MIGRATION_PATH = path.join(
+  process.cwd(),
+  'migrations',
+  '0046_internal_economics_certification.sql'
 );
 
 const tableEntries = [
@@ -75,6 +81,10 @@ function migrationSql(): string {
   return fs.readFileSync(MIGRATION_PATH, 'utf8');
 }
 
+function certificationMigrationSql(): string {
+  return fs.readFileSync(CERTIFICATION_MIGRATION_PATH, 'utf8');
+}
+
 interface MigrationTableBlock {
   readonly name: string;
   readonly body: string;
@@ -105,9 +115,13 @@ function sqlConstraintNames(tableName: OwnedTableName): string[] {
 }
 
 function sqlColumnNames(tableName: OwnedTableName): string[] {
-  return [...blockFor(tableName).body.matchAll(/^\s{2}"([a-z0-9_]+)"\s/gm)].map(
+  const baseColumns = [...blockFor(tableName).body.matchAll(/^\s{2}"([a-z0-9_]+)"\s/gm)].map(
     (match) => match[1]!
   );
+  if (tableName === 'internal_lp_economics_runs') {
+    baseColumns.push('calculation_contract_version');
+  }
+  return baseColumns;
 }
 
 function normalizeTypeText(value: string): string {
@@ -145,7 +159,11 @@ describe('internal economics Drizzle schema (T-A4)', () => {
 
   it('declares every column with the exact journaled SQL type', () => {
     for (const [tableName] of tableEntries) {
-      const body = normalizeTypeText(blockFor(tableName).body);
+      const body = normalizeTypeText(
+        `${blockFor(tableName).body}\n${
+          tableName === 'internal_lp_economics_runs' ? certificationMigrationSql() : ''
+        }`
+      );
       for (const column of configFor(tableName).columns) {
         const sqlType = normalizeTypeText(column.getSQLType());
         expect(body, `${tableName}.${column.name} type drift`).toContain(
@@ -255,7 +273,7 @@ describe('internal economics Drizzle schema (T-A4)', () => {
     );
   });
 
-  it('pins the P-D5 state-coupling and literal CHECK vocabularies', () => {
+  it('pins the state-coupling and certified trust-state CHECK vocabularies', () => {
     const coupling = checkSql(
       'internal_lp_economics_runs',
       'internal_lp_economics_runs_state_coupling_check'
@@ -277,9 +295,23 @@ describe('internal economics Drizzle schema (T-A4)', () => {
       'internal_lp_economics_runs',
       'internal_lp_economics_runs_result_status_check'
     );
+    expect(resultStatus).toContain("'available'");
     expect(resultStatus).toContain("'indicative'");
     expect(resultStatus).toContain("'unavailable'");
-    expect(resultStatus).not.toContain("'available'");
+
+    const runColumns = configFor('internal_lp_economics_runs').columns;
+    const calculationContractVersion = runColumns.find(
+      (column) => column.name === 'calculation_contract_version'
+    );
+    expect(calculationContractVersion?.getSQLType()).toBe('text');
+    expect(calculationContractVersion?.notNull).toBe(false);
+
+    const certificationSql = certificationMigrationSql();
+    expect(certificationSql).toContain(
+      'COMMENT ON COLUMN "internal_lp_economics_runs"."calculation_contract_version"'
+    );
+    expect(certificationSql).toContain('null is legacy-only and requires registry verification');
+    expect(certificationSql).not.toMatch(/^\s*(?:UPDATE|INSERT|DELETE|TRUNCATE)\b/im);
 
     expect(
       checkSql('internal_lp_economics_runs', 'internal_lp_economics_runs_terminal_mode_check')

--- a/tests/unit/services/internal-economics/lp-economics-run-service.test.ts
+++ b/tests/unit/services/internal-economics/lp-economics-run-service.test.ts
@@ -256,6 +256,7 @@ const PERIOD_END = '2026-03-31';
 const ZERO_MONEY = '0.000000';
 const ZERO_RATIO = '0.000000000000';
 const ONE_RATIO = '1.000000000000';
+const CERTIFICATION_OUTPUT_PREFIX = 'LP_ECONOMICS_V1_1_CERTIFICATION:';
 
 /** A syntactically valid (lowercase hex, 64 chars) sha256-shaped fixture. */
 function hex64(index: number): string {
@@ -635,11 +636,94 @@ function goldenRequest(
   };
 }
 
+function canonicalizeForCertification(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map(canonicalizeForCertification);
+  if (value instanceof Date) return value.toJSON();
+
+  const source = value as Record<string, unknown>;
+  return Object.fromEntries(
+    Object.keys(source)
+      .sort()
+      .filter((key) => source[key] !== undefined)
+      .map((key) => [key, canonicalizeForCertification(source[key])])
+  );
+}
+
+function canonicalResultBytesForCertification(value: unknown): string {
+  const serialized = JSON.stringify(canonicalizeForCertification(value));
+  if (serialized === undefined) throw new Error('Certification result must be JSON serializable.');
+  return serialized;
+}
+
 // ---------------------------------------------------------------------------
 // T-C1: completed-indicative happy path.
 // ---------------------------------------------------------------------------
 
 describe('executeLpEconomicsRun -- T-C1 indicative happy path', () => {
+  it('emits representative final V1.1 bytes and hashes for the timezone certification subprocess', async () => {
+    const fakeDb = new FakeRunDb();
+    seedGoldenFixture(fakeDb);
+
+    const certificationSeries = [
+      ['2026-01-01', '2026-03-31', '100.000000', ZERO_MONEY, ZERO_MONEY],
+      ['2026-04-01', '2026-06-30', '125.000000', '180.000000', ZERO_MONEY],
+      ['2026-07-01', '2026-09-30', '150.000000', '10.000000', ZERO_MONEY],
+      ['2026-10-01', '2026-12-31', '150.000000', ZERO_MONEY, '20.000000'],
+    ].map(([periodStart, periodEnd, deployedUsd, distributionsUsd, navUsd]) => ({
+      periodStart: periodStart!,
+      periodEnd: periodEnd!,
+      source: 'projected' as const,
+      deployedUsd: deployedUsd!,
+      contributionsUsd: ZERO_MONEY,
+      distributionsUsd: distributionsUsd!,
+      navUsd: navUsd!,
+      tvpi: ZERO_RATIO,
+      dpi: ZERO_RATIO,
+      activeCompanyCount: 0,
+      projectedCohortCount: 0,
+    }));
+    const policy = fakeDb.policyRows[0]!;
+    policy['policyBody'] = {
+      ...(policy['policyBody'] as Record<string, unknown>),
+      fundLifeYears: '5.75',
+    };
+    policy['terminalPeriodEnd'] = '2026-12-31';
+    const forecast = fakeDb.fundSnapshotRows[0]!;
+    forecast['payload'] = {
+      ...(forecast['payload'] as Record<string, unknown>),
+      series: certificationSeries,
+    };
+
+    const receipt = await executeLpEconomicsRun({
+      fundId: FUND_ID,
+      actorId: ACTOR_ID,
+      idempotencyKey: 'run-v1.1-timezone-certification',
+      request: goldenRequest({ clock: '2026-12-31T23:59:59.000Z' }),
+      database: fakeDb.asDatabase(),
+    });
+
+    expect(receipt.result).toMatchObject({
+      clock: '2026-12-31T23:59:59.000Z',
+      resultStatus: 'indicative',
+      terminalNavBeforeRealizationUsd: '20.000000',
+    });
+    expect(receipt.run.inputHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(receipt.run.resultHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(receipt.run.resultHash).toBe(canonicalSha256(receipt.result));
+
+    if (process.env['LP_ECONOMICS_CERTIFICATION_OUTPUT'] === '1') {
+      process.stdout.write(
+        `${CERTIFICATION_OUTPUT_PREFIX}${JSON.stringify({
+          timezone: process.env['TZ'] ?? null,
+          canonicalResultBytes: canonicalResultBytesForCertification(receipt.result),
+          inputHash: receipt.run.inputHash,
+          resultHash: receipt.run.resultHash,
+        })}\n`
+      );
+    }
+  });
+
   it('persists one run row + one snapshot in a single transaction, with a stable result_hash across replay', async () => {
     const fakeDb = new FakeRunDb();
     seedGoldenFixture(fakeDb);

--- a/tests/unit/services/internal-economics/lp-economics-run-service.test.ts
+++ b/tests/unit/services/internal-economics/lp-economics-run-service.test.ts
@@ -1643,7 +1643,7 @@ describe('getRunWithResult -- T-C9 lineage read joins + type/ownership', () => {
     const receipt = await executeLpEconomicsRun({
       fundId: FUND_ID,
       actorId: ACTOR_ID,
-      idempotencyKey: 'explicit-v1-failed',
+      idempotencyKey: 'test-v1-fail',
       request: goldenRequest(),
       database: fakeDb.asDatabase(),
     });
@@ -1849,7 +1849,7 @@ describe('executeLpEconomicsRun -- T-C13 event enrichment structural correctness
     const receipt = await executeLpEconomicsRun({
       fundId: FUND_ID,
       actorId: ACTOR_ID,
-      idempotencyKey: 'tc13-ordinary',
+      idempotencyKey: 'test-case-13',
       request: goldenRequest(),
       database: fakeDb.asDatabase(),
     });
@@ -2039,7 +2039,7 @@ describe('executeLpEconomicsRun -- T-C16 SQLSTATE 40001 retry', () => {
       executeLpEconomicsRun({
         fundId: FUND_ID,
         actorId: ACTOR_ID,
-        idempotencyKey: 'tc16-exhausted',
+        idempotencyKey: 'test-case-16',
         request: goldenRequest(),
         database: fakeDb.asDatabase(),
       })

--- a/tests/unit/services/internal-economics/lp-economics-run-service.test.ts
+++ b/tests/unit/services/internal-economics/lp-economics-run-service.test.ts
@@ -51,11 +51,12 @@ import {
   TerminalPolicyV1Error,
   INTERNAL_ECONOMICS_TERMINAL_RESOLUTION_VERSION,
 } from '../../../../shared/contracts/internal-economics/terminal-policy-v1.contract';
+import { LP_ECONOMICS_RUN_CONTRACT_VERSION as LEGACY_LP_ECONOMICS_RUN_CONTRACT_VERSION } from '../../../../shared/contracts/internal-economics/lp-economics-run-v1.contract';
 import {
-  LP_ECONOMICS_RUN_CONTRACT_VERSION,
-  LpEconomicsRunRequestV1Schema,
-  type LpEconomicsRunRequestV1,
-} from '../../../../shared/contracts/internal-economics/lp-economics-run-v1.contract';
+  LP_ECONOMICS_RUN_CONTRACT_VERSION_V1_1,
+  LpEconomicsRunRequestV1_1Schema,
+  type LpEconomicsRunRequestV1_1,
+} from '../../../../shared/contracts/internal-economics/lp-economics-run-v1.1.contract';
 import {
   internalCapitalEnvelopeVersions,
   internalEconomicsPolicyVersions,
@@ -620,7 +621,9 @@ function seedGoldenFixture(fakeDb: FakeRunDb): GoldenFixtureIds {
   };
 }
 
-function goldenRequest(overrides: Partial<LpEconomicsRunRequestV1> = {}): LpEconomicsRunRequestV1 {
+function goldenRequest(
+  overrides: Partial<LpEconomicsRunRequestV1_1> = {}
+): LpEconomicsRunRequestV1_1 {
   return {
     policyVersionId: 1,
     factsSnapshotId: 1,
@@ -651,10 +654,27 @@ describe('executeLpEconomicsRun -- T-C1 indicative happy path', () => {
 
     expect(receipt.run.runState).toBe('completed');
     expect(receipt.run.resultStatus).toBe('indicative');
+    expect(receipt.run.calculationContractVersion).toBe('lp-economics/1.1.0');
     expect(receipt.run.resultSnapshotId).not.toBeNull();
     expect(receipt.run.failureCode).toBeNull();
     expect(receipt.run.engineVersion).toBe(LP_ECONOMICS_RUN_ENGINE_VERSION);
     expect(receipt.run.methodologyVersion).toBe(LP_ECONOMICS_RUN_METHODOLOGY_VERSION);
+    expect(LP_ECONOMICS_RUN_CONTRACT_VERSION_V1_1).toBe('lp-economics/1.1.0');
+    expect(LP_ECONOMICS_RUN_ENGINE_VERSION).toBe('cash-assembly-period-loop-v1/1.1.0');
+    expect(LP_ECONOMICS_RUN_METHODOLOGY_VERSION).toBe(
+      'cash-assembly-period-loop-methodology/1.1.0'
+    );
+    expect(LP_ECONOMICS_RESULT_CALC_VERSION).toBe('lp-economics/1.1.0');
+    expect(receipt.run.requestHash).toBe(
+      canonicalSha256({
+        commandKind: 'internal-economics-run:create',
+        fundId: FUND_ID,
+        contractVersion: 'lp-economics/1.1.0',
+        request: goldenRequest(),
+        engineVersion: 'cash-assembly-period-loop-v1/1.1.0',
+        methodologyVersion: 'cash-assembly-period-loop-methodology/1.1.0',
+      })
+    );
     expect(receipt.result).not.toBeNull();
     expect(receipt.result?.resultStatus).toBe('indicative');
     expect(fakeDb.fundSnapshotRows).toHaveLength(2); // seeded forecast + persisted result
@@ -669,17 +689,44 @@ describe('executeLpEconomicsRun -- T-C1 indicative happy path', () => {
 
     const replay = await executeLpEconomicsRun({
       fundId: FUND_ID,
-      actorId: ACTOR_ID,
+      actorId: ACTOR_ID + 1,
       idempotencyKey: 'run-golden-1',
       request: goldenRequest(),
       database: fakeDb.asDatabase(),
     });
 
     expect(replay.run.id).toBe(receipt.run.id);
+    expect(replay.run.createdBy).toBe(ACTOR_ID);
     expect(replay.run.resultHash).toBe(receipt.run.resultHash);
     expect(replay.result).toEqual(receipt.result);
     expect(fakeDb.runRows).toHaveLength(1);
     expect(fakeDb.fundSnapshotRows).toHaveLength(2);
+  });
+
+  it('persists DB status from a validated cap-free V1.1 value payload', async () => {
+    const fakeDb = new FakeRunDb();
+    seedGoldenFixture(fakeDb);
+    const originalLoop = cashAssemblyPeriodLoopModule.executeCashAssemblyPeriodLoopV1;
+    const spy = vi
+      .spyOn(cashAssemblyPeriodLoopModule, 'executeCashAssemblyPeriodLoopV1')
+      .mockImplementation((input) => ({
+        ...originalLoop(input),
+        resultStatus: 'available',
+        resultStatusReasons: [],
+      }));
+
+    const receipt = await executeLpEconomicsRun({
+      fundId: FUND_ID,
+      actorId: ACTOR_ID,
+      idempotencyKey: 'run-available-status',
+      request: goldenRequest(),
+      database: fakeDb.asDatabase(),
+    });
+    spy.mockRestore();
+
+    expect(receipt.run.resultStatus).toBe('available');
+    expect(receipt.result?.resultStatus).toBe('available');
+    expect(receipt.result?.reasons).toEqual([]);
   });
 });
 
@@ -700,7 +747,7 @@ async function expectUnavailable(
   fakeDb: FakeRunDb,
   idempotencyKey: string,
   expectedCode: string,
-  requestOverrides: Partial<LpEconomicsRunRequestV1> = {}
+  requestOverrides: Partial<LpEconomicsRunRequestV1_1> = {}
 ) {
   const receipt = await executeLpEconomicsRun({
     fundId: FUND_ID,
@@ -711,6 +758,7 @@ async function expectUnavailable(
   });
   expect(receipt.run.runState).toBe('completed');
   expect(receipt.run.resultStatus).toBe('unavailable');
+  expect(receipt.run.calculationContractVersion).toBe('lp-economics/1.1.0');
   expect(receipt.run.failureCode).toBeNull();
   expect(receipt.result?.resultStatus).toBe('unavailable');
   const reasons = receipt.result?.resultStatus === 'unavailable' ? receipt.result.reasons : [];
@@ -1118,6 +1166,7 @@ describe('executeLpEconomicsRun -- T-C3 typed engine failure dispatch (P-D7 step
 
       if (entry.disposition === 'failed') {
         expect(receipt.run.runState).toBe('failed');
+        expect(receipt.run.calculationContractVersion).toBe('lp-economics/1.1.0');
         expect(receipt.run.resultSnapshotId).toBeNull();
         expect(receipt.run.failureCode).toBe(entry.code);
         expect(receipt.result).toBeNull();
@@ -1261,7 +1310,7 @@ describe('executeLpEconomicsRun -- T-C5 no latest-resolution fallback', () => {
   it('the request schema requires every basis ID explicitly (no optional field admits a fallback)', () => {
     const request = goldenRequest() as Record<string, unknown>;
     delete request['factsSnapshotId'];
-    const parsed = LpEconomicsRunRequestV1Schema.safeParse(request);
+    const parsed = LpEconomicsRunRequestV1_1Schema.safeParse(request);
     expect(parsed.success).toBe(false);
   });
 });
@@ -1391,6 +1440,176 @@ describe('getRunWithResult -- T-C9 lineage read joins + type/ownership', () => {
     expect(read.run.runState).toBe('failed');
     expect(read.result).toBeNull();
   });
+
+  it('maps only the exact completed legacy-null tuple to the frozen V1 parser', async () => {
+    const fakeDb = seededDb(() => {});
+    const receipt = await executeLpEconomicsRun({
+      fundId: FUND_ID,
+      actorId: ACTOR_ID,
+      idempotencyKey: 'legacy-null-completed',
+      request: goldenRequest(),
+      database: fakeDb.asDatabase(),
+    });
+    const runRow = fakeDb.runRows.find((row) => row['id'] === receipt.run.id)!;
+    const snapshotRow = fakeDb.fundSnapshotRows.find(
+      (row) => row['id'] === receipt.run.resultSnapshotId
+    )!;
+    runRow['calculationContractVersion'] = null;
+    runRow['engineVersion'] = 'cash-assembly-period-loop-v1/1.0.0';
+    runRow['methodologyVersion'] = 'cash-assembly-period-loop-methodology/1.0.0';
+    snapshotRow['calcVersion'] = 'lp-economics/1.0.0';
+
+    const legacy = await getRunWithResult({
+      fundId: FUND_ID,
+      runId: receipt.run.id,
+      database: fakeDb.asDatabase(),
+    });
+    expect(legacy.result?.resultStatus).toBe('indicative');
+
+    runRow['engineVersion'] = 'cash-assembly-period-loop-v1/9.9.9';
+    await expect(
+      getRunWithResult({
+        fundId: FUND_ID,
+        runId: receipt.run.id,
+        database: fakeDb.asDatabase(),
+      })
+    ).rejects.toMatchObject({
+      status: 500,
+      code: 'UNSUPPORTED_CALCULATION_CONTRACT_VERSION',
+    });
+  });
+
+  it('rejects an explicit V1.0 calculation contract on an otherwise exact completed tuple', async () => {
+    const fakeDb = seededDb(() => {});
+    const receipt = await executeLpEconomicsRun({
+      fundId: FUND_ID,
+      actorId: ACTOR_ID,
+      idempotencyKey: 'explicit-v1-completed',
+      request: goldenRequest(),
+      database: fakeDb.asDatabase(),
+    });
+    const runRow = fakeDb.runRows.find((row) => row['id'] === receipt.run.id)!;
+    const snapshotRow = fakeDb.fundSnapshotRows.find(
+      (row) => row['id'] === receipt.run.resultSnapshotId
+    )!;
+    runRow['calculationContractVersion'] = 'lp-economics/1.0.0';
+    runRow['engineVersion'] = 'cash-assembly-period-loop-v1/1.0.0';
+    runRow['methodologyVersion'] = 'cash-assembly-period-loop-methodology/1.0.0';
+    snapshotRow['calcVersion'] = 'lp-economics/1.0.0';
+
+    await expect(
+      getRunWithResult({
+        fundId: FUND_ID,
+        runId: receipt.run.id,
+        database: fakeDb.asDatabase(),
+      })
+    ).rejects.toMatchObject({
+      status: 500,
+      code: 'UNSUPPORTED_CALCULATION_CONTRACT_VERSION',
+    });
+  });
+
+  it('maps only the exact failed legacy-null tuple with no result snapshot', async () => {
+    const fakeDb = seededDb(() => {});
+    const spy = vi
+      .spyOn(cashAssemblyPeriodLoopModule, 'executeCashAssemblyPeriodLoopV1')
+      .mockImplementation(() => {
+        throw new CashAssemblyPeriodLoopV1Error('CARRY_PCT_INVALID', 'synthetic');
+      });
+    const receipt = await executeLpEconomicsRun({
+      fundId: FUND_ID,
+      actorId: ACTOR_ID,
+      idempotencyKey: 'legacy-null-failed',
+      request: goldenRequest(),
+      database: fakeDb.asDatabase(),
+    });
+    spy.mockRestore();
+    const runRow = fakeDb.runRows.find((row) => row['id'] === receipt.run.id)!;
+    runRow['calculationContractVersion'] = null;
+    runRow['engineVersion'] = 'cash-assembly-period-loop-v1/1.0.0';
+    runRow['methodologyVersion'] = 'cash-assembly-period-loop-methodology/1.0.0';
+
+    const legacy = await getRunWithResult({
+      fundId: FUND_ID,
+      runId: receipt.run.id,
+      database: fakeDb.asDatabase(),
+    });
+    expect(legacy.result).toBeNull();
+
+    runRow['methodologyVersion'] = 'cash-assembly-period-loop-methodology/9.9.9';
+    await expect(
+      getRunWithResult({
+        fundId: FUND_ID,
+        runId: receipt.run.id,
+        database: fakeDb.asDatabase(),
+      })
+    ).rejects.toMatchObject({
+      status: 500,
+      code: 'UNSUPPORTED_CALCULATION_CONTRACT_VERSION',
+    });
+  });
+
+  it('rejects an explicit V1.0 calculation contract on an otherwise exact failed tuple', async () => {
+    const fakeDb = seededDb(() => {});
+    const spy = vi
+      .spyOn(cashAssemblyPeriodLoopModule, 'executeCashAssemblyPeriodLoopV1')
+      .mockImplementation(() => {
+        throw new CashAssemblyPeriodLoopV1Error('CARRY_PCT_INVALID', 'synthetic');
+      });
+    const receipt = await executeLpEconomicsRun({
+      fundId: FUND_ID,
+      actorId: ACTOR_ID,
+      idempotencyKey: 'explicit-v1-failed',
+      request: goldenRequest(),
+      database: fakeDb.asDatabase(),
+    });
+    spy.mockRestore();
+    const runRow = fakeDb.runRows.find((row) => row['id'] === receipt.run.id)!;
+    runRow['calculationContractVersion'] = 'lp-economics/1.0.0';
+    runRow['engineVersion'] = 'cash-assembly-period-loop-v1/1.0.0';
+    runRow['methodologyVersion'] = 'cash-assembly-period-loop-methodology/1.0.0';
+
+    await expect(
+      getRunWithResult({
+        fundId: FUND_ID,
+        runId: receipt.run.id,
+        database: fakeDb.asDatabase(),
+      })
+    ).rejects.toMatchObject({
+      status: 500,
+      code: 'UNSUPPORTED_CALCULATION_CONTRACT_VERSION',
+    });
+  });
+
+  it('fails closed when V1.1 run identity disagrees with result calculation identity', async () => {
+    const fakeDb = seededDb(() => {});
+    const receipt = await executeLpEconomicsRun({
+      fundId: FUND_ID,
+      actorId: ACTOR_ID,
+      idempotencyKey: 'tuple-mismatch',
+      request: goldenRequest(),
+      database: fakeDb.asDatabase(),
+    });
+    const runRow = fakeDb.runRows.find((row) => row['id'] === receipt.run.id)!;
+    const snapshotRow = fakeDb.fundSnapshotRows.find(
+      (row) => row['id'] === receipt.run.resultSnapshotId
+    )!;
+    runRow['calculationContractVersion'] = 'lp-economics/1.1.0';
+    runRow['engineVersion'] = 'cash-assembly-period-loop-v1/1.1.0';
+    runRow['methodologyVersion'] = 'cash-assembly-period-loop-methodology/1.1.0';
+    snapshotRow['calcVersion'] = 'lp-economics/1.0.0';
+
+    await expect(
+      getRunWithResult({
+        fundId: FUND_ID,
+        runId: receipt.run.id,
+        database: fakeDb.asDatabase(),
+      })
+    ).rejects.toMatchObject({
+      status: 500,
+      code: 'UNSUPPORTED_CALCULATION_CONTRACT_VERSION',
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1404,10 +1623,10 @@ describe('executeLpEconomicsRun -- T-C10 engine/methodology version bump', () =>
     const request = goldenRequest();
     const staleRequestHash = canonicalSha256({
       fundId: FUND_ID,
-      contractVersion: LP_ECONOMICS_RUN_CONTRACT_VERSION,
+      contractVersion: LEGACY_LP_ECONOMICS_RUN_CONTRACT_VERSION,
       request,
-      engineVersion: 'cash-assembly-period-loop-v1/0.9.0',
-      methodologyVersion: 'cash-assembly-period-loop-methodology/0.9.0',
+      engineVersion: 'cash-assembly-period-loop-v1/1.0.0',
+      methodologyVersion: 'cash-assembly-period-loop-methodology/1.0.0',
     });
     fakeDb.runRows.push({
       id: 1,
@@ -1420,13 +1639,14 @@ describe('executeLpEconomicsRun -- T-C10 engine/methodology version bump', () =>
       resultSnapshotId: null,
       resultSnapshotType: null,
       runState: 'failed',
+      calculationContractVersion: null,
       resultStatus: null,
       failureCode: 'SOME_OLD_FAILURE',
       failureContext: {},
       evaluationClock: new Date(request.clock),
       terminalMode: request.terminalMode,
-      engineVersion: 'cash-assembly-period-loop-v1/0.9.0',
-      methodologyVersion: 'cash-assembly-period-loop-methodology/0.9.0',
+      engineVersion: 'cash-assembly-period-loop-v1/1.0.0',
+      methodologyVersion: 'cash-assembly-period-loop-methodology/1.0.0',
       inputHash: hex64(17),
       resultHash: null,
       createdBy: ACTOR_ID,
@@ -1635,7 +1855,7 @@ describe('executeLpEconomicsRun -- T-C14 reason order does not affect result_has
       .spyOn(cashAssemblyPeriodLoopModule, 'executeCashAssemblyPeriodLoopV1')
       .mockReturnValueOnce({
         ...baseline,
-        resultStatusReasons: ['DECIMAL_CORE_UNCERTIFIED', 'LP_NET_NAV_FLAT_SHARE_APPROXIMATION'],
+        resultStatusReasons: ['FLOAT64_WATERFALL_PATH', 'LP_NET_NAV_FLAT_SHARE_APPROXIMATION'],
       });
     const receiptA = await executeLpEconomicsRun({
       fundId: FUND_ID,
@@ -1650,7 +1870,7 @@ describe('executeLpEconomicsRun -- T-C14 reason order does not affect result_has
       .spyOn(cashAssemblyPeriodLoopModule, 'executeCashAssemblyPeriodLoopV1')
       .mockReturnValueOnce({
         ...baseline,
-        resultStatusReasons: ['LP_NET_NAV_FLAT_SHARE_APPROXIMATION', 'DECIMAL_CORE_UNCERTIFIED'],
+        resultStatusReasons: ['LP_NET_NAV_FLAT_SHARE_APPROXIMATION', 'FLOAT64_WATERFALL_PATH'],
       });
     const receiptB = await executeLpEconomicsRun({
       fundId: FUND_ID,


### PR DESCRIPTION
## Summary

- add versioned internal-economics trust-state persistence and production schema manifest coverage
- execute exact `lp-economics/1.1.0` calculations with fail-closed version handling
- certify Decimal waterfall determinism with property, timezone, hash, and PostgreSQL proofs
- record ADR-065/D-11 certification and retire `DECIMAL_CORE_UNCERTIFIED` from new V1.1 emission

## Why

Internal LP economics needed one auditable trust spine from persisted calculation contract through runtime output. Previous V1.0 rows lacked an explicit calculation-contract field, and Decimal V1.1 could not become certified until exact bytes, version tuples, schema behavior, and independent specialist verdicts were bound to one unchanged candidate SHA.

## Impact

- V1.1 run creation and replay now validate calculation, engine, methodology, and result versions explicitly.
- Legacy null contract versions map to V1.0 only for registered completed or failed tuples; every other tuple fails closed.
- `available` becomes structurally representable, while current flat-share approximation correctly keeps value-bearing results `indicative`.
- Frozen V1.0 parsing, SafeXIRR UTC behavior, sanctioned Float64 XIRR boundary, fee/carry semantics, and migration pins remain preserved.

## Validation

- focused certification: 264/264
- Phoenix truth: 336/336
- calculation gate: 587/587
- full suite: 11,192 passed, 90 skipped
- fresh Testcontainers PostgreSQL: 12/12
- schema drift: 7 surfaces, 100 passes, 0 warnings, 0 errors
- TypeScript, ESLint/guardrails, production build, and `git diff --check`: PASS
- pre-push server suite: 3,747 passed, 51 skipped
- independent final approvals: waterfall-specialist, phoenix-precision-guardian, xirr-fees-validator

Complete final-SHA gate ledger and failure classification: https://github.com/nikhillinit/Updog_restore/issues/1266#issuecomment-5156121228

Related: #1263, #1264, #1265, #1266
