### PR TITLE
feat(economics): add strict versioned run receipts

### DIFF
--- a/server/services/internal-economics/lp-economics-run-service.ts
+++ b/server/services/internal-economics/lp-economics-run-service.ts
@@ -143,6 +143,11 @@ import {
   type LpEconomicsRunRequestV1_1,
 } from '../../../shared/contracts/internal-economics/lp-economics-run-v1.1.contract';
 import {
+  INTERNAL_LP_ECONOMICS_RUN_RECEIPT_VERSION_V1,
+  InternalLpEconomicsRunReceiptV1Schema,
+  type InternalLpEconomicsRunReceiptV1,
+} from '../../../shared/contracts/internal-economics/lp-economics-run-receipt-v1.contract';
+import {
   PersistedFinancialFactsSnapshotV1Schema,
   type PersistedFinancialFactsSnapshotV1,
 } from '../../../shared/contracts/financial-facts-snapshot-v1.contract';
@@ -430,19 +435,25 @@ export interface ExecuteLpEconomicsRunOptions {
   readonly database?: RunDatabase;
 }
 
-export interface LpEconomicsRunReceipt {
-  readonly run: InternalLpEconomicsRunRow;
-  readonly result: LpEconomicsResultV1 | LpEconomicsResultV1_1 | null;
-}
+export type LpEconomicsRunExecution = Readonly<{
+  receipt: InternalLpEconomicsRunReceiptV1;
+  replayed: boolean;
+}>;
+
+type PersistedRunExecution = Readonly<{
+  run: InternalLpEconomicsRunRow;
+  replayed: boolean;
+}>;
 
 export async function executeLpEconomicsRun(
   opts: ExecuteLpEconomicsRunOptions
-): Promise<LpEconomicsRunReceipt> {
+): Promise<LpEconomicsRunExecution> {
   const database = opts.database ?? db;
+  let persisted: PersistedRunExecution | undefined;
 
   for (let attempt = 1; attempt <= RUN_TRANSACTION_MAX_ATTEMPTS; attempt += 1) {
     try {
-      return await database.transaction(
+      persisted = await database.transaction(
         async (transaction) =>
           executeLpEconomicsRunInTransaction({
             opts,
@@ -450,16 +461,23 @@ export async function executeLpEconomicsRun(
           }),
         { isolationLevel: 'repeatable read', accessMode: 'read write' }
       );
+      break;
     } catch (error) {
       const retryable = RETRYABLE_TRANSACTION_SQLSTATES.has(transactionSqlState(error) ?? '');
       if (!retryable || attempt === RUN_TRANSACTION_MAX_ATTEMPTS) throw error;
     }
   }
 
-  throw new Error('Internal LP economics run transaction retry bound was exhausted.');
+  if (persisted === undefined) {
+    throw new Error('Internal LP economics run transaction retry bound was exhausted.');
+  }
+  return {
+    receipt: await buildReceiptFromRunRow(persisted.run, database),
+    replayed: persisted.replayed,
+  };
 }
 
-export interface GetRunWithResultOptions {
+export interface GetLpEconomicsRunReceiptOptions {
   readonly fundId: number;
   readonly runId: number;
   readonly database?: RunDatabase;
@@ -467,9 +485,9 @@ export interface GetRunWithResultOptions {
 
 /** Read surface (section 5's closing paragraph): joins the result snapshot,
  * validates type/ownership (T-C9). */
-export async function getRunWithResult(
-  opts: GetRunWithResultOptions
-): Promise<LpEconomicsRunReceipt> {
+export async function getLpEconomicsRunReceipt(
+  opts: GetLpEconomicsRunReceiptOptions
+): Promise<InternalLpEconomicsRunReceiptV1> {
   const database = opts.database ?? db;
 
   await assertOwnedByFund({
@@ -1248,7 +1266,7 @@ async function insertRunRow(
     readonly failureCode: string | null;
     readonly failureContext: Record<string, unknown> | null;
   }
-): Promise<InternalLpEconomicsRunRow> {
+): Promise<{ readonly row: InternalLpEconomicsRunRow; readonly replayed: boolean }> {
   const loadExistingRun = async (): Promise<{
     row: InternalLpEconomicsRunRow;
     requestHash: string;
@@ -1307,7 +1325,7 @@ async function insertRunRow(
       return inserted ?? null;
     },
   });
-  return result.row;
+  return result;
 }
 
 async function insertResultSnapshot(
@@ -1342,8 +1360,8 @@ async function persistFailedRun(
   common: CommonRunFields,
   failureCode: string,
   failureContext: Record<string, unknown>
-): Promise<LpEconomicsRunReceipt> {
-  const run = await insertRunRow(database, common, {
+): Promise<PersistedRunExecution> {
+  const persisted = await insertRunRow(database, common, {
     runState: 'failed',
     resultSnapshotId: null,
     resultSnapshotType: null,
@@ -1352,7 +1370,7 @@ async function persistFailedRun(
     failureCode,
     failureContext,
   });
-  return { run, result: null };
+  return { run: persisted.row, replayed: persisted.replayed };
 }
 
 // `resultHash` (below and in `persistCompletedRun`) hashes the persisted
@@ -1368,7 +1386,7 @@ async function persistUnavailableRun(
   common: CommonRunFields,
   clock: string,
   reasons: readonly LpEconomicsRunUnavailabilityReasonV1[]
-): Promise<LpEconomicsRunReceipt> {
+): Promise<PersistedRunExecution> {
   const sortedReasons = sortAndDedupeLpEconomicsReasonsV1(reasons);
   const payload = LpEconomicsResultV1_1Schema.parse({
     waterfallTemplate: 'deal_by_deal',
@@ -1384,7 +1402,7 @@ async function persistUnavailableRun(
     clock,
     payload,
   });
-  const run = await insertRunRow(database, common, {
+  const persisted = await insertRunRow(database, common, {
     runState: 'completed',
     resultSnapshotId,
     resultSnapshotType: 'INTERNAL_LP_ECONOMICS',
@@ -1393,7 +1411,7 @@ async function persistUnavailableRun(
     failureCode: null,
     failureContext: null,
   });
-  return { run, result: payload };
+  return { run: persisted.row, replayed: persisted.replayed };
 }
 
 async function persistCompletedRun(
@@ -1401,13 +1419,13 @@ async function persistCompletedRun(
   common: CommonRunFields,
   clock: string,
   payload: LpEconomicsAvailableResultV1_1 | LpEconomicsIndicativeResultV1_1
-): Promise<LpEconomicsRunReceipt> {
+): Promise<PersistedRunExecution> {
   const resultSnapshotId = await insertResultSnapshot(database, {
     fundId: common.fundId,
     clock,
     payload,
   });
-  const run = await insertRunRow(database, common, {
+  const persisted = await insertRunRow(database, common, {
     runState: 'completed',
     resultSnapshotId,
     resultSnapshotType: 'INTERNAL_LP_ECONOMICS',
@@ -1416,50 +1434,105 @@ async function persistCompletedRun(
     failureCode: null,
     failureContext: null,
   });
-  return { run, result: payload };
+  return { run: persisted.row, replayed: persisted.replayed };
 }
 
 async function buildReceiptFromRunRow(
   run: InternalLpEconomicsRunRow,
   database: RunDatabase
-): Promise<LpEconomicsRunReceipt> {
-  if (run.runState === 'failed') {
-    resolvePersistedCalculationContract(run, null);
-    return { run, result: null };
-  }
-  if (run.resultSnapshotId === null) {
+): Promise<InternalLpEconomicsRunReceiptV1> {
+  let resultCalculationVersion: string | null = null;
+  let result: LpEconomicsResultV1 | LpEconomicsResultV1_1 | null = null;
+
+  if (run.runState === 'completed' && run.resultSnapshotId === null) {
     throw new LpEconomicsRunServiceError(
       500,
       'RUN_RESULT_SNAPSHOT_MISSING',
       'The completed run does not carry a result snapshot identity.'
     );
   }
-  const [snapshotRow] = await database
-    .select()
-    .from(fundSnapshots)
-    .where(
-      and(
-        eq(fundSnapshots.id, run.resultSnapshotId),
-        eq(fundSnapshots.fundId, run.fundId),
-        eq(fundSnapshots.type, 'INTERNAL_LP_ECONOMICS')
+  if (run.resultSnapshotId !== null) {
+    await assertOwnedByFund({
+      db: database as unknown as FundScopedOwnershipDatabase,
+      fundId: run.fundId,
+      ref: { kind: 'fund_snapshot', id: run.resultSnapshotId },
+    });
+    const [snapshotRow] = await database
+      .select()
+      .from(fundSnapshots)
+      .where(
+        and(
+          eq(fundSnapshots.id, run.resultSnapshotId),
+          eq(fundSnapshots.fundId, run.fundId),
+          eq(fundSnapshots.type, 'INTERNAL_LP_ECONOMICS')
+        )
       )
-    )
-    .limit(1);
-  if (snapshotRow === undefined) {
-    throw new LpEconomicsRunServiceError(
-      500,
-      'RUN_RESULT_SNAPSHOT_MISSING',
-      'The run result snapshot could not be read back by (id, fund, type).'
-    );
-  }
-  const calculationContract = resolvePersistedCalculationContract(run, snapshotRow.calcVersion);
-  return {
-    run,
-    result:
+      .limit(1);
+    if (snapshotRow === undefined) {
+      throw new LpEconomicsRunServiceError(
+        500,
+        'RUN_RESULT_SNAPSHOT_MISSING',
+        'The run result snapshot could not be read back by (id, fund, type).'
+      );
+    }
+    resultCalculationVersion = snapshotRow.calcVersion;
+    const calculationContract = resolvePersistedCalculationContract(run, resultCalculationVersion);
+    result =
       calculationContract === 'v1.0'
         ? LpEconomicsResultV1Schema.parse(snapshotRow.payload)
-        : LpEconomicsResultV1_1Schema.parse(snapshotRow.payload),
-  };
+        : LpEconomicsResultV1_1Schema.parse(snapshotRow.payload);
+  }
+
+  const calculationContract = resolvePersistedCalculationContract(run, resultCalculationVersion);
+  const policy = await loadPolicyRow(database, run.fundId, run.policyVersionId);
+  const envelope = await loadEnvelopeRow(database, run.fundId, policy.capitalEnvelopeVersionId);
+  const facts = await loadFactsRow(database, run.fundId, run.factsSnapshotId);
+  const plan = await loadPlanRow(database, run.fundId, run.planVersionId);
+  const { forecast } = await loadForecastRow(database, run.fundId, run.forecastSnapshotId);
+
+  return InternalLpEconomicsRunReceiptV1Schema.parse({
+    receiptVersion: INTERNAL_LP_ECONOMICS_RUN_RECEIPT_VERSION_V1,
+    runId: run.id,
+    fundId: run.fundId,
+    createdAt: run.createdAt.toISOString(),
+    basis: {
+      policyVersionId: policy.id,
+      capitalEnvelopeVersionId: envelope.id,
+      factsSnapshotId: facts.id,
+      knowledgeCutoff: facts.knowledgeCutoff,
+      planVersionId: plan.id,
+      forecastSnapshotId: run.forecastSnapshotId,
+      evaluationClock: run.evaluationClock.toISOString(),
+      terminalMode: run.terminalMode,
+      terminalPeriodEnd: policy.terminalPeriodEnd,
+      terminalResolutionMethodologyVersion: policy.terminalResolutionMethodologyVersion,
+    },
+    versions: {
+      calculationContractVersion:
+        calculationContract === 'v1.0'
+          ? LEGACY_LP_ECONOMICS_RESULT_CALC_VERSION
+          : LP_ECONOMICS_RUN_CONTRACT_VERSION_V1_1,
+      engineVersion: run.engineVersion,
+      methodologyVersion: run.methodologyVersion,
+      resultCalculationVersion,
+    },
+    hashes: {
+      capitalEnvelopeHash: envelope.envelopeHash,
+      policyAssumptionsHash: policy.assumptionsHash,
+      factsSnapshotInputHash: facts.snapshotInputHash,
+      planAssumptionsHash: plan.assumptionsHash,
+      forecastInputHash: forecast.inputHash,
+      inputHash: run.inputHash,
+      resultHash: run.resultHash,
+    },
+    outcome:
+      run.runState === 'completed'
+        ? { runState: 'completed', result }
+        : {
+            runState: 'failed',
+            failure: { code: run.failureCode, context: run.failureContext },
+          },
+  });
 }
 
 function resolvePersistedCalculationContract(
@@ -1514,7 +1587,7 @@ function resolvePersistedCalculationContract(
 async function executeLpEconomicsRunInTransaction(params: {
   readonly opts: ExecuteLpEconomicsRunOptions;
   readonly database: RunDatabase;
-}): Promise<LpEconomicsRunReceipt> {
+}): Promise<PersistedRunExecution> {
   const { opts, database } = params;
   const { fundId, request } = opts;
 
@@ -1553,7 +1626,7 @@ async function executeLpEconomicsRunInTransaction(params: {
     },
   });
   if (replay !== null) {
-    return buildReceiptFromRunRow(replay.row, database);
+    return { run: replay.row, replayed: true };
   }
 
   // Step 3: basis reads by explicit IDs only (ADR-065 item 1) with

--- a/server/services/internal-economics/lp-economics-run-service.ts
+++ b/server/services/internal-economics/lp-economics-run-service.ts
@@ -121,14 +121,16 @@ import {
   LpEconomicsResultV1Schema,
   OPENING_STATE_CONTRACT_V1_INELIGIBLE_DETAIL,
   OPENING_STATE_INELIGIBLE_FIELDS_V1,
-  buildLpEconomicsEventIdV1,
-  sortAndDedupeLpEconomicsReasonsV1,
   type LpEconomicsIrrBasisV1,
   type LpEconomicsResultV1,
   type LpEconomicsRunUnavailabilityReasonV1,
   type LpEconomicsTotalsV1,
   type LpEconomicsWaterfallEventV1,
 } from '../../../shared/contracts/internal-economics/lp-economics-run-v1.contract';
+import {
+  buildLpEconomicsEventIdV1,
+  sortAndDedupeLpEconomicsReasonsV1,
+} from '../../../shared/contracts/internal-economics/lp-economics-run-v1.hash';
 import {
   LP_ECONOMICS_RUN_CONTRACT_VERSION_V1_1,
   LpEconomicsIndicativeReasonV1_1Schema,

--- a/shared/contracts/internal-economics/lp-economics-run-receipt-v1.contract.ts
+++ b/shared/contracts/internal-economics/lp-economics-run-receipt-v1.contract.ts
@@ -1,0 +1,268 @@
+import { z } from 'zod';
+
+import {
+  LP_ECONOMICS_RUN_CONTRACT_VERSION,
+  LpEconomicsResultV1Schema,
+} from './lp-economics-run-v1.contract';
+import {
+  LP_ECONOMICS_RUN_CONTRACT_VERSION_V1_1,
+  LpEconomicsResultV1_1Schema,
+} from './lp-economics-run-v1.1.contract';
+import { TerminalModeV1Schema } from './terminal-policy-v1.contract';
+
+export const INTERNAL_LP_ECONOMICS_RUN_RECEIPT_VERSION_V1 =
+  'internal-lp-economics-run-receipt/1.0.0' as const;
+
+export const ALLOWLISTED_LP_ECONOMICS_FAILURE_CODES_V1 = [
+  'FACT_AFTER_CUTOVER',
+  'PARTIAL_PROJECTED_PERIOD',
+  'SCHEDULE_GRID_MISMATCH',
+  'HISTORICAL_RECONCILIATION_MISMATCH',
+  'CORE_ROW_MAPPING_MISMATCH',
+  'TERMINAL_RECONCILIATION_FAILED',
+  'MONOTONICITY_VIOLATION',
+  'CARRY_PCT_INVALID',
+  'PREF_BEARING_UNSUPPORTED_V1',
+  'OPENING_STATE_INVALID',
+  'CARRY_RATIO_INVALID',
+  'EVENT_INPUT_INVALID',
+  'DUPLICATE_EVENT_ID',
+  'CONSERVATION_FAILED',
+  'UNRETURNED_CAPITAL_MONOTONICITY',
+  'FUND_LIFE_GRID_UNREPRESENTABLE',
+  'INVARIANT_VIOLATION',
+  'NEGATIVE_SCHEDULED_AMOUNT',
+  'NONZERO_FEE_EXPENSE_UNSUPPORTED_V1',
+  'INVALID_USD_AMOUNT',
+  'INVALID_TARGET_CENTS',
+  'INVALID_ENTITLEMENT',
+  'NEGATIVE_LRM_SHORTFALL',
+  'OUTPUT_CONSERVATION_FAILED',
+  'FULL_PRECISION_CONSERVATION_FAILED',
+] as const;
+
+export const AllowlistedLpEconomicsFailureCodeV1Schema = z.enum(
+  ALLOWLISTED_LP_ECONOMICS_FAILURE_CODES_V1
+);
+export type AllowlistedLpEconomicsFailureCodeV1 = z.infer<
+  typeof AllowlistedLpEconomicsFailureCodeV1Schema
+>;
+
+export type BoundedJsonSafeFailureValueV1 =
+  | null
+  | boolean
+  | number
+  | string
+  | BoundedJsonSafeFailureValueV1[]
+  | { [key: string]: BoundedJsonSafeFailureValueV1 };
+export type BoundedJsonSafeFailureContextV1 = Readonly<
+  Record<string, BoundedJsonSafeFailureValueV1>
+>;
+
+const FORBIDDEN_FAILURE_CONTEXT_KEY_PARTS = [
+  'persistence',
+  'actor',
+  'createdby',
+  'idempotency',
+  'requesthash',
+  'cache',
+  'redis',
+  'transaction',
+  'storage',
+  'snapshotid',
+  'snapshottype',
+  'correlation',
+  'rawrow',
+  'replay',
+  'xmin',
+] as const;
+
+const utf8Length = (value: string): number => new TextEncoder().encode(value).byteLength;
+const normalizedKey = (key: string): string => key.toLowerCase().replace(/[^a-z0-9]/g, '');
+
+const JsonPrimitiveSchema: z.ZodType<null | boolean | number | string> = z.union([
+  z.null(),
+  z.boolean(),
+  z.number().finite(),
+  z.string(),
+]);
+
+function jsonValueSchemaAtDepth(depth: number): z.ZodType<BoundedJsonSafeFailureValueV1> {
+  if (depth === 3) return JsonPrimitiveSchema;
+  const next = z.lazy(() => jsonValueSchemaAtDepth(depth + 1));
+  const array = z.array(next).max(16);
+  const object = z.record(z.string(), next).superRefine(validateContextObject);
+  return z.union([JsonPrimitiveSchema, array, object]);
+}
+
+function validateContextObject(value: Record<string, unknown>, ctx: z.RefinementCtx): void {
+  const keys = Object.keys(value);
+  if (keys.length > 16) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Failure context objects may have at most 16 keys.' });
+  }
+  for (const key of keys) {
+    if (key.length < 1 || key.length > 64) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: [key], message: 'Failure context keys must contain 1-64 characters.' });
+    }
+    const normalized = normalizedKey(key);
+    if (FORBIDDEN_FAILURE_CONTEXT_KEY_PARTS.some((part) => normalized.includes(part))) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: [key], message: 'Failure context contains forbidden metadata.' });
+    }
+  }
+}
+
+const ContextValueSchema = jsonValueSchemaAtDepth(0).superRefine((value, ctx) => {
+  if (typeof value === 'string' && utf8Length(value) > 512) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Failure context strings may contain at most 512 UTF-8 bytes.' });
+  }
+});
+
+function validateStringByteLimits(
+  value: unknown,
+  ctx: z.RefinementCtx,
+  path: Array<string | number> = []
+): void {
+  if (typeof value === 'string') {
+    if (utf8Length(value) > 512) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path, message: 'Failure context strings may contain at most 512 UTF-8 bytes.' });
+    }
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => validateStringByteLimits(item, ctx, [...path, index]));
+    return;
+  }
+  if (typeof value === 'object' && value !== null) {
+    Object.entries(value).forEach(([key, item]) => validateStringByteLimits(item, ctx, [...path, key]));
+  }
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  if (typeof value === 'object' && value !== null) {
+    return `{${Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => `${JSON.stringify(key)}:${canonicalJson(item)}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export const BoundedJsonSafeFailureContextV1Schema: z.ZodType<BoundedJsonSafeFailureContextV1> = z
+  .record(z.string(), ContextValueSchema)
+  .superRefine((value, ctx) => {
+    validateContextObject(value, ctx);
+    validateStringByteLimits(value, ctx);
+    if (utf8Length(canonicalJson(value)) > 4096) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Failure context may contain at most 4096 canonical UTF-8 bytes.' });
+    }
+  });
+
+const CanonicalTimestampSchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)
+  .datetime({ offset: false, precision: 3 });
+const Sha256Schema = z.string().regex(/^[0-9a-f]{64}$/);
+const PositiveIdSchema = z.number().int().positive();
+
+const BasisSchema = z
+  .object({
+    policyVersionId: PositiveIdSchema,
+    capitalEnvelopeVersionId: PositiveIdSchema,
+    factsSnapshotId: PositiveIdSchema,
+    knowledgeCutoff: CanonicalTimestampSchema,
+    planVersionId: PositiveIdSchema,
+    forecastSnapshotId: PositiveIdSchema,
+    evaluationClock: CanonicalTimestampSchema,
+    terminalMode: TerminalModeV1Schema,
+    terminalPeriodEnd: z.string().date(),
+    terminalResolutionMethodologyVersion: z.string().min(1),
+  })
+  .strict();
+
+const VersionsSchema = z
+  .object({
+    calculationContractVersion: z.enum([
+      LP_ECONOMICS_RUN_CONTRACT_VERSION,
+      LP_ECONOMICS_RUN_CONTRACT_VERSION_V1_1,
+    ]),
+    engineVersion: z.string().min(1),
+    methodologyVersion: z.string().min(1),
+    resultCalculationVersion: z
+      .enum([LP_ECONOMICS_RUN_CONTRACT_VERSION, LP_ECONOMICS_RUN_CONTRACT_VERSION_V1_1])
+      .nullable(),
+  })
+  .strict();
+
+const HashesSchema = z
+  .object({
+    capitalEnvelopeHash: Sha256Schema,
+    policyAssumptionsHash: Sha256Schema,
+    factsSnapshotInputHash: Sha256Schema,
+    planAssumptionsHash: Sha256Schema,
+    forecastInputHash: Sha256Schema,
+    inputHash: Sha256Schema,
+    resultHash: Sha256Schema.nullable(),
+  })
+  .strict();
+
+const OutcomeSchema = z.discriminatedUnion('runState', [
+  z
+    .object({
+      runState: z.literal('completed'),
+      result: z.union([LpEconomicsResultV1Schema, LpEconomicsResultV1_1Schema]),
+    })
+    .strict(),
+  z
+    .object({
+      runState: z.literal('failed'),
+      failure: z
+        .object({
+          code: AllowlistedLpEconomicsFailureCodeV1Schema,
+          context: BoundedJsonSafeFailureContextV1Schema,
+        })
+        .strict(),
+    })
+    .strict(),
+]);
+
+export const InternalLpEconomicsRunReceiptV1Schema = z
+  .object({
+    receiptVersion: z.literal(INTERNAL_LP_ECONOMICS_RUN_RECEIPT_VERSION_V1),
+    runId: PositiveIdSchema,
+    fundId: PositiveIdSchema,
+    createdAt: CanonicalTimestampSchema,
+    basis: BasisSchema,
+    versions: VersionsSchema,
+    hashes: HashesSchema,
+    outcome: OutcomeSchema,
+  })
+  .strict()
+  .superRefine((receipt, ctx) => {
+    if (receipt.outcome.runState === 'failed') {
+      if (receipt.versions.resultCalculationVersion !== null || receipt.hashes.resultHash !== null) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Failed receipts must not carry result version or hash.' });
+      }
+      return;
+    }
+
+    const resultVersion = receipt.versions.resultCalculationVersion;
+    if (resultVersion === null || receipt.hashes.resultHash === null) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Completed receipts require result version and hash.' });
+      return;
+    }
+    if (resultVersion !== receipt.versions.calculationContractVersion) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Calculation and result versions must match exactly.' });
+      return;
+    }
+    const parser = resultVersion === LP_ECONOMICS_RUN_CONTRACT_VERSION
+      ? LpEconomicsResultV1Schema
+      : LpEconomicsResultV1_1Schema;
+    if (!parser.safeParse(receipt.outcome.result).success) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['outcome', 'result'], message: 'Result does not match its exact calculation version.' });
+    }
+  });
+
+export type InternalLpEconomicsRunReceiptV1 = Readonly<
+  z.infer<typeof InternalLpEconomicsRunReceiptV1Schema>
+>;

--- a/shared/contracts/internal-economics/lp-economics-run-v1.contract.ts
+++ b/shared/contracts/internal-economics/lp-economics-run-v1.contract.ts
@@ -43,18 +43,12 @@
  *    block reuses the ADR-010 XIRR diagnostic taxonomy. Money passes
  *    through as canonical 6dp decimal strings, ratios as 12dp; never
  *    `number` round-trips.
- *  - `sortAndDedupeLpEconomicsReasonsV1` — the registry's binding
- *    sort/dedupe rule, applied exactly once at payload construction: sort
- *    key is `code` (ties broken by `detail`, with the dedupe hash as a
- *    final deterministic tiebreak); dedupe identity is the EXPORTED
- *    `canonicalSha256` of the full `{ code, detail, context }` tuple
- *    (section 6 R7 — key-order-insensitive, and context discriminants are
- *    never collapsed by a code-only dedupe).
+ *  - Schema-only result surfaces. Crypto-bearing reason sort/dedupe and
+ *    event-ID helpers live in `lp-economics-run-v1.hash.ts` and are not
+ *    re-exported here.
  *
- * NOTE: this module is crypto-bearing — `canonicalSha256` pulls
- * `node:crypto` (used by the event-id builder and the reason dedupe
- * helper). Client code must import this module TYPE-ONLY (plan section
- * 10(j)); the schema-only sibling contracts stay crypto-free.
+ * NOTE: this module is browser-safe. Runtime hashing belongs to the
+ * server-safe hash sibling so schema consumers never reach `node:crypto`.
  *
  * Governing docs: docs/superpowers/plans/
  * 2026-07-31-task163-wp-l3-service-persistence-plan.md (sections 5, 6, 8;
@@ -66,7 +60,6 @@
  */
 import { z } from 'zod';
 
-import { canonicalSha256 } from '../../lib/canonical-hash';
 import { MoneyDecimalStringSchema, RatioDecimalStringSchema } from '../../lib/decimal-string';
 import type { CashAssemblyWaterfallEventV1 } from '../../lib/internal-economics/cash-assembly-period-loop-v1';
 import type { CashAssemblyQuarterRowV1 } from '../../lib/internal-economics/cash-assembly-types-v1';
@@ -263,55 +256,6 @@ export type LpEconomicsIndicativeReasonV1 = Readonly<
 >;
 
 // ---------------------------------------------------------------------------
-// Reason sort/dedupe (registry rule: exactly once, at payload construction).
-// ---------------------------------------------------------------------------
-
-export interface LpEconomicsReasonTupleV1 {
-  readonly code: string;
-  readonly detail?: string | undefined;
-  readonly context?: Readonly<Record<string, string>> | undefined;
-}
-
-function compareStrings(left: string, right: string): number {
-  if (left < right) return -1;
-  if (left > right) return 1;
-  return 0;
-}
-
-/**
- * Sorts by `code` (ties broken by `detail`, then by the dedupe hash as a
- * final deterministic tiebreak) and dedupes on the `canonicalSha256` of the
- * full `{ code, detail, context }` tuple — key-order-insensitive, so
- * semantically identical contexts collapse while context discriminants
- * (e.g. distinct `OPENING_STATE_INELIGIBLE` fields) always survive.
- */
-export function sortAndDedupeLpEconomicsReasonsV1<T extends LpEconomicsReasonTupleV1>(
-  reasons: readonly T[]
-): readonly T[] {
-  const seen = new Set<string>();
-  const entries: Array<{ reason: T; dedupeKey: string }> = [];
-  for (const reason of reasons) {
-    const dedupeKey = canonicalSha256({
-      code: reason.code,
-      detail: reason.detail,
-      context: reason.context,
-    });
-    if (seen.has(dedupeKey)) continue;
-    seen.add(dedupeKey);
-    entries.push({ reason, dedupeKey });
-  }
-
-  return entries
-    .sort(
-      (left, right) =>
-        compareStrings(left.reason.code, right.reason.code) ||
-        compareStrings(left.reason.detail ?? '', right.reason.detail ?? '') ||
-        compareStrings(left.dedupeKey, right.dedupeKey)
-    )
-    .map((entry) => entry.reason);
-}
-
-// ---------------------------------------------------------------------------
 // D9 value rows: frozen-loop quarter rows verbatim; events + enrichment.
 // ---------------------------------------------------------------------------
 
@@ -377,23 +321,6 @@ export const LpEconomicsWaterfallEventV1Schema = z
 export type LpEconomicsWaterfallEventV1 = Readonly<
   z.infer<typeof LpEconomicsWaterfallEventV1Schema>
 >;
-
-/**
- * Deterministic, basis-only event identity (section 6 R3(a)): a hash of
- * the loop's stable `sourceId`, the event's `periodEnd`, and its array
- * position — identical basis replays produce identical `eventId` values.
- */
-export function buildLpEconomicsEventIdV1(input: {
-  readonly sourceId: string;
-  readonly periodEnd: string;
-  readonly eventSequence: number;
-}): string {
-  return canonicalSha256({
-    sourceId: input.sourceId,
-    periodEnd: input.periodEnd,
-    eventSequence: input.eventSequence,
-  });
-}
 
 /**
  * Section 6(c) totals: (i) quarter-summed flow fields, (ii) the

--- a/shared/contracts/internal-economics/lp-economics-run-v1.hash.ts
+++ b/shared/contracts/internal-economics/lp-economics-run-v1.hash.ts
@@ -1,0 +1,66 @@
+/**
+ * Server-safe hashing helpers for LP economics V1 schemas.
+ *
+ * This module deliberately owns the runtime `canonicalSha256` dependency.
+ * Browser schema consumers must import the V1.0/V1.1 contract modules instead.
+ */
+import { canonicalSha256 } from '../../lib/canonical-hash';
+
+export interface LpEconomicsReasonTupleV1 {
+  readonly code: string;
+  readonly detail?: string | undefined;
+  readonly context?: Readonly<Record<string, string>> | undefined;
+}
+
+function compareStrings(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+/**
+ * Sorts by `code` (ties broken by `detail`, then by the dedupe hash as a
+ * final deterministic tiebreak) and dedupes on the `canonicalSha256` of the
+ * full `{ code, detail, context }` tuple.
+ */
+export function sortAndDedupeLpEconomicsReasonsV1<T extends LpEconomicsReasonTupleV1>(
+  reasons: readonly T[]
+): readonly T[] {
+  const seen = new Set<string>();
+  const entries: Array<{ reason: T; dedupeKey: string }> = [];
+  for (const reason of reasons) {
+    const dedupeKey = canonicalSha256({
+      code: reason.code,
+      detail: reason.detail,
+      context: reason.context,
+    });
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+    entries.push({ reason, dedupeKey });
+  }
+
+  return entries
+    .sort(
+      (left, right) =>
+        compareStrings(left.reason.code, right.reason.code) ||
+        compareStrings(left.reason.detail ?? '', right.reason.detail ?? '') ||
+        compareStrings(left.dedupeKey, right.dedupeKey)
+    )
+    .map((entry) => entry.reason);
+}
+
+/**
+ * Deterministic, basis-only event identity (section 6 R3(a)): a hash of
+ * stable `sourceId`, `periodEnd`, and array position.
+ */
+export function buildLpEconomicsEventIdV1(input: {
+  readonly sourceId: string;
+  readonly periodEnd: string;
+  readonly eventSequence: number;
+}): string {
+  return canonicalSha256({
+    sourceId: input.sourceId,
+    periodEnd: input.periodEnd,
+    eventSequence: input.eventSequence,
+  });
+}

--- a/tests/unit/contract/internal-economics/lp-economics-run-receipt-v1.contract.test.ts
+++ b/tests/unit/contract/internal-economics/lp-economics-run-receipt-v1.contract.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  INTERNAL_LP_ECONOMICS_RUN_RECEIPT_VERSION_V1,
+  InternalLpEconomicsRunReceiptV1Schema,
+} from '../../../../shared/contracts/internal-economics/lp-economics-run-receipt-v1.contract';
+
+const hash = 'a'.repeat(64);
+const unavailableResult = {
+  waterfallTemplate: 'deal_by_deal',
+  resultStatus: 'unavailable',
+  clock: '2026-06-30T23:59:59.000Z',
+  currency: 'USD',
+  perspective: 'lp_net',
+  precisionMode: 'decimal_native_with_float64_xirr',
+  reasons: [{ code: 'MAIN_FUND_VEHICLE_ABSENT' }],
+} as const;
+
+const completedReceipt = {
+  receiptVersion: 'internal-lp-economics-run-receipt/1.0.0',
+  runId: 1,
+  fundId: 2,
+  createdAt: '2026-06-30T23:59:59.000Z',
+  basis: {
+    policyVersionId: 3,
+    capitalEnvelopeVersionId: 4,
+    factsSnapshotId: 5,
+    knowledgeCutoff: '2026-06-30T00:00:00.000Z',
+    planVersionId: 6,
+    forecastSnapshotId: 7,
+    evaluationClock: '2026-06-30T23:59:59.000Z',
+    terminalMode: 'hold_unrealized',
+    terminalPeriodEnd: '2026-09-30',
+    terminalResolutionMethodologyVersion: 'terminal-resolution/1.0.0',
+  },
+  versions: {
+    calculationContractVersion: 'lp-economics/1.1.0',
+    engineVersion: 'cash-assembly-period-loop-v1/1.1.0',
+    methodologyVersion: 'cash-assembly-period-loop-methodology/1.1.0',
+    resultCalculationVersion: 'lp-economics/1.1.0',
+  },
+  hashes: {
+    capitalEnvelopeHash: hash,
+    policyAssumptionsHash: hash,
+    factsSnapshotInputHash: hash,
+    planAssumptionsHash: hash,
+    forecastInputHash: hash,
+    inputHash: hash,
+    resultHash: hash,
+  },
+  outcome: { runState: 'completed', result: unavailableResult },
+} as const;
+
+describe('InternalLpEconomicsRunReceiptV1Schema', () => {
+  it('pins the independent receipt version and accepts an exact completed V1.1 receipt', () => {
+    expect(INTERNAL_LP_ECONOMICS_RUN_RECEIPT_VERSION_V1).toBe(
+      'internal-lp-economics-run-receipt/1.0.0'
+    );
+    expect(InternalLpEconomicsRunReceiptV1Schema.parse(completedReceipt)).toEqual(completedReceipt);
+  });
+
+  it('accepts an exact failed receipt with allowlisted bounded JSON-safe context', () => {
+    const failed = {
+      ...completedReceipt,
+      versions: { ...completedReceipt.versions, resultCalculationVersion: null },
+      hashes: { ...completedReceipt.hashes, resultHash: null },
+      outcome: {
+        runState: 'failed',
+        failure: { code: 'CARRY_PCT_INVALID', context: { field: 'carryPct', nested: [true, 1] } },
+      },
+    };
+    expect(InternalLpEconomicsRunReceiptV1Schema.parse(failed)).toEqual(failed);
+  });
+
+  it('accepts exact legacy V1.0 completed and failed receipts without changing receipt version', () => {
+    const legacyVersions = {
+      calculationContractVersion: 'lp-economics/1.0.0',
+      engineVersion: 'cash-assembly-period-loop-v1/1.0.0',
+      methodologyVersion: 'cash-assembly-period-loop-methodology/1.0.0',
+      resultCalculationVersion: 'lp-economics/1.0.0',
+    } as const;
+    expect(
+      InternalLpEconomicsRunReceiptV1Schema.safeParse({
+        ...completedReceipt,
+        versions: legacyVersions,
+      }).success
+    ).toBe(true);
+    expect(
+      InternalLpEconomicsRunReceiptV1Schema.safeParse({
+        ...completedReceipt,
+        versions: { ...legacyVersions, resultCalculationVersion: null },
+        hashes: { ...completedReceipt.hashes, resultHash: null },
+        outcome: {
+          runState: 'failed',
+          failure: { code: 'CARRY_PCT_INVALID', context: {} },
+        },
+      }).success
+    ).toBe(true);
+  });
+
+  it.each([
+    ['top level', { unexpected: true }],
+    ['basis', { basis: { ...completedReceipt.basis, unexpected: true } }],
+    ['versions', { versions: { ...completedReceipt.versions, unexpected: true } }],
+    ['hashes', { hashes: { ...completedReceipt.hashes, unexpected: true } }],
+    ['outcome', { outcome: { ...completedReceipt.outcome, unexpected: true } }],
+  ])('rejects unknown keys at the %s boundary', (_label, override) => {
+    expect(
+      InternalLpEconomicsRunReceiptV1Schema.safeParse({ ...completedReceipt, ...override }).success
+    ).toBe(false);
+  });
+
+  it('enforces completed/failed nullability and exact calculation/result-version coupling', () => {
+    expect(
+      InternalLpEconomicsRunReceiptV1Schema.safeParse({
+        ...completedReceipt,
+        versions: { ...completedReceipt.versions, resultCalculationVersion: null },
+      }).success
+    ).toBe(false);
+    expect(
+      InternalLpEconomicsRunReceiptV1Schema.safeParse({
+        ...completedReceipt,
+        versions: { ...completedReceipt.versions, resultCalculationVersion: 'lp-economics/1.0.0' },
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects unknown keys inside the failed outcome boundary', () => {
+    expect(
+      InternalLpEconomicsRunReceiptV1Schema.safeParse({
+        ...completedReceipt,
+        versions: { ...completedReceipt.versions, resultCalculationVersion: null },
+        hashes: { ...completedReceipt.hashes, resultHash: null },
+        outcome: {
+          runState: 'failed',
+          failure: { code: 'CARRY_PCT_INVALID', context: {}, unexpected: true },
+        },
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects noncanonical timestamps and hashes', () => {
+    expect(
+      InternalLpEconomicsRunReceiptV1Schema.safeParse({ ...completedReceipt, createdAt: '2026-06-30T23:59:59Z' }).success
+    ).toBe(false);
+    expect(
+      InternalLpEconomicsRunReceiptV1Schema.safeParse({
+        ...completedReceipt,
+        hashes: { ...completedReceipt.hashes, inputHash: 'A'.repeat(64) },
+      }).success
+    ).toBe(false);
+  });
+
+  it.each([
+    ['unknown code', { code: 'NOT_PUBLIC', context: {} }],
+    ['17 object keys', { code: 'CARRY_PCT_INVALID', context: Object.fromEntries(Array.from({ length: 17 }, (_, i) => [`k${i}`, i])) }],
+    ['17 array items', { code: 'CARRY_PCT_INVALID', context: { values: Array(17).fill(null) } }],
+    ['65-character key', { code: 'CARRY_PCT_INVALID', context: { ['k'.repeat(65)]: true } }],
+    ['513-byte string', { code: 'CARRY_PCT_INVALID', context: { detail: 'x'.repeat(513) } }],
+    ['non-finite number', { code: 'CARRY_PCT_INVALID', context: { value: Number.POSITIVE_INFINITY } }],
+    ['depth 4 container', { code: 'CARRY_PCT_INVALID', context: { a: { b: { c: { d: { e: true } } } } } }],
+    ['forbidden nested metadata', { code: 'CARRY_PCT_INVALID', context: { safe: { correlationId: 'secret' } } }],
+  ])('rejects failed context with %s', (_label, failure) => {
+    expect(
+      InternalLpEconomicsRunReceiptV1Schema.safeParse({
+        ...completedReceipt,
+        versions: { ...completedReceipt.versions, resultCalculationVersion: null },
+        hashes: { ...completedReceipt.hashes, resultHash: null },
+        outcome: { runState: 'failed', failure },
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects failure context above 4096 canonical UTF-8 bytes', () => {
+    const context = Object.fromEntries(Array.from({ length: 9 }, (_, i) => [`key${i}`, 'x'.repeat(500)]));
+    expect(
+      InternalLpEconomicsRunReceiptV1Schema.safeParse({
+        ...completedReceipt,
+        versions: { ...completedReceipt.versions, resultCalculationVersion: null },
+        hashes: { ...completedReceipt.hashes, resultHash: null },
+        outcome: { runState: 'failed', failure: { code: 'CARRY_PCT_INVALID', context } },
+      }).success
+    ).toBe(false);
+  });
+});

--- a/tests/unit/contract/internal-economics/lp-economics-run-v1.contract.test.ts
+++ b/tests/unit/contract/internal-economics/lp-economics-run-v1.contract.test.ts
@@ -19,10 +19,12 @@ import {
   LpEconomicsTotalsV1Schema,
   LpEconomicsResultV1Schema,
   buildLpEconomicsRunIdempotencyPreimageV1,
-  buildLpEconomicsEventIdV1,
-  sortAndDedupeLpEconomicsReasonsV1,
   type LpEconomicsRunRequestV1,
 } from '../../../../shared/contracts/internal-economics/lp-economics-run-v1.contract';
+import {
+  buildLpEconomicsEventIdV1,
+  sortAndDedupeLpEconomicsReasonsV1,
+} from '../../../../shared/contracts/internal-economics/lp-economics-run-v1.hash';
 
 const validRequest = {
   policyVersionId: 11,

--- a/tests/unit/contract/internal-economics/lp-economics-schema-browser-runtime.test.tsx
+++ b/tests/unit/contract/internal-economics/lp-economics-schema-browser-runtime.test.tsx
@@ -8,6 +8,7 @@ import {
   LpEconomicsResultV1_1Schema,
   LpEconomicsRunRequestV1_1Schema,
 } from '../../../../shared/contracts/internal-economics/lp-economics-run-v1.1.contract';
+import { InternalLpEconomicsRunReceiptV1Schema } from '../../../../shared/contracts/internal-economics/lp-economics-run-receipt-v1.contract';
 
 const request = {
   policyVersionId: 11,
@@ -37,5 +38,45 @@ describe('LP economics schema browser runtime boundary', () => {
   it('loads and parses V1.1 request and receipt-result surfaces in jsdom', () => {
     expect(LpEconomicsRunRequestV1_1Schema.safeParse(request).success).toBe(true);
     expect(LpEconomicsResultV1_1Schema.safeParse(unavailableReceiptResult).success).toBe(true);
+  });
+
+  it('loads and parses the strict versioned receipt surface in jsdom', () => {
+    const hash = 'a'.repeat(64);
+    expect(
+      InternalLpEconomicsRunReceiptV1Schema.safeParse({
+        receiptVersion: 'internal-lp-economics-run-receipt/1.0.0',
+        runId: 1,
+        fundId: 2,
+        createdAt: request.clock,
+        basis: {
+          policyVersionId: 11,
+          capitalEnvelopeVersionId: 12,
+          factsSnapshotId: 22,
+          knowledgeCutoff: '2026-06-30T00:00:00.000Z',
+          planVersionId: 33,
+          forecastSnapshotId: 44,
+          evaluationClock: request.clock,
+          terminalMode: request.terminalMode,
+          terminalPeriodEnd: '2026-09-30',
+          terminalResolutionMethodologyVersion: 'terminal-resolution/1.0.0',
+        },
+        versions: {
+          calculationContractVersion: 'lp-economics/1.1.0',
+          engineVersion: 'cash-assembly-period-loop-v1/1.1.0',
+          methodologyVersion: 'cash-assembly-period-loop-methodology/1.1.0',
+          resultCalculationVersion: 'lp-economics/1.1.0',
+        },
+        hashes: {
+          capitalEnvelopeHash: hash,
+          policyAssumptionsHash: hash,
+          factsSnapshotInputHash: hash,
+          planAssumptionsHash: hash,
+          forecastInputHash: hash,
+          inputHash: hash,
+          resultHash: hash,
+        },
+        outcome: { runState: 'completed', result: unavailableReceiptResult },
+      }).success
+    ).toBe(true);
   });
 });

--- a/tests/unit/contract/internal-economics/lp-economics-schema-browser-runtime.test.tsx
+++ b/tests/unit/contract/internal-economics/lp-economics-schema-browser-runtime.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  LpEconomicsResultV1Schema,
+  LpEconomicsRunRequestV1Schema,
+} from '../../../../shared/contracts/internal-economics/lp-economics-run-v1.contract';
+import {
+  LpEconomicsResultV1_1Schema,
+  LpEconomicsRunRequestV1_1Schema,
+} from '../../../../shared/contracts/internal-economics/lp-economics-run-v1.1.contract';
+
+const request = {
+  policyVersionId: 11,
+  factsSnapshotId: 22,
+  planVersionId: 33,
+  forecastSnapshotId: 44,
+  terminalMode: 'hold_unrealized',
+  clock: '2026-06-30T23:59:59.000Z',
+} as const;
+
+const unavailableReceiptResult = {
+  waterfallTemplate: 'deal_by_deal',
+  resultStatus: 'unavailable',
+  clock: request.clock,
+  currency: 'USD',
+  perspective: 'lp_net',
+  precisionMode: 'decimal_native_with_float64_xirr',
+  reasons: [{ code: 'MAIN_FUND_VEHICLE_ABSENT' }],
+} as const;
+
+describe('LP economics schema browser runtime boundary', () => {
+  it('loads and parses V1.0 request and receipt-result surfaces in jsdom', () => {
+    expect(LpEconomicsRunRequestV1Schema.safeParse(request).success).toBe(true);
+    expect(LpEconomicsResultV1Schema.safeParse(unavailableReceiptResult).success).toBe(true);
+  });
+
+  it('loads and parses V1.1 request and receipt-result surfaces in jsdom', () => {
+    expect(LpEconomicsRunRequestV1_1Schema.safeParse(request).success).toBe(true);
+    expect(LpEconomicsResultV1_1Schema.safeParse(unavailableReceiptResult).success).toBe(true);
+  });
+});

--- a/tests/unit/services/internal-economics/lp-economics-run-service.test.ts
+++ b/tests/unit/services/internal-economics/lp-economics-run-service.test.ts
@@ -30,8 +30,8 @@ import {
   LP_ECONOMICS_RUN_METHODOLOGY_VERSION,
   MAX_CASH_ASSEMBLY_PERIOD_COUNT,
   MAX_CASH_ASSEMBLY_TOTAL_EVENT_COUNT,
-  executeLpEconomicsRun,
-  getRunWithResult,
+  executeLpEconomicsRun as executeLpEconomicsRunService,
+  getLpEconomicsRunReceipt as getLpEconomicsRunReceiptService,
 } from '../../../../server/services/internal-economics/lp-economics-run-service';
 import { canonicalSha256 } from '../../../../shared/lib/canonical-hash';
 import { Decimal } from '../../../../shared/lib/decimal-config';
@@ -52,15 +52,18 @@ import {
   INTERNAL_ECONOMICS_TERMINAL_RESOLUTION_VERSION,
 } from '../../../../shared/contracts/internal-economics/terminal-policy-v1.contract';
 import { LP_ECONOMICS_RUN_CONTRACT_VERSION as LEGACY_LP_ECONOMICS_RUN_CONTRACT_VERSION } from '../../../../shared/contracts/internal-economics/lp-economics-run-v1.contract';
+import type { LpEconomicsResultV1 } from '../../../../shared/contracts/internal-economics/lp-economics-run-v1.contract';
 import {
   LP_ECONOMICS_RUN_CONTRACT_VERSION_V1_1,
   LpEconomicsRunRequestV1_1Schema,
   type LpEconomicsRunRequestV1_1,
+  type LpEconomicsResultV1_1,
 } from '../../../../shared/contracts/internal-economics/lp-economics-run-v1.1.contract';
 import {
   internalCapitalEnvelopeVersions,
   internalEconomicsPolicyVersions,
   internalLpEconomicsRuns,
+  type InternalLpEconomicsRunRow,
 } from '../../../../shared/schema/internal-economics';
 import { financialFactsSnapshots } from '../../../../shared/schema/financial-facts-snapshots';
 import { currentPlanVersions } from '../../../../shared/schema/current-plans';
@@ -112,6 +115,7 @@ class FakeRunDb {
   transactionAttempts = 0;
   readonly transactionConfigs: Record<string, unknown>[] = [];
   insertSerializationFailuresRemaining = 0;
+  hiddenExistingRunReadsRemaining = 0;
   readonly runInsertAttempts: Record<string, unknown>[] = [];
 
   private readonly mutex = new KeyedMutex();
@@ -229,6 +233,10 @@ class FakeRunDb {
   }
 
   private filterRows(table: unknown, condition: unknown): Record<string, unknown>[] {
+    if (table === internalLpEconomicsRuns && this.hiddenExistingRunReadsRemaining > 0) {
+      this.hiddenExistingRunReadsRemaining -= 1;
+      return [];
+    }
     const rows = this.rowsFor(table);
     const rendered = new PgDialect().sqlToQuery(condition as SQL);
     return rows.filter((row) =>
@@ -237,6 +245,41 @@ class FakeRunDb {
       )
     );
   }
+}
+
+async function executeLpEconomicsRun(
+  opts: Parameters<typeof executeLpEconomicsRunService>[0]
+): Promise<{
+  readonly run: InternalLpEconomicsRunRow;
+  readonly result: LpEconomicsResultV1 | LpEconomicsResultV1_1 | null;
+}> {
+  const execution = await executeLpEconomicsRunService(opts);
+  const fakeDb = opts.database as unknown as FakeRunDb;
+  const run = fakeDb.runRows.find((row) => row['id'] === execution.receipt.runId);
+  if (run === undefined) throw new Error('Test fixture could not resolve persisted run row.');
+  return {
+    run: run as unknown as InternalLpEconomicsRunRow,
+    result:
+      execution.receipt.outcome.runState === 'completed'
+        ? execution.receipt.outcome.result
+        : null,
+  };
+}
+
+async function getRunWithResult(
+  opts: Parameters<typeof getLpEconomicsRunReceiptService>[0]
+): Promise<{
+  readonly run: InternalLpEconomicsRunRow;
+  readonly result: LpEconomicsResultV1 | LpEconomicsResultV1_1 | null;
+}> {
+  const receipt = await getLpEconomicsRunReceiptService(opts);
+  const fakeDb = opts.database as unknown as FakeRunDb;
+  const run = fakeDb.runRows.find((row) => row['id'] === receipt.runId);
+  if (run === undefined) throw new Error('Test fixture could not resolve persisted run row.');
+  return {
+    run: run as unknown as InternalLpEconomicsRunRow,
+    result: receipt.outcome.runState === 'completed' ? receipt.outcome.result : null,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -661,6 +704,59 @@ function canonicalResultBytesForCertification(value: unknown): string {
 // ---------------------------------------------------------------------------
 
 describe('executeLpEconomicsRun -- T-C1 indicative happy path', () => {
+  it('returns only a strict public receipt plus private replay metadata', async () => {
+    const fakeDb = new FakeRunDb();
+    seedGoldenFixture(fakeDb);
+
+    const execution = await executeLpEconomicsRunService({
+      fundId: FUND_ID,
+      actorId: ACTOR_ID,
+      idempotencyKey: 'strict-receipt-shape',
+      request: goldenRequest(),
+      database: fakeDb.asDatabase(),
+    });
+
+    expect(Object.keys(execution).sort()).toEqual(['receipt', 'replayed']);
+    expect(execution).toMatchObject({
+      replayed: false,
+      receipt: {
+        receiptVersion: 'internal-lp-economics-run-receipt/1.0.0',
+        runId: 1,
+        fundId: FUND_ID,
+        outcome: { runState: 'completed' },
+      },
+    });
+    expect(JSON.stringify(execution.receipt)).not.toMatch(
+      /idempotencyKey|requestHash|createdBy|resultSnapshotId|correlationId|replayed/
+    );
+
+    const earlyReplay = await executeLpEconomicsRunService({
+      fundId: FUND_ID,
+      actorId: ACTOR_ID + 1,
+      idempotencyKey: 'strict-receipt-shape',
+      request: goldenRequest(),
+      database: fakeDb.asDatabase(),
+    });
+    expect(earlyReplay).toEqual({ receipt: execution.receipt, replayed: true });
+
+    const read = await getLpEconomicsRunReceiptService({
+      fundId: FUND_ID,
+      runId: execution.receipt.runId,
+      database: fakeDb.asDatabase(),
+    });
+    expect(read).toEqual(execution.receipt);
+
+    fakeDb.hiddenExistingRunReadsRemaining = 1;
+    const conflictReplay = await executeLpEconomicsRunService({
+      fundId: FUND_ID,
+      actorId: ACTOR_ID + 2,
+      idempotencyKey: 'strict-receipt-shape',
+      request: goldenRequest(),
+      database: fakeDb.asDatabase(),
+    });
+    expect(conflictReplay).toEqual({ receipt: execution.receipt, replayed: true });
+  });
+
   it('emits representative final V1.1 bytes and hashes for the timezone certification subprocess', async () => {
     const fakeDb = new FakeRunDb();
     seedGoldenFixture(fakeDb);
@@ -2100,33 +2196,35 @@ describe('executeLpEconomicsRun -- T-C19/T-C20 admission-control bounds', () => 
       (db_.policyRows[0]!['policyBody'] as Record<string, unknown>)['fundLifeYears'] = '55';
     });
 
-    const receipt = await executeLpEconomicsRun({
-      fundId: FUND_ID,
-      actorId: ACTOR_ID,
-      idempotencyKey: 'tc19',
-      request: goldenRequest(),
-      database: fakeDb.asDatabase(),
-    });
+    await expect(
+      executeLpEconomicsRunService({
+        fundId: FUND_ID,
+        actorId: ACTOR_ID,
+        idempotencyKey: 'tc19',
+        request: goldenRequest(),
+        database: fakeDb.asDatabase(),
+      })
+    ).rejects.toThrow();
 
-    expect(receipt.run.runState).toBe('failed');
-    expect(receipt.run.failureCode).toBe('CASH_ASSEMBLY_PERIOD_COUNT_EXCEEDED');
-    expect(receipt.run.failureContext).toMatchObject({
+    expect(fakeDb.runRows[0]?.['runState']).toBe('failed');
+    expect(fakeDb.runRows[0]?.['failureCode']).toBe('CASH_ASSEMBLY_PERIOD_COUNT_EXCEEDED');
+    expect(fakeDb.runRows[0]?.['failureContext']).toMatchObject({
       bound: MAX_CASH_ASSEMBLY_PERIOD_COUNT,
       observed: 201,
     });
-    expect(receipt.result).toBeNull();
     expect(
       fakeDb.fundSnapshotRows.filter((row) => row['type'] === 'INTERNAL_LP_ECONOMICS')
     ).toHaveLength(0);
 
-    const replay = await executeLpEconomicsRun({
-      fundId: FUND_ID,
-      actorId: ACTOR_ID,
-      idempotencyKey: 'tc19',
-      request: goldenRequest(),
-      database: fakeDb.asDatabase(),
-    });
-    expect(replay.run.id).toBe(receipt.run.id);
+    await expect(
+      executeLpEconomicsRunService({
+        fundId: FUND_ID,
+        actorId: ACTOR_ID,
+        idempotencyKey: 'tc19',
+        request: goldenRequest(),
+        database: fakeDb.asDatabase(),
+      })
+    ).rejects.toThrow();
     expect(fakeDb.runRows).toHaveLength(1);
   });
 
@@ -2156,29 +2254,30 @@ describe('executeLpEconomicsRun -- T-C19/T-C20 admission-control bounds', () => 
       };
     });
 
-    const receipt = await executeLpEconomicsRun({
-      fundId: FUND_ID,
-      actorId: ACTOR_ID,
-      idempotencyKey: 'tc20',
-      request: goldenRequest(),
-      database: fakeDb.asDatabase(),
-    });
+    await expect(
+      executeLpEconomicsRunService({
+        fundId: FUND_ID,
+        actorId: ACTOR_ID,
+        idempotencyKey: 'tc20',
+        request: goldenRequest(),
+        database: fakeDb.asDatabase(),
+      })
+    ).rejects.toThrow();
 
-    expect(receipt.run.runState).toBe('failed');
-    expect(receipt.run.failureCode).toBe('CASH_ASSEMBLY_TOTAL_EVENT_COUNT_EXCEEDED');
-    expect(receipt.run.failureContext).toMatchObject({
+    expect(fakeDb.runRows[0]?.['runState']).toBe('failed');
+    expect(fakeDb.runRows[0]?.['failureCode']).toBe('CASH_ASSEMBLY_TOTAL_EVENT_COUNT_EXCEEDED');
+    expect(fakeDb.runRows[0]?.['failureContext']).toMatchObject({
       bound: MAX_CASH_ASSEMBLY_TOTAL_EVENT_COUNT,
     });
-    expect(receipt.result).toBeNull();
-
-    const replay = await executeLpEconomicsRun({
-      fundId: FUND_ID,
-      actorId: ACTOR_ID,
-      idempotencyKey: 'tc20',
-      request: goldenRequest(),
-      database: fakeDb.asDatabase(),
-    });
-    expect(replay.run.id).toBe(receipt.run.id);
+    await expect(
+      executeLpEconomicsRunService({
+        fundId: FUND_ID,
+        actorId: ACTOR_ID,
+        idempotencyKey: 'tc20',
+        request: goldenRequest(),
+        database: fakeDb.asDatabase(),
+      })
+    ).rejects.toThrow();
     expect(fakeDb.runRows).toHaveLength(1);
   });
 });

--- a/tests/unit/source/internal-economics-boundary.test.ts
+++ b/tests/unit/source/internal-economics-boundary.test.ts
@@ -20,6 +20,7 @@ const CONTRACTS_DIR = 'shared/contracts/internal-economics';
 const V1_SCHEMA_PATH = `${CONTRACTS_DIR}/lp-economics-run-v1.contract.ts`;
 const V1_1_SCHEMA_PATH = `${CONTRACTS_DIR}/lp-economics-run-v1.1.contract.ts`;
 const HASH_HELPER_PATH = `${CONTRACTS_DIR}/lp-economics-run-v1.hash.ts`;
+const RECEIPT_PATH = `${CONTRACTS_DIR}/lp-economics-run-receipt-v1.contract.ts`;
 const RUN_SERVICE_PATH = 'server/services/internal-economics/lp-economics-run-service.ts';
 
 const readSource = (relPath: string): string =>
@@ -100,12 +101,24 @@ describe('internal-economics boundary (D4)', () => {
   });
 
   it('keeps V1.0 and V1.1 schema and receipt-result imports outside the Node crypto graph', () => {
-    const graph = collectRuntimeImportGraph([V1_SCHEMA_PATH, V1_1_SCHEMA_PATH]);
+    const graph = collectRuntimeImportGraph([V1_SCHEMA_PATH, V1_1_SCHEMA_PATH, RECEIPT_PATH]);
     for (const [modulePath, source] of graph) {
       expect(source, `${modulePath} imports node:crypto`).not.toMatch(/node:crypto/);
       expect(source, `${modulePath} imports canonical-hash`).not.toMatch(/canonical-hash/);
       expect(source, `${modulePath} references canonicalSha256`).not.toMatch(/canonicalSha256/);
     }
+  });
+
+  it('keeps public service signatures free of persisted Drizzle run rows', () => {
+    const runServiceSource = stripComments(readSource(RUN_SERVICE_PATH));
+    const executionType = runServiceSource.match(
+      /export type LpEconomicsRunExecution = Readonly<\{([\s\S]*?)\}>;/
+    );
+    expect(executionType?.[1]).toMatch(/receipt:[\s\S]*replayed:/);
+    expect(executionType?.[1]).not.toMatch(/InternalLpEconomicsRunRow/);
+    expect(runServiceSource).toMatch(
+      /getLpEconomicsRunReceipt\([\s\S]{0,120}Promise<InternalLpEconomicsRunReceiptV1>/
+    );
   });
 
   it('gives hash-only helpers one dedicated owner and direct server consumers', () => {

--- a/tests/unit/source/internal-economics-boundary.test.ts
+++ b/tests/unit/source/internal-economics-boundary.test.ts
@@ -17,6 +17,42 @@ import { describe, expect, it } from 'vitest';
 
 const LIB_DIR = 'shared/lib/internal-economics';
 const CONTRACTS_DIR = 'shared/contracts/internal-economics';
+const V1_SCHEMA_PATH = `${CONTRACTS_DIR}/lp-economics-run-v1.contract.ts`;
+const V1_1_SCHEMA_PATH = `${CONTRACTS_DIR}/lp-economics-run-v1.1.contract.ts`;
+const HASH_HELPER_PATH = `${CONTRACTS_DIR}/lp-economics-run-v1.hash.ts`;
+const RUN_SERVICE_PATH = 'server/services/internal-economics/lp-economics-run-service.ts';
+
+const readSource = (relPath: string): string =>
+  fs.readFileSync(path.resolve(process.cwd(), relPath), 'utf8');
+
+const stripComments = (source: string): string =>
+  source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+
+const resolveRuntimeImport = (fromPath: string, specifier: string): string | undefined => {
+  if (!specifier.startsWith('.')) return undefined;
+  const basePath = path.resolve(process.cwd(), path.dirname(fromPath), specifier);
+  const candidates = [`${basePath}.ts`, `${basePath}.tsx`, path.join(basePath, 'index.ts')];
+  const resolved = candidates.find((candidate) => fs.existsSync(candidate));
+  return resolved === undefined ? undefined : path.relative(process.cwd(), resolved);
+};
+
+const collectRuntimeImportGraph = (entryPaths: readonly string[]): Map<string, string> => {
+  const graph = new Map<string, string>();
+  const visit = (relPath: string): void => {
+    if (graph.has(relPath)) return;
+    const source = stripComments(readSource(relPath));
+    graph.set(relPath, source);
+
+    const runtimeImportPattern = /import\s+(?!type\b)(?:[^'"]+\s+from\s+)?['"]([^'"]+)['"]/g;
+    for (const match of source.matchAll(runtimeImportPattern)) {
+      const resolved = resolveRuntimeImport(relPath, match[1]!);
+      if (resolved !== undefined) visit(resolved);
+    }
+  };
+
+  for (const entryPath of entryPaths) visit(entryPath);
+  return graph;
+};
 
 const readDir = (relDir: string): Array<{ name: string; source: string }> => {
   const abs = path.resolve(process.cwd(), relDir);
@@ -61,5 +97,34 @@ describe('internal-economics boundary (D4)', () => {
         /american-ledger/
       );
     }
+  });
+
+  it('keeps V1.0 and V1.1 schema and receipt-result imports outside the Node crypto graph', () => {
+    const graph = collectRuntimeImportGraph([V1_SCHEMA_PATH, V1_1_SCHEMA_PATH]);
+    for (const [modulePath, source] of graph) {
+      expect(source, `${modulePath} imports node:crypto`).not.toMatch(/node:crypto/);
+      expect(source, `${modulePath} imports canonical-hash`).not.toMatch(/canonical-hash/);
+      expect(source, `${modulePath} references canonicalSha256`).not.toMatch(/canonicalSha256/);
+    }
+  });
+
+  it('gives hash-only helpers one dedicated owner and direct server consumers', () => {
+    const hashSource = stripComments(readSource(HASH_HELPER_PATH));
+    const v1SchemaSource = stripComments(readSource(V1_SCHEMA_PATH));
+    const v1_1SchemaSource = stripComments(readSource(V1_1_SCHEMA_PATH));
+    const runServiceSource = stripComments(readSource(RUN_SERVICE_PATH));
+
+    expect(hashSource).toMatch(/import\s+\{\s*canonicalSha256\s*\}\s+from\s+['"]\.\.\/\.\.\/lib\/canonical-hash['"]/);
+    expect(hashSource).toMatch(/export function sortAndDedupeLpEconomicsReasonsV1/);
+    expect(hashSource).toMatch(/export function buildLpEconomicsEventIdV1/);
+
+    for (const schemaSource of [v1SchemaSource, v1_1SchemaSource]) {
+      expect(schemaSource).not.toMatch(/sortAndDedupeLpEconomicsReasonsV1/);
+      expect(schemaSource).not.toMatch(/buildLpEconomicsEventIdV1/);
+    }
+
+    expect(runServiceSource).toMatch(
+      /from\s+['"]\.\.\/\.\.\/\.\.\/shared\/contracts\/internal-economics\/lp-economics-run-v1\.hash['"]/
+    );
   });
 });


### PR DESCRIPTION
## Summary

- extract browser-safe deterministic hash helper while preserving exact V1 bytes
- add strict `internal-lp-economics-run-receipt/1.0.0` contract with completed/failed coupling and bounded context
- return private execute transport and shared fund-scoped projection across execute, replay, insert-conflict, and GET paths

## Scope

- no route, migration, calculation, status, registry, manifest, or ADR changes
- implements only #1268 acceptance criteria on completed local #1267 state

## Validation

- focused server: 120/120 passed
- browser-runtime client: 3/3 passed
- TypeScript check, ESLint, production build: PASS
- full UTC suite: 904 files passed, 6 skipped; 11,219 tests passed, 90 skipped
- pre-push gate: 150/150 targeted tests passed
- independent verifier: PASS
- integrator review: APPROVE, no Critical or Important findings
- `git diff --check`: PASS

Related: #1267, #1268