### PR TITLE
feat: link economics evidence to analysis and tasks

### DIFF
--- a/server/lib/database-backed-idempotency-routes.ts
+++ b/server/lib/database-backed-idempotency-routes.ts
@@ -1,8 +1,14 @@
 const INTERNAL_ECONOMICS_RUN_CREATION_PATH =
   /^\/api\/funds\/[^/?#]+\/internal-economics\/runs\/?$/i;
+const TASK_EVIDENCE_LINK_CREATION_PATH =
+  /^\/api\/funds\/[^/?#]+\/tasks\/[^/?#]+\/evidence-links\/?$/i;
 
 export function isDatabaseBackedIdempotencyRoute(method: string, path: string): boolean {
   const pathnameEnd = path.search(/[?#]/);
   const pathname = pathnameEnd === -1 ? path : path.slice(0, pathnameEnd);
-  return method === 'POST' && INTERNAL_ECONOMICS_RUN_CREATION_PATH.test(pathname);
+  return (
+    method === 'POST' &&
+    (INTERNAL_ECONOMICS_RUN_CREATION_PATH.test(pathname) ||
+      TASK_EVIDENCE_LINK_CREATION_PATH.test(pathname))
+  );
 }

--- a/server/route-policy/api-route-policy-registry.ts
+++ b/server/route-policy/api-route-policy-registry.ts
@@ -1887,6 +1887,11 @@ export const EXPLICIT_API_ROUTE_POLICY_ENTRIES: RoutePolicyEntry[] = [
         'Create a manual-period draft; quarterly drafts come from the job_outbox planner.',
       ],
       [
+        'PATCH',
+        '/api/funds/:fundId/internal-analysis/drafts/:draftId/economics-reference',
+        'Attach or clear one completed same-fund economics run under the draft If-Match.',
+      ],
+      [
         'POST',
         '/api/funds/:fundId/internal-analysis/drafts/:draftId/refresh',
         'Advance the cutoff and repin every consumer from ONE facts snapshot (D6); rotates the ETag.',
@@ -2064,6 +2069,7 @@ export const COMMON_API_ROUTE_POLICY_IDS = {
     'api:get:/api/funds/:fundId/internal-analysis/drafts',
     'api:get:/api/funds/:fundId/internal-analysis/drafts/:draftId',
     'api:post:/api/funds/:fundId/internal-analysis/drafts',
+    'api:patch:/api/funds/:fundId/internal-analysis/drafts/:draftId/economics-reference',
     'api:post:/api/funds/:fundId/internal-analysis/drafts/:draftId/refresh',
     'api:post:/api/funds/:fundId/internal-analysis/drafts/:draftId/save',
     'api:get:/api/funds/:fundId/internal-analysis/references',

--- a/server/routes/internal-analysis.ts
+++ b/server/routes/internal-analysis.ts
@@ -23,6 +23,7 @@ import rateLimit from 'express-rate-limit';
 import { toNumber } from '@shared/number';
 import {
   AnalysisDraftCreateRequestSchema,
+  AnalysisDraftEconomicsReferencePatchRequestSchema,
   AnalysisDraftSaveRequestSchema,
   AnalysisPeriodSchema,
   QuarterlyDraftRunRequestSchema,
@@ -58,6 +59,7 @@ import {
   createDraftForPeriod,
   listReferences,
   planQuarterlyDrafts,
+  replaceDraftEconomicsReference,
   refreshDraft,
   saveDraft,
   startCorrectionDraft,
@@ -247,6 +249,49 @@ router.post(
     } catch (error) {
       if (respondToTypedError(error, res)) return undefined;
       routeLog.error({ err: error, fundId }, 'Failed to create analysis draft');
+      throw error;
+    }
+  })
+);
+
+router.patch(
+  '/funds/:fundId/internal-analysis/drafts/:draftId/economics-reference',
+  writeLimiter,
+  requireAuth(),
+  validateFundIdParam,
+  requireFundAccess,
+  routeHandler(async (req: Request, res: Response) => {
+    const fundId = fundIdOf(req);
+    const draftId = Number(req.params['draftId']);
+    if (!Number.isInteger(draftId) || draftId < 1) {
+      return res.status(400).json({ error: 'Invalid parameter', message: 'Invalid draftId' });
+    }
+
+    try {
+      const current = await requireFreshDraft(req, fundId, draftId);
+      const parsed = AnalysisDraftEconomicsReferencePatchRequestSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return res.status(400).json({
+          error: 'invalid_analysis_economics_reference_request',
+          message: 'Invalid analysis economics-reference request',
+          details: parsed.error.flatten(),
+        });
+      }
+
+      const updated = await replaceDraftEconomicsReference(createAnalysisCheckpointPorts(), {
+        fundId,
+        draftId,
+        expectedVersion: current.version,
+        economicsReferenceId: parsed.data.economicsReferenceId,
+      });
+      setETagHeaders(res, draftETag(updated));
+      return res.json({ draft: toDraftContract(updated) });
+    } catch (error) {
+      if (respondToTypedError(error, res)) return undefined;
+      routeLog.error(
+        { err: error, fundId, draftId },
+        'Failed to replace analysis draft economics reference'
+      );
       throw error;
     }
   })

--- a/server/routes/operating-object-tasks.ts
+++ b/server/routes/operating-object-tasks.ts
@@ -7,16 +7,23 @@ import {
   TaskResponseSchema,
   type TaskResponse,
 } from '@shared/contracts/operating-objects/task.contract';
+import { TaskEvidenceLinkCreateRequestSchema } from '@shared/contracts/operating-objects/task-evidence-link.contract';
 import type { Task } from '@shared/schema/operating-objects';
 import { firstString } from '../lib/request-values';
 import { enforceProvidedFundScope } from '../lib/auth/provided-fund-scope';
 import { parseETag, rowVersionETag } from '../lib/http-preconditions';
+import { IdempotentCommandError } from '../lib/idempotent-command';
+import { parseInternalEconomicsIdempotencyKey } from '../lib/internal-economics-idempotency-key';
 import {
   createTask,
   listTasksForFund,
   loadTask,
   updateTask,
 } from '../services/operating-objects/task-service';
+import {
+  TaskEvidenceLinkServiceError,
+  createTaskEvidenceLink,
+} from '../services/operating-objects/task-evidence-link-service';
 
 const router = Router();
 
@@ -97,6 +104,65 @@ router['get']('/api/funds/:fundId/tasks', async (req: Request, res: Response) =>
     return res.status(500).json({ error: 'Failed to list tasks' });
   }
 });
+
+router['post'](
+  '/api/funds/:fundId/tasks/:taskId/evidence-links',
+  async (req: Request, res: Response) => {
+    try {
+      const fundId = parseFundIdParam(firstString(req.params['fundId']));
+      if (fundId === null) {
+        return res.status(400).json({ error: 'Invalid fund ID' });
+      }
+      const taskId = parseFundIdParam(firstString(req.params['taskId']));
+      if (taskId === null) {
+        return res.status(400).json({ error: 'Invalid task ID' });
+      }
+      if (!(await enforceProvidedFundScope(req, res, fundId, { forWrite: true }))) {
+        return;
+      }
+
+      const parsedKey = parseInternalEconomicsIdempotencyKey(req.headers['idempotency-key']);
+      if (parsedKey.kind === 'missing') {
+        return res.status(428).json({
+          error: 'IDEMPOTENCY_KEY_REQUIRED',
+          message: 'Idempotency-Key header is required.',
+        });
+      }
+      if (parsedKey.kind === 'invalid') {
+        return res.status(400).json({
+          error: 'INVALID_IDEMPOTENCY_KEY',
+          message: 'Idempotency-Key must contain 1 to 128 RFC token characters.',
+        });
+      }
+
+      const parsedBody = TaskEvidenceLinkCreateRequestSchema.safeParse(req.body);
+      if (!parsedBody.success) {
+        return res.status(400).json({
+          error: 'INVALID_TASK_EVIDENCE_LINK_BODY',
+          message: 'Request body does not satisfy the task evidence contract.',
+        });
+      }
+
+      const result = await createTaskEvidenceLink({
+        fundId,
+        taskId,
+        target: parsedBody.data.target,
+        actorId: resolveActorId(req),
+        idempotencyKey: parsedKey.value,
+      });
+      res.setHeader('Cache-Control', 'private, no-store');
+      return res.status(result.replayed ? 200 : 201).json(result.evidenceLink);
+    } catch (error) {
+      if (error instanceof TaskEvidenceLinkServiceError) {
+        return res.status(error.statusCode).json({ error: error.code, message: error.message });
+      }
+      if (error instanceof IdempotentCommandError) {
+        return res.status(error.status).json({ error: error.code, message: error.message });
+      }
+      return res.status(500).json({ error: 'Failed to create task evidence link' });
+    }
+  }
+);
 
 // Edit fields + status under optimistic concurrency. Error order mirrors
 // cash-flow-events: parse (400) -> scope (403) -> If-Match present (428) -> body

--- a/server/services/internal-analysis/analysis-checkpoint-service.ts
+++ b/server/services/internal-analysis/analysis-checkpoint-service.ts
@@ -39,6 +39,7 @@ import {
   internalAnalysisReferences,
   internalAnalysisRevisionEvents,
 } from '../../../shared/schema/internal-analysis';
+import { internalLpEconomicsRuns } from '../../../shared/schema/internal-economics';
 import { jobOutbox, type JobOutbox } from '@shared/schema';
 import { db } from '../../db';
 import {
@@ -219,6 +220,12 @@ export interface AnalysisCheckpointPorts {
     draftId: number;
     expectedVersion: number;
     basis: RebuiltBasis;
+  }): Promise<DraftRecord>;
+  replaceDraftEconomicsReference(input: {
+    fundId: number;
+    draftId: number;
+    expectedVersion: number;
+    economicsReferenceId: number | null;
   }): Promise<DraftRecord>;
   /**
    * Insert the reference AND close its draft atomically, under the draft's
@@ -409,12 +416,45 @@ export async function refreshDraft(
       knowledgeCutoff: basis.knowledgeCutoff.toISOString(),
       financialFactsSnapshotId: basis.financialFactsSnapshotId,
       forecastFundSnapshotId: basis.forecastFundSnapshotId,
+      economicsReferenceCleared: draft.economicsReferenceId !== null,
       version: refreshed.version,
     },
     actorId: input.actorId,
   });
 
   return refreshed;
+}
+
+export async function replaceDraftEconomicsReference(
+  ports: AnalysisCheckpointPorts,
+  input: {
+    fundId: number;
+    draftId: number;
+    expectedVersion: number;
+    economicsReferenceId: number | null;
+  }
+): Promise<DraftRecord> {
+  const draft = await ports.getDraftById(input.fundId, input.draftId);
+  if (draft === null) {
+    throw new AnalysisCheckpointServiceError(404, 'DRAFT_NOT_FOUND', 'Analysis draft not found.');
+  }
+  if (draft.savedAt !== null) {
+    throw new AnalysisCheckpointServiceError(
+      409,
+      'DRAFT_ALREADY_SAVED',
+      'A saved draft is immutable. Start a new draft from its reference to correct it.'
+    );
+  }
+  if (draft.version !== input.expectedVersion) {
+    throw new AnalysisCheckpointServiceError(
+      412,
+      'DRAFT_VERSION_CONFLICT',
+      'The draft changed since it was read.',
+      { expectedVersion: input.expectedVersion, currentVersion: draft.version }
+    );
+  }
+
+  return ports.replaceDraftEconomicsReference(input);
 }
 
 /** The components actually pinned on a draft, paired with their persisted basis. */
@@ -789,6 +829,7 @@ export function createAnalysisCheckpointPorts(database: Database = db): Analysis
           knowledgeCutoff: input.basis.knowledgeCutoff,
           financialFactsSnapshotId: input.basis.financialFactsSnapshotId,
           forecastFundSnapshotId: input.basis.forecastFundSnapshotId,
+          economicsReferenceId: null,
           version: sql`${internalAnalysisDrafts.version} + 1`,
           updatedAt: new Date(),
         })
@@ -812,6 +853,88 @@ export function createAnalysisCheckpointPorts(database: Database = db): Analysis
         );
       }
       return toDraftRecord(row);
+    },
+
+    async replaceDraftEconomicsReference(input) {
+      if (input.economicsReferenceId !== null) {
+        const [run] = await database
+          .select({ runState: internalLpEconomicsRuns.runState })
+          .from(internalLpEconomicsRuns)
+          .where(
+            and(
+              eq(internalLpEconomicsRuns.id, input.economicsReferenceId),
+              eq(internalLpEconomicsRuns.fundId, input.fundId)
+            )
+          )
+          .limit(1);
+
+        if (!run) {
+          throw new AnalysisCheckpointServiceError(
+            404,
+            'ECONOMICS_RUN_NOT_FOUND',
+            'Economics run not found.'
+          );
+        }
+        if (run.runState !== 'completed') {
+          throw new AnalysisCheckpointServiceError(
+            409,
+            'ECONOMICS_RUN_NOT_COMPLETED',
+            'Only completed economics runs can be attached.'
+          );
+        }
+      }
+
+      const updated = await database
+        .update(internalAnalysisDrafts)
+        .set({
+          economicsReferenceId: input.economicsReferenceId,
+          version: sql`${internalAnalysisDrafts.version} + 1`,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(internalAnalysisDrafts.id, input.draftId),
+            eq(internalAnalysisDrafts.fundId, input.fundId),
+            eq(internalAnalysisDrafts.version, input.expectedVersion),
+            isNull(internalAnalysisDrafts.savedAt)
+          )
+        )
+        .returning();
+
+      const row = updated[0];
+      if (row) return toDraftRecord(row);
+
+      const [currentRow] = await database
+        .select()
+        .from(internalAnalysisDrafts)
+        .where(
+          and(
+            eq(internalAnalysisDrafts.id, input.draftId),
+            eq(internalAnalysisDrafts.fundId, input.fundId)
+          )
+        )
+        .limit(1);
+      if (!currentRow) {
+        throw new AnalysisCheckpointServiceError(
+          404,
+          'DRAFT_NOT_FOUND',
+          'Analysis draft not found.'
+        );
+      }
+      const current = toDraftRecord(currentRow);
+      if (current.savedAt !== null) {
+        throw new AnalysisCheckpointServiceError(
+          409,
+          'DRAFT_ALREADY_SAVED',
+          'A saved draft is immutable. Start a new draft from its reference to correct it.'
+        );
+      }
+      throw new AnalysisCheckpointServiceError(
+        412,
+        'DRAFT_VERSION_CONFLICT',
+        'The draft changed since it was read.',
+        { expectedVersion: input.expectedVersion, currentVersion: current.version }
+      );
     },
 
     async rebuildBasis(input) {
@@ -891,8 +1014,20 @@ export function createAnalysisCheckpointPorts(database: Database = db): Analysis
         if (typeof raw === 'number' && Number.isInteger(raw)) return raw;
         return null;
       }
-      // Waves E/F have not landed: a pinned reserve or economics run cannot have a
-      // readable basis yet, so it can only ever be reported as unproven.
+      if (input.component === 'economics') {
+        const rows = await database
+          .select({ factsSnapshotId: internalLpEconomicsRuns.factsSnapshotId })
+          .from(internalLpEconomicsRuns)
+          .where(
+            and(
+              eq(internalLpEconomicsRuns.id, input.id),
+              eq(internalLpEconomicsRuns.fundId, input.fundId)
+            )
+          )
+          .limit(1);
+        return rows[0]?.factsSnapshotId ?? null;
+      }
+      // Reserve linkage has not landed, so its basis remains unproven.
       return null;
     },
 

--- a/server/services/operating-objects/task-evidence-link-service.ts
+++ b/server/services/operating-objects/task-evidence-link-service.ts
@@ -1,0 +1,215 @@
+import { and, eq } from 'drizzle-orm';
+
+import {
+  TASK_EVIDENCE_LINK_CONTRACT_VERSION,
+  TaskEvidenceLinkV1Schema,
+  type TaskEvidenceLinkV1,
+  type TaskEvidenceTarget,
+} from '@shared/contracts/operating-objects/task-evidence-link.contract';
+import { taskEvidenceLinks, tasks, type TaskEvidenceLink } from '@shared/schema/operating-objects';
+import { db } from '../../db';
+import {
+  FundScopeError,
+  assertOwnedByFund,
+  type FundScopedOwnershipDatabase,
+} from '../../lib/fund-scoped-ownership';
+import { runIdempotentCommand } from '../../lib/idempotent-command';
+
+type TaskEvidenceDatabase = typeof db;
+
+export type TaskEvidenceLinkRecord = TaskEvidenceLink;
+
+export class TaskEvidenceLinkServiceError extends Error {
+  readonly status: number;
+
+  constructor(
+    readonly statusCode: number,
+    readonly code: string,
+    message: string
+  ) {
+    super(message);
+    this.name = 'TaskEvidenceLinkServiceError';
+    this.status = statusCode;
+  }
+}
+
+export interface TaskEvidenceCommandPreimage extends Record<string, unknown> {
+  commandKind: 'create_task_evidence_link';
+  contractVersion: typeof TASK_EVIDENCE_LINK_CONTRACT_VERSION;
+  fundId: number;
+  taskId: number;
+  target: TaskEvidenceTarget;
+}
+
+export interface TaskEvidenceLinkPorts {
+  assertTaskOwned(fundId: number, taskId: number): Promise<void>;
+  assertTargetOwned(fundId: number, target: TaskEvidenceTarget): Promise<void>;
+  createIdempotent(input: {
+    fundId: number;
+    taskId: number;
+    target: TaskEvidenceTarget;
+    actorId: number | null;
+    idempotencyKey: string;
+    preimage: TaskEvidenceCommandPreimage;
+  }): Promise<{ row: TaskEvidenceLinkRecord; replayed: boolean }>;
+}
+
+export interface CreateTaskEvidenceLinkInput {
+  fundId: number;
+  taskId: number;
+  target: TaskEvidenceTarget;
+  actorId: number | null;
+  idempotencyKey: string;
+}
+
+export interface CreateTaskEvidenceLinkResult {
+  evidenceLink: TaskEvidenceLinkV1;
+  replayed: boolean;
+}
+
+function targetFromRow(row: TaskEvidenceLinkRecord): TaskEvidenceTarget {
+  if (row.targetKind === 'analysis_reference' && row.analysisReferenceId !== null) {
+    return { kind: 'analysis_reference', id: row.analysisReferenceId };
+  }
+  if (row.targetKind === 'internal_economics_run' && row.economicsRunId !== null) {
+    return { kind: 'internal_economics_run', id: row.economicsRunId };
+  }
+  throw new TaskEvidenceLinkServiceError(
+    500,
+    'TASK_EVIDENCE_LINK_CORRUPT',
+    'Stored task evidence target is inconsistent.'
+  );
+}
+
+export function toTaskEvidenceLinkContract(row: TaskEvidenceLinkRecord): TaskEvidenceLinkV1 {
+  return TaskEvidenceLinkV1Schema.parse({
+    contractVersion: TASK_EVIDENCE_LINK_CONTRACT_VERSION,
+    linkId: row.id,
+    fundId: row.fundId,
+    taskId: row.taskId,
+    target: targetFromRow(row),
+    createdAt: row.createdAt.toISOString(),
+  });
+}
+
+export async function createTaskEvidenceLinkWithPorts(
+  ports: TaskEvidenceLinkPorts,
+  input: CreateTaskEvidenceLinkInput
+): Promise<CreateTaskEvidenceLinkResult> {
+  await ports.assertTaskOwned(input.fundId, input.taskId);
+  await ports.assertTargetOwned(input.fundId, input.target);
+
+  const preimage: TaskEvidenceCommandPreimage = {
+    commandKind: 'create_task_evidence_link',
+    contractVersion: TASK_EVIDENCE_LINK_CONTRACT_VERSION,
+    fundId: input.fundId,
+    taskId: input.taskId,
+    target: input.target,
+  };
+  const result = await ports.createIdempotent({ ...input, preimage });
+  return {
+    evidenceLink: toTaskEvidenceLinkContract(result.row),
+    replayed: result.replayed,
+  };
+}
+
+function createTaskEvidenceLinkPorts(database: TaskEvidenceDatabase): TaskEvidenceLinkPorts {
+  return {
+    async assertTaskOwned(fundId, taskId) {
+      const [task] = await database
+        .select({ id: tasks.id })
+        .from(tasks)
+        .where(and(eq(tasks.id, taskId), eq(tasks.fundId, fundId)))
+        .limit(1);
+      if (!task) {
+        throw new TaskEvidenceLinkServiceError(404, 'TASK_NOT_FOUND', 'Task not found.');
+      }
+    },
+
+    async assertTargetOwned(fundId, target) {
+      try {
+        await assertOwnedByFund({
+          db: database as unknown as FundScopedOwnershipDatabase,
+          fundId,
+          ref:
+            target.kind === 'analysis_reference'
+              ? { kind: 'analysis_reference', id: target.id }
+              : { kind: 'lp_economics_run', id: target.id },
+        });
+      } catch (error) {
+        if (error instanceof FundScopeError) {
+          throw new TaskEvidenceLinkServiceError(
+            404,
+            'EVIDENCE_TARGET_NOT_FOUND',
+            'Evidence target not found.'
+          );
+        }
+        throw error;
+      }
+    },
+
+    async createIdempotent(input) {
+      const loadExisting = async () => {
+        const [existing] = await database
+          .select()
+          .from(taskEvidenceLinks)
+          .where(
+            and(
+              eq(taskEvidenceLinks.fundId, input.fundId),
+              eq(taskEvidenceLinks.taskId, input.taskId),
+              eq(taskEvidenceLinks.idempotencyKey, input.idempotencyKey)
+            )
+          )
+          .limit(1);
+        return existing ? { row: existing, requestHash: existing.requestHash } : null;
+      };
+
+      return runIdempotentCommand<TaskEvidenceLinkRecord>({
+        db: database,
+        fundId: input.fundId,
+        idempotencyKey: input.idempotencyKey,
+        contractVersion: TASK_EVIDENCE_LINK_CONTRACT_VERSION,
+        request: input.preimage,
+        loadExisting,
+        insert: async (requestHash) => {
+          const [inserted] = await database
+            .insert(taskEvidenceLinks)
+            .values({
+              fundId: input.fundId,
+              taskId: input.taskId,
+              targetKind: input.target.kind,
+              analysisReferenceId:
+                input.target.kind === 'analysis_reference' ? input.target.id : null,
+              economicsRunId:
+                input.target.kind === 'internal_economics_run' ? input.target.id : null,
+              idempotencyKey: input.idempotencyKey,
+              requestHash,
+              createdBy: input.actorId,
+            })
+            .onConflictDoNothing({
+              target: [
+                taskEvidenceLinks.fundId,
+                taskEvidenceLinks.taskId,
+                taskEvidenceLinks.idempotencyKey,
+              ],
+            })
+            .returning();
+          return inserted ?? null;
+        },
+      });
+    },
+  };
+}
+
+export async function createTaskEvidenceLink(
+  input: CreateTaskEvidenceLinkInput,
+  options: { database?: TaskEvidenceDatabase } = {}
+): Promise<CreateTaskEvidenceLinkResult> {
+  const database = options.database ?? db;
+  return database.transaction(async (transaction) =>
+    createTaskEvidenceLinkWithPorts(
+      createTaskEvidenceLinkPorts(transaction as unknown as TaskEvidenceDatabase),
+      input
+    )
+  );
+}

--- a/shared/contracts/internal-analysis/analysis-reference-snapshot-v1.contract.ts
+++ b/shared/contracts/internal-analysis/analysis-reference-snapshot-v1.contract.ts
@@ -267,6 +267,12 @@ export const AnalysisDraftCreateRequestSchema = z
 
 export const AnalysisDraftRefreshRequestSchema = z.object({}).strict();
 
+export const AnalysisDraftEconomicsReferencePatchRequestSchema = z
+  .object({
+    economicsReferenceId: PositiveIntSchema.nullable(),
+  })
+  .strict();
+
 export const AnalysisDraftSaveRequestSchema = z
   .object({
     /**
@@ -333,6 +339,9 @@ export type AnalysisDraftV1 = z.infer<typeof AnalysisDraftV1Schema>;
 export type AnalysisReferenceV1 = z.infer<typeof AnalysisReferenceV1Schema>;
 export type AnalysisRevisionEventV1 = z.infer<typeof AnalysisRevisionEventV1Schema>;
 export type AnalysisDraftCreateRequest = z.output<typeof AnalysisDraftCreateRequestSchema>;
+export type AnalysisDraftEconomicsReferencePatchRequest = z.infer<
+  typeof AnalysisDraftEconomicsReferencePatchRequestSchema
+>;
 export type AnalysisDraftSaveRequest = z.output<typeof AnalysisDraftSaveRequestSchema>;
 export type QuarterlyDraftRunRequest = z.infer<typeof QuarterlyDraftRunRequestSchema>;
 export type AnalysisDraftListResponse = z.infer<typeof AnalysisDraftListResponseSchema>;

--- a/shared/contracts/operating-objects/task-evidence-link.contract.ts
+++ b/shared/contracts/operating-objects/task-evidence-link.contract.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+export const TASK_EVIDENCE_LINK_CONTRACT_VERSION = 'task-evidence-link/1.0.0' as const;
+
+const PositiveIntSchema = z.number().int().positive();
+
+export const TaskEvidenceTargetSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('analysis_reference'), id: PositiveIntSchema }).strict(),
+  z.object({ kind: z.literal('internal_economics_run'), id: PositiveIntSchema }).strict(),
+]);
+
+export const TaskEvidenceLinkCreateRequestSchema = z
+  .object({ target: TaskEvidenceTargetSchema })
+  .strict();
+
+export const TaskEvidenceLinkV1Schema = z
+  .object({
+    contractVersion: z.literal(TASK_EVIDENCE_LINK_CONTRACT_VERSION),
+    linkId: PositiveIntSchema,
+    fundId: PositiveIntSchema,
+    taskId: PositiveIntSchema,
+    target: TaskEvidenceTargetSchema,
+    createdAt: z.string().datetime(),
+  })
+  .strict();
+
+export type TaskEvidenceTarget = z.infer<typeof TaskEvidenceTargetSchema>;
+export type TaskEvidenceLinkCreateRequest = z.infer<typeof TaskEvidenceLinkCreateRequestSchema>;
+export type TaskEvidenceLinkV1 = z.infer<typeof TaskEvidenceLinkV1Schema>;

--- a/shared/routes/api-route-manifest.ts
+++ b/shared/routes/api-route-manifest.ts
@@ -635,7 +635,13 @@ export const COMMON_API_ROUTE_MANIFEST = [
     fundScope: 'path',
     financial: true,
     migrationParity: { kind: 'c1', tables: ['tasks'] },
-    schemaTables: ['tasks', 'funds'],
+    schemaTables: [
+      'tasks',
+      'task_evidence_links',
+      'internal_analysis_references',
+      'internal_lp_economics_runs',
+      'funds',
+    ],
     owner: 'gp-team',
     probe: {
       method: 'GET',
@@ -1027,6 +1033,7 @@ export const COMMON_API_ROUTE_MANIFEST = [
       'internal_analysis_drafts',
       'internal_analysis_references',
       'internal_analysis_revision_events',
+      'internal_lp_economics_runs',
       'financial_facts_snapshots',
       'fund_snapshots',
       'job_outbox',

--- a/tests/integration/internal-economics/economics-linkage-schema.pg.test.ts
+++ b/tests/integration/internal-economics/economics-linkage-schema.pg.test.ts
@@ -9,6 +9,7 @@ import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import { Pool } from 'pg';
+import { drizzle } from 'drizzle-orm/node-postgres';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import {
@@ -27,6 +28,11 @@ import {
   getMigrationStateFromConnectionString,
   runMigrationsWithConnectionString,
 } from '../../helpers/testcontainers-migration';
+import {
+  createAnalysisCheckpointPorts,
+  replaceDraftEconomicsReference,
+} from '../../../server/services/internal-analysis/analysis-checkpoint-service';
+import { createTaskEvidenceLink } from '../../../server/services/operating-objects/task-evidence-link-service';
 
 const skipIfNoDocker =
   !process.env.TEST_DATABASE_URL && !process.env.CI && process.platform === 'win32';
@@ -1369,6 +1375,156 @@ describe.skipIf(skipIfNoDocker)('internal economics linkage PostgreSQL proof', (
       expect(
         after.objects.every((object: { deltas: unknown[] }) => object.deltas.length === 0)
       ).toBe(true);
+    });
+  }, 120_000);
+
+  it('pins only completed same-fund economics runs with guarded version rotation', async () => {
+    const { connectionString } = await createMigratedDatabase('pin_service');
+
+    await withPool(connectionString, async (pool) => {
+      const basis = await seedLinkageBasis(pool, 'pin-service');
+      const completedRunId = await insertRun(pool, basis, {
+        idempotencyKey: 'pin-completed',
+        runState: 'completed',
+      });
+      const failedRunId = await insertRun(pool, basis, {
+        idempotencyKey: 'pin-failed',
+        runState: 'failed',
+      });
+      const database = drizzle(pool, { logger: false }) as never;
+      const ports = createAnalysisCheckpointPorts(database);
+
+      const attached = await replaceDraftEconomicsReference(ports, {
+        fundId: basis.fundId,
+        draftId: basis.draftId,
+        expectedVersion: 1,
+        economicsReferenceId: completedRunId,
+      });
+      const sameValue = await replaceDraftEconomicsReference(ports, {
+        fundId: basis.fundId,
+        draftId: basis.draftId,
+        expectedVersion: 2,
+        economicsReferenceId: completedRunId,
+      });
+
+      expect(attached).toMatchObject({ economicsReferenceId: completedRunId, version: 2 });
+      expect(sameValue).toMatchObject({ economicsReferenceId: completedRunId, version: 3 });
+      await expect(
+        replaceDraftEconomicsReference(ports, {
+          fundId: basis.fundId,
+          draftId: basis.draftId,
+          expectedVersion: 2,
+          economicsReferenceId: null,
+        })
+      ).rejects.toMatchObject({ statusCode: 412, code: 'DRAFT_VERSION_CONFLICT' });
+      await expect(
+        replaceDraftEconomicsReference(ports, {
+          fundId: basis.fundId,
+          draftId: basis.draftId,
+          expectedVersion: 3,
+          economicsReferenceId: failedRunId,
+        })
+      ).rejects.toMatchObject({ statusCode: 409, code: 'ECONOMICS_RUN_NOT_COMPLETED' });
+      await expect(
+        replaceDraftEconomicsReference(ports, {
+          fundId: basis.fundId,
+          draftId: basis.draftId,
+          expectedVersion: 3,
+          economicsReferenceId: completedRunId + 1_000_000,
+        })
+      ).rejects.toMatchObject({ statusCode: 404, code: 'ECONOMICS_RUN_NOT_FOUND' });
+
+      expect(
+        await ports.readComponentBasis({
+          fundId: basis.fundId,
+          component: 'economics',
+          id: completedRunId,
+        })
+      ).toBe(basis.factsSnapshotId);
+
+      await pool.query('UPDATE internal_analysis_drafts SET saved_at = NOW() WHERE id = $1', [
+        basis.draftId,
+      ]);
+      await expect(
+        replaceDraftEconomicsReference(ports, {
+          fundId: basis.fundId,
+          draftId: basis.draftId,
+          expectedVersion: 3,
+          economicsReferenceId: null,
+        })
+      ).rejects.toMatchObject({ statusCode: 409, code: 'DRAFT_ALREADY_SAVED' });
+    });
+  }, 120_000);
+
+  it('creates task evidence once under replay, conflict, concurrency, and cross-actor retry', async () => {
+    const { connectionString } = await createMigratedDatabase('evidence_service');
+
+    await withPool(connectionString, async (pool) => {
+      const basis = await seedLinkageBasis(pool, 'evidence-service');
+      const runId = await insertRun(pool, basis, {
+        idempotencyKey: 'evidence-run',
+        runState: 'failed',
+      });
+      const database = drizzle(pool, { logger: false }) as never;
+      const common = {
+        fundId: basis.fundId,
+        taskId: basis.taskId,
+        target: { kind: 'analysis_reference' as const, id: basis.referenceId },
+        actorId: basis.userId,
+        idempotencyKey: 'evidence-create',
+      };
+
+      const created = await createTaskEvidenceLink(common, { database });
+      const crossActorReplay = await createTaskEvidenceLink(
+        { ...common, actorId: null },
+        { database }
+      );
+
+      expect(created.replayed).toBe(false);
+      expect(crossActorReplay).toEqual({ ...created, replayed: true });
+      expect(Object.keys(created.evidenceLink).sort()).toEqual(
+        ['contractVersion', 'createdAt', 'fundId', 'linkId', 'target', 'taskId'].sort()
+      );
+      await expect(
+        createTaskEvidenceLink(
+          {
+            ...common,
+            target: { kind: 'internal_economics_run', id: runId },
+          },
+          { database }
+        )
+      ).rejects.toMatchObject({ status: 409, code: 'IDEMPOTENCY_KEY_REUSE' });
+
+      const concurrent = await Promise.all(
+        Array.from({ length: 8 }, () =>
+          createTaskEvidenceLink({ ...common, idempotencyKey: 'evidence-concurrent' }, { database })
+        )
+      );
+      expect(new Set(concurrent.map((result) => result.evidenceLink.linkId)).size).toBe(1);
+      expect(concurrent.filter((result) => !result.replayed)).toHaveLength(1);
+
+      const persisted = await pool.query<{
+        count: number;
+        created_by: number | null;
+        idempotency_key: string;
+      }>(
+        'SELECT count(*) OVER ()::integer AS count, created_by, idempotency_key ' +
+          'FROM task_evidence_links WHERE fund_id = $1 AND task_id = $2 ORDER BY id',
+        [basis.fundId, basis.taskId]
+      );
+      expect(persisted.rows).toHaveLength(2);
+      expect(persisted.rows[0]).toMatchObject({
+        count: 2,
+        created_by: basis.userId,
+        idempotency_key: 'evidence-create',
+      });
+
+      await expect(
+        createTaskEvidenceLink(
+          { ...common, fundId: basis.fundId + 1, idempotencyKey: 'cross-fund' },
+          { database }
+        )
+      ).rejects.toMatchObject({ statusCode: 404 });
     });
   }, 120_000);
 });

--- a/tests/unit/contract/internal-analysis/draft-economics-reference-patch.contract.test.ts
+++ b/tests/unit/contract/internal-analysis/draft-economics-reference-patch.contract.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { AnalysisDraftEconomicsReferencePatchRequestSchema } from '../../../../shared/contracts/internal-analysis/analysis-reference-snapshot-v1.contract';
+
+describe('analysis draft economics-reference PATCH request', () => {
+  it.each([7, null])('accepts the strict supported value %s', (economicsReferenceId) => {
+    expect(
+      AnalysisDraftEconomicsReferencePatchRequestSchema.parse({ economicsReferenceId })
+    ).toEqual({ economicsReferenceId });
+  });
+
+  it.each([
+    {},
+    { economicsReferenceId: 0 },
+    { economicsReferenceId: -1 },
+    { economicsReferenceId: 1.5 },
+    { economicsReferenceId: '7' },
+    { economicsReferenceId: 7, extra: true },
+  ])('rejects unsupported payload %#', (payload) => {
+    expect(AnalysisDraftEconomicsReferencePatchRequestSchema.safeParse(payload).success).toBe(
+      false
+    );
+  });
+});

--- a/tests/unit/contract/operating-objects/task-evidence-link.contract.test.ts
+++ b/tests/unit/contract/operating-objects/task-evidence-link.contract.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  TASK_EVIDENCE_LINK_CONTRACT_VERSION,
+  TaskEvidenceLinkCreateRequestSchema,
+  TaskEvidenceLinkV1Schema,
+} from '../../../../shared/contracts/operating-objects/task-evidence-link.contract';
+
+describe('task-evidence-link/1.0.0 contract', () => {
+  it.each([
+    { kind: 'analysis_reference', id: 11 },
+    { kind: 'internal_economics_run', id: 12 },
+  ] as const)('accepts typed target $kind', (target) => {
+    expect(TaskEvidenceLinkCreateRequestSchema.parse({ target })).toEqual({ target });
+  });
+
+  it.each([
+    {},
+    { target: { kind: 'analysis_draft', id: 1 } },
+    { target: { kind: 'analysis_reference', id: 0 } },
+    { target: { kind: 'analysis_reference', id: 1, extra: true } },
+    { target: { kind: 'internal_economics_run', id: '1' } },
+    { target: { kind: 'analysis_reference', analysisReferenceId: 1 } },
+    { target: { kind: 'analysis_reference', id: 1 }, creator: 7 },
+  ])('rejects unsupported request %#', (request) => {
+    expect(TaskEvidenceLinkCreateRequestSchema.safeParse(request).success).toBe(false);
+  });
+
+  it('publishes only strict identity, scope, target, and creation time', () => {
+    const publicLink = {
+      contractVersion: TASK_EVIDENCE_LINK_CONTRACT_VERSION,
+      linkId: 31,
+      fundId: 1,
+      taskId: 2,
+      target: { kind: 'analysis_reference' as const, id: 11 },
+      createdAt: '2026-08-01T12:00:00.000Z',
+    };
+
+    expect(TaskEvidenceLinkV1Schema.parse(publicLink)).toEqual(publicLink);
+    expect(
+      TaskEvidenceLinkV1Schema.safeParse({
+        ...publicLink,
+        createdBy: 7,
+        idempotencyKey: 'secret',
+        requestHash: 'a'.repeat(64),
+        persistenceRow: {},
+        transaction: {},
+      }).success
+    ).toBe(false);
+  });
+});

--- a/tests/unit/middleware/database-backed-idempotency-routes.test.ts
+++ b/tests/unit/middleware/database-backed-idempotency-routes.test.ts
@@ -17,6 +17,9 @@ describe('database-backed idempotency route classification', () => {
     ['POST', '/api/FUNDS/1/INTERNAL-ECONOMICS/RUNS'],
     ['POST', '/api/funds/1/internal-economics/runs/'],
     ['POST', '/api/FUNDS/1/INTERNAL-ECONOMICS/RUNS/?mode=create#receipt'],
+    ['POST', '/api/funds/1/tasks/2/evidence-links'],
+    ['POST', '/api/funds/0/tasks/00/evidence-links?mode=create'],
+    ['POST', '/api/FUNDS/1/TASKS/2/EVIDENCE-LINKS/'],
   ])('matches %s %s', (method, path) => {
     expect(isDatabaseBackedIdempotencyRoute(method, path)).toBe(true);
   });
@@ -33,6 +36,11 @@ describe('database-backed idempotency route classification', () => {
     ['POST', '/api/funds/1/internal-economics/runs-near'],
     ['POST', '/api/funds/1/internal-economics/runs-near?mode=create'],
     ['POST', '/prefix/api/funds/1/internal-economics/runs'],
+    ['GET', '/api/funds/1/tasks/2/evidence-links'],
+    ['post', '/api/funds/1/tasks/2/evidence-links'],
+    ['POST', '/api/funds/1/tasks/2/evidence-links/extra'],
+    ['POST', '/api/funds/1/tasks/2/evidence-link'],
+    ['POST', '/prefix/api/funds/1/tasks/2/evidence-links'],
   ])('does not match %s %s', (method, path) => {
     expect(isDatabaseBackedIdempotencyRoute(method, path)).toBe(false);
   });
@@ -105,5 +113,32 @@ describe('generic idempotency cache bypass', () => {
     expect(second.status).toBe(201);
     expect(second.headers['idempotency-replay']).toBe('true');
     expect(calls).toBe(1);
+  });
+
+  it('bypasses generic cache only for exact task-evidence creation', async () => {
+    const app = express();
+    let calls = 0;
+
+    app.use(express.json());
+    app.use(idempotency());
+    app.post('/api/funds/:fundId/tasks/:taskId/evidence-links', (_req, res) => {
+      calls += 1;
+      res.status(201).json({ calls });
+    });
+
+    const first = await request(app)
+      .post('/api/funds/1/tasks/2/evidence-links')
+      .set('Idempotency-Key', 'database-backed-evidence')
+      .send({ target: { kind: 'analysis_reference', id: 11 } });
+    const second = await request(app)
+      .post('/api/funds/1/tasks/2/evidence-links')
+      .set('Idempotency-Key', 'database-backed-evidence')
+      .send({ target: { kind: 'analysis_reference', id: 11 } });
+
+    expect(first.status).toBe(201);
+    expect(second.status).toBe(201);
+    expect(first.headers['idempotency-replay']).toBeUndefined();
+    expect(second.headers['idempotency-replay']).toBeUndefined();
+    expect(calls).toBe(2);
   });
 });

--- a/tests/unit/routes/internal-analysis.contract.test.ts
+++ b/tests/unit/routes/internal-analysis.contract.test.ts
@@ -9,6 +9,7 @@ const service = vi.hoisted(() => ({
   getReferenceById: vi.fn(),
   listRevisionEvents: vi.fn(),
   createDraftForPeriod: vi.fn(),
+  replaceDraftEconomicsReference: vi.fn(),
   refreshDraft: vi.fn(),
   saveDraft: vi.fn(),
   startCorrectionDraft: vi.fn(),
@@ -71,6 +72,7 @@ vi.mock('../../../server/services/internal-analysis/analysis-checkpoint-service'
       listRevisionEvents: service.listRevisionEvents,
     }),
     createDraftForPeriod: service.createDraftForPeriod,
+    replaceDraftEconomicsReference: service.replaceDraftEconomicsReference,
     refreshDraft: service.refreshDraft,
     saveDraft: service.saveDraft,
     startCorrectionDraft: service.startCorrectionDraft,
@@ -155,6 +157,9 @@ describe('internal-analysis route contract', () => {
       request(app).get('/api/funds/abc/internal-analysis/drafts'),
       request(app).get('/api/funds/abc/internal-analysis/drafts/3'),
       request(app).post('/api/funds/abc/internal-analysis/drafts').send({}),
+      request(app)
+        .patch('/api/funds/abc/internal-analysis/drafts/3/economics-reference')
+        .send({ economicsReferenceId: 9 }),
       request(app).post('/api/funds/abc/internal-analysis/drafts/3/refresh').send({}),
       request(app).post('/api/funds/abc/internal-analysis/drafts/3/save').send({}),
       request(app).get('/api/funds/abc/internal-analysis/references'),
@@ -177,6 +182,9 @@ describe('internal-analysis route contract', () => {
 
     const responses = await Promise.all([
       request(app).get('/api/funds/1/internal-analysis/drafts/abc'),
+      request(app)
+        .patch('/api/funds/1/internal-analysis/drafts/abc/economics-reference')
+        .send({ economicsReferenceId: 9 }),
       request(app).post('/api/funds/1/internal-analysis/drafts/abc/refresh').send({}),
       request(app).post('/api/funds/1/internal-analysis/drafts/abc/save').send({}),
       request(app).get('/api/funds/1/internal-analysis/references/abc'),
@@ -262,6 +270,80 @@ describe('internal-analysis route contract', () => {
   });
 
   describe('If-Match preconditions', () => {
+    it('requires If-Match on economics-reference replacement (428)', async () => {
+      service.getDraftById.mockResolvedValue(draftRecord());
+
+      const response = await request(buildApp())
+        .patch('/api/funds/1/internal-analysis/drafts/3/economics-reference')
+        .send({ economicsReferenceId: 9 });
+
+      expect(response.status).toBe(428);
+      expect(response.body.error).toBe('PRECONDITION_REQUIRED');
+      expect(service.replaceDraftEconomicsReference).not.toHaveBeenCalled();
+    });
+
+    it('rejects a stale economics-reference ETag before mutation (412)', async () => {
+      service.getDraftById.mockResolvedValue(draftRecord({ version: 2 }));
+
+      const response = await request(buildApp())
+        .patch('/api/funds/1/internal-analysis/drafts/3/economics-reference')
+        .set('If-Match', 'W/"0000000000000000"')
+        .send({ economicsReferenceId: 9 });
+
+      expect(response.status).toBe(412);
+      expect(service.replaceDraftEconomicsReference).not.toHaveBeenCalled();
+    });
+
+    it.each([{ economicsReferenceId: 9 }, { economicsReferenceId: null }])(
+      'replaces economics reference and rotates ETag for $economicsReferenceId',
+      async (body) => {
+        const before = await readDraftETag();
+        service.getDraftById.mockResolvedValue(draftRecord());
+        service.replaceDraftEconomicsReference.mockResolvedValue(
+          draftRecord({ version: 2, economicsReferenceId: body.economicsReferenceId })
+        );
+
+        const response = await request(buildApp())
+          .patch('/api/funds/1/internal-analysis/drafts/3/economics-reference')
+          .set('If-Match', before)
+          .send(body);
+
+        expect(response.status).toBe(200);
+        expect(response.headers['etag']).not.toBe(before);
+        expect(response.body.draft.version).toBe(2);
+        expect(response.body.draft.basis.economicsReferenceId).toBe(body.economicsReferenceId);
+        expect(service.replaceDraftEconomicsReference).toHaveBeenCalledWith(expect.anything(), {
+          fundId: 1,
+          draftId: 3,
+          expectedVersion: 1,
+          economicsReferenceId: body.economicsReferenceId,
+        });
+      }
+    );
+
+    it('rejects retry with the consumed economics-reference ETag', async () => {
+      const before = await readDraftETag();
+      service.getDraftById.mockResolvedValue(draftRecord());
+      service.replaceDraftEconomicsReference.mockResolvedValue(
+        draftRecord({ version: 2, economicsReferenceId: 9 })
+      );
+
+      await request(buildApp())
+        .patch('/api/funds/1/internal-analysis/drafts/3/economics-reference')
+        .set('If-Match', before)
+        .send({ economicsReferenceId: 9 })
+        .expect(200);
+
+      service.getDraftById.mockResolvedValue(draftRecord({ version: 2, economicsReferenceId: 9 }));
+      const retry = await request(buildApp())
+        .patch('/api/funds/1/internal-analysis/drafts/3/economics-reference')
+        .set('If-Match', before)
+        .send({ economicsReferenceId: 9 });
+
+      expect(retry.status).toBe(412);
+      expect(service.replaceDraftEconomicsReference).toHaveBeenCalledTimes(1);
+    });
+
     it('requires If-Match on refresh and save (428)', async () => {
       service.getDraftById.mockResolvedValue(draftRecord());
 
@@ -330,6 +412,44 @@ describe('internal-analysis route contract', () => {
       expect(response.body.reference.referenceId).toBe(11);
       expect(response.body.reference.mixedBasisAtSave).toBe(false);
     });
+  });
+
+  it.each([
+    {},
+    { economicsReferenceId: 0 },
+    { economicsReferenceId: '9' },
+    { economicsReferenceId: 9, unexpected: true },
+  ])('rejects an invalid economics-reference body %#', async (body) => {
+    const etag = await readDraftETag();
+    const response = await request(buildApp())
+      .patch('/api/funds/1/internal-analysis/drafts/3/economics-reference')
+      .set('If-Match', etag)
+      .send(body);
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('invalid_analysis_economics_reference_request');
+    expect(service.replaceDraftEconomicsReference).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [404, 'ECONOMICS_RUN_NOT_FOUND'],
+    [409, 'ECONOMICS_RUN_NOT_COMPLETED'],
+    [409, 'DRAFT_ALREADY_SAVED'],
+    [412, 'DRAFT_VERSION_CONFLICT'],
+  ] as const)('maps economics-reference service error %s %s', async (statusCode, code) => {
+    const etag = await readDraftETag();
+    service.getDraftById.mockResolvedValue(draftRecord());
+    service.replaceDraftEconomicsReference.mockRejectedValue(
+      new AnalysisCheckpointServiceError(statusCode, code, 'Rejected')
+    );
+
+    const response = await request(buildApp())
+      .patch('/api/funds/1/internal-analysis/drafts/3/economics-reference')
+      .set('If-Match', etag)
+      .send({ economicsReferenceId: 9 });
+
+    expect(response.status).toBe(statusCode);
+    expect(response.body.error).toBe(code);
   });
 
   it('maps MIXED_FACTS_BASIS to 409 with the mismatch details', async () => {

--- a/tests/unit/routes/operating-object-tasks.contract.test.ts
+++ b/tests/unit/routes/operating-object-tasks.contract.test.ts
@@ -8,6 +8,10 @@ const fundScopeState = vi.hoisted(() => ({
   enforceProvidedFundScope: vi.fn(async (_req: Request, _res: Response, _fundId: number) => true),
 }));
 
+const evidenceService = vi.hoisted(() => ({
+  createTaskEvidenceLink: vi.fn(),
+}));
+
 const dbState = vi.hoisted(() => {
   const state = {
     insertResult: [] as unknown[],
@@ -52,7 +56,27 @@ vi.mock('../../../server/lib/auth/provided-fund-scope', () => ({
 
 vi.mock('../../../server/db', () => ({ db: dbState.db }));
 
+vi.mock('../../../server/services/operating-objects/task-evidence-link-service', () => {
+  class MockTaskEvidenceLinkServiceError extends Error {
+    readonly status: number;
+    constructor(
+      readonly statusCode: number,
+      readonly code: string,
+      message: string
+    ) {
+      super(message);
+      this.status = statusCode;
+    }
+  }
+  return {
+    TaskEvidenceLinkServiceError: MockTaskEvidenceLinkServiceError,
+    createTaskEvidenceLink: evidenceService.createTaskEvidenceLink,
+  };
+});
+
 import tasksRouter from '../../../server/routes/operating-object-tasks';
+import { IdempotentCommandError } from '../../../server/lib/idempotent-command';
+import { TaskEvidenceLinkServiceError } from '../../../server/services/operating-objects/task-evidence-link-service';
 
 function makeApp() {
   const app = express();
@@ -389,5 +413,146 @@ describe('operating-object tasks PATCH route', () => {
       .set('If-Match', etagFor('1'))
       .send({ title: 'x' });
     expect(res.status).toBe(404);
+  });
+});
+
+describe('operating-object task evidence POST route', () => {
+  const publicLink = {
+    contractVersion: 'task-evidence-link/1.0.0',
+    linkId: 31,
+    fundId: 1,
+    taskId: 10,
+    target: { kind: 'analysis_reference', id: 11 },
+    createdAt: '2026-08-01T12:00:00.000Z',
+  } as const;
+
+  beforeEach(() => {
+    fundScopeState.enforceProvidedFundScope.mockReset();
+    fundScopeState.enforceProvidedFundScope.mockResolvedValue(true);
+    evidenceService.createTaskEvidenceLink.mockReset();
+    evidenceService.createTaskEvidenceLink.mockResolvedValue({
+      evidenceLink: publicLink,
+      replayed: false,
+    });
+  });
+
+  it.each([
+    ['/api/funds/01/tasks/10/evidence-links', 'Invalid fund ID'],
+    ['/api/funds/1/tasks/01/evidence-links', 'Invalid task ID'],
+  ])('rejects non-canonical path %s', async (path, error) => {
+    const response = await request(makeApp())
+      .post(path)
+      .set('Idempotency-Key', 'evidence-1')
+      .send({ target: { kind: 'analysis_reference', id: 11 } });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe(error);
+    expect(evidenceService.createTaskEvidenceLink).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 before target lookup when request-fund access is missing', async () => {
+    denyOnce();
+    const response = await request(makeApp())
+      .post('/api/funds/2/tasks/10/evidence-links')
+      .set('Idempotency-Key', 'evidence-1')
+      .send({ target: { kind: 'analysis_reference', id: 11 } });
+
+    expect(response.status).toBe(403);
+    expect(evidenceService.createTaskEvidenceLink).not.toHaveBeenCalled();
+  });
+
+  it('requires and validates Idempotency-Key', async () => {
+    const missing = await request(makeApp())
+      .post('/api/funds/1/tasks/10/evidence-links')
+      .send({ target: { kind: 'analysis_reference', id: 11 } });
+    const malformed = await request(makeApp())
+      .post('/api/funds/1/tasks/10/evidence-links')
+      .set('Idempotency-Key', 'bad key')
+      .send({ target: { kind: 'analysis_reference', id: 11 } });
+
+    expect(missing.status).toBe(428);
+    expect(missing.body.error).toBe('IDEMPOTENCY_KEY_REQUIRED');
+    expect(malformed.status).toBe(400);
+    expect(malformed.body.error).toBe('INVALID_IDEMPOTENCY_KEY');
+  });
+
+  it.each([
+    {},
+    { target: { kind: 'analysis_draft', id: 11 } },
+    { target: { kind: 'analysis_reference', id: 0 } },
+    { target: { kind: 'analysis_reference', id: 11 }, extra: true },
+  ])('rejects invalid strict evidence body %#', async (body) => {
+    const response = await request(makeApp())
+      .post('/api/funds/1/tasks/10/evidence-links')
+      .set('Idempotency-Key', 'evidence-1')
+      .send(body);
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('INVALID_TASK_EVIDENCE_LINK_BODY');
+    expect(evidenceService.createTaskEvidenceLink).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [{ kind: 'analysis_reference', id: 11 }, 201],
+    [{ kind: 'internal_economics_run', id: 12 }, 201],
+  ] as const)('creates target $kind with strict response', async (target, status) => {
+    evidenceService.createTaskEvidenceLink.mockResolvedValue({
+      evidenceLink: { ...publicLink, target },
+      replayed: false,
+    });
+
+    const response = await request(makeApp())
+      .post('/api/funds/1/tasks/10/evidence-links')
+      .set('Idempotency-Key', ' evidence-1 ')
+      .send({ target });
+
+    expect(response.status).toBe(status);
+    expect(response.body).toEqual({ ...publicLink, target });
+    expect(response.headers['location']).toBeUndefined();
+    expect(evidenceService.createTaskEvidenceLink).toHaveBeenCalledWith({
+      fundId: 1,
+      taskId: 10,
+      target,
+      actorId: null,
+      idempotencyKey: 'evidence-1',
+    });
+  });
+
+  it('returns 200 for identical replay', async () => {
+    evidenceService.createTaskEvidenceLink.mockResolvedValue({
+      evidenceLink: publicLink,
+      replayed: true,
+    });
+
+    const response = await request(makeApp())
+      .post('/api/funds/1/tasks/10/evidence-links')
+      .set('Idempotency-Key', 'evidence-1')
+      .send({ target: publicLink.target });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(publicLink);
+  });
+
+  it.each([
+    [
+      new TaskEvidenceLinkServiceError(404, 'EVIDENCE_TARGET_NOT_FOUND', 'Target not found.'),
+      404,
+      'EVIDENCE_TARGET_NOT_FOUND',
+    ],
+    [
+      new IdempotentCommandError(409, 'IDEMPOTENCY_KEY_REUSE', 'Key conflict.'),
+      409,
+      'IDEMPOTENCY_KEY_REUSE',
+    ],
+  ] as const)('maps typed service failures', async (error, status, code) => {
+    evidenceService.createTaskEvidenceLink.mockRejectedValue(error);
+
+    const response = await request(makeApp())
+      .post('/api/funds/1/tasks/10/evidence-links')
+      .set('Idempotency-Key', 'evidence-1')
+      .send({ target: publicLink.target });
+
+    expect(response.status).toBe(status);
+    expect(response.body.error).toBe(code);
   });
 });

--- a/tests/unit/routes/pr4-linkage-dual-runtime.contract.test.ts
+++ b/tests/unit/routes/pr4-linkage-dual-runtime.contract.test.ts
@@ -1,0 +1,263 @@
+import express from 'express';
+import type { Express } from 'express';
+import type { Server } from 'node:http';
+import request from 'supertest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const analysisService = vi.hoisted(() => ({
+  getDraftById: vi.fn(),
+  replaceDraftEconomicsReference: vi.fn(),
+}));
+
+const evidenceService = vi.hoisted(() => ({
+  createTaskEvidenceLink: vi.fn(),
+}));
+
+vi.mock('../../../server/services/internal-analysis/analysis-checkpoint-service', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../../server/services/internal-analysis/analysis-checkpoint-service')
+  >('../../../server/services/internal-analysis/analysis-checkpoint-service');
+  return {
+    ...actual,
+    createAnalysisCheckpointPorts: () => ({
+      getDraftById: analysisService.getDraftById,
+    }),
+    replaceDraftEconomicsReference: analysisService.replaceDraftEconomicsReference,
+  };
+});
+
+vi.mock('../../../server/services/operating-objects/task-evidence-link-service', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../../server/services/operating-objects/task-evidence-link-service')
+  >('../../../server/services/operating-objects/task-evidence-link-service');
+  return {
+    ...actual,
+    createTaskEvidenceLink: evidenceService.createTaskEvidenceLink,
+  };
+});
+
+const ENV_KEYS = [
+  'NODE_ENV',
+  '_EXPLICIT_NODE_ENV',
+  'VITEST',
+  'ALLOW_MEMORY_STORAGE',
+  'DATABASE_URL',
+  'NEON_DATABASE_URL',
+  'REDIS_URL',
+  '_EXPLICIT_REDIS_URL',
+  'RATE_LIMIT_REDIS_URL',
+  'QUEUE_REDIS_URL',
+  'SESSION_REDIS_URL',
+  'ENABLE_QUEUES',
+  'REQUIRE_AUTH',
+  'DEFAULT_USER_ID',
+  'JWT_ALG',
+  '_EXPLICIT_JWT_ALG',
+  'JWT_SECRET',
+  '_EXPLICIT_JWT_SECRET',
+  'JWT_AUDIENCE',
+  '_EXPLICIT_JWT_AUDIENCE',
+  'JWT_ISSUER',
+  '_EXPLICIT_JWT_ISSUER',
+  'JWT_JWKS_URL',
+  '_EXPLICIT_JWT_JWKS_URL',
+  'SESSION_SECRET',
+] as const;
+
+const originalEnv = new Map<string, string | undefined>();
+
+const draft = {
+  draftId: 3,
+  fundId: 1,
+  period: {
+    periodKind: 'quarterly' as const,
+    periodStart: '2026-04-01',
+    periodEnd: '2026-06-30',
+  },
+  knowledgeCutoff: new Date('2026-07-02T00:00:00.000Z'),
+  financialFactsSnapshotId: 41,
+  forecastFundSnapshotId: 902,
+  reserveReferenceId: null,
+  economicsReferenceId: null,
+  sourceReferenceId: null,
+  savedAt: null,
+  version: 1,
+  createdAt: new Date('2026-07-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-07-01T00:00:00.000Z'),
+};
+
+const evidenceLink = {
+  contractVersion: 'task-evidence-link/1.0.0' as const,
+  linkId: 31,
+  fundId: 1,
+  taskId: 10,
+  target: { kind: 'analysis_reference' as const, id: 11 },
+  createdAt: '2026-08-01T12:00:00.000Z',
+};
+
+type Surface = { name: 'makeApp' | 'registerRoutes'; app: Express };
+let surfaces: readonly Surface[] = [];
+let registerRoutesServer: Server | undefined;
+
+function configureEnvironment() {
+  process.env.NODE_ENV = 'test';
+  process.env._EXPLICIT_NODE_ENV = 'test';
+  process.env.VITEST = 'true';
+  process.env.ALLOW_MEMORY_STORAGE = '1';
+  delete process.env.DATABASE_URL;
+  delete process.env.NEON_DATABASE_URL;
+  process.env.REDIS_URL = 'memory://';
+  process.env._EXPLICIT_REDIS_URL = 'memory://';
+  delete process.env.RATE_LIMIT_REDIS_URL;
+  delete process.env.QUEUE_REDIS_URL;
+  delete process.env.SESSION_REDIS_URL;
+  process.env.ENABLE_QUEUES = '0';
+  process.env.REQUIRE_AUTH = '1';
+  process.env.DEFAULT_USER_ID = '1';
+  process.env.JWT_ALG = 'HS256';
+  process.env._EXPLICIT_JWT_ALG = 'HS256';
+  process.env.JWT_SECRET = 'test'.repeat(8);
+  process.env._EXPLICIT_JWT_SECRET = process.env.JWT_SECRET;
+  process.env.JWT_AUDIENCE = 'updog-test';
+  process.env._EXPLICIT_JWT_AUDIENCE = process.env.JWT_AUDIENCE;
+  process.env.JWT_ISSUER = 'updog-test';
+  process.env._EXPLICIT_JWT_ISSUER = process.env.JWT_ISSUER;
+  delete process.env.JWT_JWKS_URL;
+  delete process.env._EXPLICIT_JWT_JWKS_URL;
+  process.env.SESSION_SECRET = 'pr4-linkage-dual-runtime-secret-32';
+}
+
+async function authorizationHeader(
+  fundIds: readonly number[] = [1],
+  role = 'admin'
+): Promise<string> {
+  const { signToken } = await import('../../../server/lib/auth/jwt');
+  return `Bearer ${signToken({
+    sub: '9',
+    email: 'pr4-linkage@example.com',
+    role,
+    fundIds,
+  })}`;
+}
+
+async function closeServer(server: Server | undefined) {
+  if (!server?.listening) return;
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+beforeAll(async () => {
+  for (const key of ENV_KEYS) originalEnv.set(key, process.env[key]);
+  configureEnvironment();
+  vi.resetModules();
+
+  const { makeApp } = await import('../../../server/app');
+  const registerRoutesApp = express();
+  registerRoutesApp.set('trust proxy', false);
+  registerRoutesApp.use(express.json({ limit: '1mb' }));
+  const { registerRoutes } = await import('../../../server/routes');
+  registerRoutesServer = await registerRoutes(registerRoutesApp);
+  surfaces = [
+    { name: 'makeApp', app: makeApp() },
+    { name: 'registerRoutes', app: registerRoutesApp },
+  ];
+}, 30_000);
+
+afterAll(async () => {
+  await closeServer(registerRoutesServer);
+  for (const key of ENV_KEYS) {
+    const value = originalEnv.get(key);
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+beforeEach(() => {
+  analysisService.getDraftById.mockReset();
+  analysisService.getDraftById.mockResolvedValue(draft);
+  analysisService.replaceDraftEconomicsReference.mockReset();
+  analysisService.replaceDraftEconomicsReference.mockResolvedValue({
+    ...draft,
+    economicsReferenceId: 9,
+    version: 2,
+    updatedAt: new Date('2026-08-01T12:00:00.000Z'),
+  });
+  evidenceService.createTaskEvidenceLink.mockReset();
+});
+
+describe('PR4 linkage dual-runtime parity', () => {
+  it('enforces router-local authorization on both runtimes and global authorization on makeApp', async () => {
+    for (const surface of surfaces) {
+      await request(surface.app)
+        .patch('/api/funds/1/internal-analysis/drafts/3/economics-reference')
+        .send({ economicsReferenceId: 9 })
+        .expect(401);
+    }
+
+    await request(surfaces[0]!.app)
+      .post('/api/funds/1/tasks/10/evidence-links')
+      .set('Idempotency-Key', 'evidence-1')
+      .send({ target: evidenceLink.target })
+      .expect(401);
+  });
+
+  it('rotates economics-pin ETags identically', async () => {
+    const authorization = await authorizationHeader();
+    for (const surface of surfaces) {
+      const detail = await request(surface.app)
+        .get('/api/funds/1/internal-analysis/drafts/3')
+        .set('Authorization', authorization)
+        .expect(200);
+      const response = await request(surface.app)
+        .patch('/api/funds/1/internal-analysis/drafts/3/economics-reference')
+        .set('Authorization', authorization)
+        .set('If-Match', detail.headers['etag'] as string)
+        .send({ economicsReferenceId: 9 })
+        .expect(200);
+
+      expect(response.headers['etag'], surface.name).not.toBe(detail.headers['etag']);
+      expect(response.body.draft.basis.economicsReferenceId, surface.name).toBe(9);
+    }
+  });
+
+  it('returns 201 then 200 replay with the same strict evidence response', async () => {
+    const authorization = await authorizationHeader();
+    for (const surface of surfaces) {
+      evidenceService.createTaskEvidenceLink
+        .mockResolvedValueOnce({ evidenceLink, replayed: false })
+        .mockResolvedValueOnce({ evidenceLink, replayed: true });
+
+      const first = await request(surface.app)
+        .post('/api/funds/1/tasks/10/evidence-links')
+        .set('Authorization', authorization)
+        .set('Idempotency-Key', 'evidence-1')
+        .send({ target: evidenceLink.target })
+        .expect(201);
+      const replay = await request(surface.app)
+        .post('/api/funds/1/tasks/10/evidence-links')
+        .set('Authorization', authorization)
+        .set('Idempotency-Key', 'evidence-1')
+        .send({ target: evidenceLink.target })
+        .expect(200);
+
+      expect(first.body, surface.name).toEqual(evidenceLink);
+      expect(replay.body, surface.name).toEqual(evidenceLink);
+      expect(first.headers['location'], surface.name).toBeUndefined();
+      expect(replay.headers['location'], surface.name).toBeUndefined();
+    }
+  });
+
+  it('returns 403 before evidence service work without request-fund grant', async () => {
+    const authorization = await authorizationHeader([2], 'user');
+    for (const surface of surfaces) {
+      const response = await request(surface.app)
+        .post('/api/funds/1/tasks/10/evidence-links')
+        .set('Authorization', authorization)
+        .set('Idempotency-Key', 'evidence-denied')
+        .send({ target: evidenceLink.target });
+      expect(response.status, `${surface.name} ${JSON.stringify(response.body)}`).toBe(403);
+    }
+    expect(evidenceService.createTaskEvidenceLink).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/server/common-route-manifest.test.ts
+++ b/tests/unit/server/common-route-manifest.test.ts
@@ -244,6 +244,26 @@ describe('canonical common API route manifest', () => {
     ]);
   });
 
+  it('registers PR4 economics pins and task evidence persistence on common runtimes', () => {
+    const analysis = COMMON_API_ROUTE_MANIFEST.find((entry) => entry.id === 'internal-analysis');
+    const tasks = COMMON_API_ROUTE_MANIFEST.find((entry) => entry.id === 'operating-object-tasks');
+
+    expect(COMMON_API_ROUTE_POLICY_IDS['internal-analysis']).toContain(
+      'api:patch:/api/funds/:fundId/internal-analysis/drafts/:draftId/economics-reference'
+    );
+    expect(analysis?.schemaTables).toEqual(
+      expect.arrayContaining(['internal_analysis_drafts', 'internal_lp_economics_runs'])
+    );
+    expect(tasks?.schemaTables).toEqual(
+      expect.arrayContaining([
+        'tasks',
+        'task_evidence_links',
+        'internal_analysis_references',
+        'internal_lp_economics_runs',
+      ])
+    );
+  });
+
   it('bypasses database-backed internal-economics creation before generic idempotency', async () => {
     const source = await readFile(path.resolve(process.cwd(), 'server/server.ts'), 'utf8');
     const compositionStart = source.indexOf(

--- a/tests/unit/services/internal-analysis/analysis-checkpoint-service.test.ts
+++ b/tests/unit/services/internal-analysis/analysis-checkpoint-service.test.ts
@@ -18,6 +18,7 @@ import {
   draftIdempotencyKey,
   listReferences,
   planQuarterlyDrafts,
+  replaceDraftEconomicsReference,
   refreshDraft,
   saveDraft,
   selectTerminalReferences,
@@ -54,6 +55,10 @@ class FakePorts implements AnalysisCheckpointPorts {
   nextForecastId = 900;
   /** Persisted basis per forecast fund_snapshot id -- the coherence oracle. */
   forecastBasis = new Map<number, number | null>();
+  economicsRuns = new Map<
+    number,
+    { fundId: number; runState: 'completed' | 'failed'; factsSnapshotId: number }
+  >();
   rebuildCalls: Array<{ fundId: number; asOfDate: string; idempotencyKey: string }> = [];
 
   /** Mirrors the fund-scoped idempotency uniques the real tables enforce. */
@@ -143,6 +148,7 @@ class FakePorts implements AnalysisCheckpointPorts {
     draft.knowledgeCutoff = input.basis.knowledgeCutoff;
     draft.financialFactsSnapshotId = input.basis.financialFactsSnapshotId;
     draft.forecastFundSnapshotId = input.basis.forecastFundSnapshotId;
+    draft.economicsReferenceId = null;
     draft.version += 1;
     draft.updatedAt = this.tick();
     return { ...draft };
@@ -190,7 +196,57 @@ class FakePorts implements AnalysisCheckpointPorts {
 
   async readComponentBasis(input: { fundId: number; component: PinnedComponentKind; id: number }) {
     if (input.component === 'forecast') return this.forecastBasis.get(input.id) ?? null;
+    if (input.component === 'economics') {
+      const run = this.economicsRuns.get(input.id);
+      return run?.fundId === input.fundId ? run.factsSnapshotId : null;
+    }
     return null;
+  }
+
+  async replaceDraftEconomicsReference(
+    input: Parameters<AnalysisCheckpointPorts['replaceDraftEconomicsReference']>[0]
+  ) {
+    if (input.economicsReferenceId !== null) {
+      const run = this.economicsRuns.get(input.economicsReferenceId);
+      if (!run || run.fundId !== input.fundId) {
+        throw new AnalysisCheckpointServiceError(
+          404,
+          'ECONOMICS_RUN_NOT_FOUND',
+          'Economics run not found.'
+        );
+      }
+      if (run.runState !== 'completed') {
+        throw new AnalysisCheckpointServiceError(
+          409,
+          'ECONOMICS_RUN_NOT_COMPLETED',
+          'Only completed economics runs can be attached.'
+        );
+      }
+    }
+
+    const draft = this.findDraft(input.fundId, input.draftId);
+    if (!draft) {
+      throw new AnalysisCheckpointServiceError(404, 'DRAFT_NOT_FOUND', 'Analysis draft not found.');
+    }
+    if (draft.savedAt !== null) {
+      throw new AnalysisCheckpointServiceError(
+        409,
+        'DRAFT_ALREADY_SAVED',
+        'Saved draft is immutable.'
+      );
+    }
+    if (draft.version !== input.expectedVersion) {
+      throw new AnalysisCheckpointServiceError(
+        412,
+        'DRAFT_VERSION_CONFLICT',
+        'The draft changed since it was read.'
+      );
+    }
+
+    draft.economicsReferenceId = input.economicsReferenceId;
+    draft.version += 1;
+    draft.updatedAt = this.tick();
+    return { ...draft };
   }
 
   /**
@@ -488,6 +544,37 @@ describe('analysis checkpoint service', () => {
       });
 
       expect(ports.events.map((event) => event.eventType)).toEqual(['created', 'refreshed']);
+      expect(ports.events.at(-1)?.detail).toMatchObject({ economicsReferenceCleared: false });
+    });
+
+    it('clears an economics pin in the same refresh mutation and records it', async () => {
+      const draft = await createDraftForPeriod(ports, {
+        fundId: FUND,
+        period: Q2_2026,
+        actorId: null,
+      });
+      ports.economicsRuns.set(21, {
+        fundId: FUND,
+        runState: 'completed',
+        factsSnapshotId: draft.financialFactsSnapshotId,
+      });
+      await replaceDraftEconomicsReference(ports, {
+        fundId: FUND,
+        draftId: draft.draftId,
+        expectedVersion: 1,
+        economicsReferenceId: 21,
+      });
+
+      const refreshed = await refreshDraft(ports, {
+        fundId: FUND,
+        draftId: draft.draftId,
+        expectedVersion: 2,
+        actorId: null,
+      });
+
+      expect(refreshed.economicsReferenceId).toBeNull();
+      expect(refreshed.version).toBe(3);
+      expect(ports.events.at(-1)?.detail).toMatchObject({ economicsReferenceCleared: true });
     });
 
     it('rejects a stale expected version', async () => {
@@ -531,6 +618,98 @@ describe('analysis checkpoint service', () => {
     });
   });
 
+  describe('replaceDraftEconomicsReference', () => {
+    async function openDraft() {
+      return createDraftForPeriod(ports, { fundId: FUND, period: Q2_2026, actorId: 5 });
+    }
+
+    it('attaches, replaces with the same value, and clears as three mutations', async () => {
+      const draft = await openDraft();
+      ports.economicsRuns.set(21, {
+        fundId: FUND,
+        runState: 'completed',
+        factsSnapshotId: draft.financialFactsSnapshotId,
+      });
+
+      const attached = await replaceDraftEconomicsReference(ports, {
+        fundId: FUND,
+        draftId: draft.draftId,
+        expectedVersion: 1,
+        economicsReferenceId: 21,
+      });
+      const sameValue = await replaceDraftEconomicsReference(ports, {
+        fundId: FUND,
+        draftId: draft.draftId,
+        expectedVersion: 2,
+        economicsReferenceId: 21,
+      });
+      const cleared = await replaceDraftEconomicsReference(ports, {
+        fundId: FUND,
+        draftId: draft.draftId,
+        expectedVersion: 3,
+        economicsReferenceId: null,
+      });
+
+      expect(attached).toMatchObject({ economicsReferenceId: 21, version: 2 });
+      expect(sameValue).toMatchObject({ economicsReferenceId: 21, version: 3 });
+      expect(cleared).toMatchObject({ economicsReferenceId: null, version: 4 });
+      expect(cleared.updatedAt.getTime()).toBeGreaterThan(sameValue.updatedAt.getTime());
+    });
+
+    it.each([
+      ['missing', undefined, 404, 'ECONOMICS_RUN_NOT_FOUND'],
+      [
+        'cross-fund',
+        { fundId: OTHER_FUND, runState: 'completed' as const, factsSnapshotId: 100 },
+        404,
+        'ECONOMICS_RUN_NOT_FOUND',
+      ],
+      [
+        'failed',
+        { fundId: FUND, runState: 'failed' as const, factsSnapshotId: 100 },
+        409,
+        'ECONOMICS_RUN_NOT_COMPLETED',
+      ],
+    ])('rejects a %s target', async (_label, run, statusCode, code) => {
+      const draft = await openDraft();
+      if (run) ports.economicsRuns.set(21, run);
+
+      await expect(
+        replaceDraftEconomicsReference(ports, {
+          fundId: FUND,
+          draftId: draft.draftId,
+          expectedVersion: 1,
+          economicsReferenceId: 21,
+        })
+      ).rejects.toMatchObject({ statusCode, code });
+    });
+
+    it('rejects a saved draft without changing the pin', async () => {
+      const draft = await openDraft();
+      ports.economicsRuns.set(21, {
+        fundId: FUND,
+        runState: 'completed',
+        factsSnapshotId: draft.financialFactsSnapshotId,
+      });
+      await saveDraft(ports, {
+        fundId: FUND,
+        draftId: draft.draftId,
+        expectedVersion: 1,
+        acknowledgeMixedBasis: false,
+        actorId: 5,
+      });
+
+      await expect(
+        replaceDraftEconomicsReference(ports, {
+          fundId: FUND,
+          draftId: draft.draftId,
+          expectedVersion: 1,
+          economicsReferenceId: 21,
+        })
+      ).rejects.toMatchObject({ statusCode: 409, code: 'DRAFT_ALREADY_SAVED' });
+    });
+  });
+
   describe('saveDraft', () => {
     async function openDraft() {
       return createDraftForPeriod(ports, { fundId: FUND, period: Q2_2026, actorId: 5 });
@@ -551,6 +730,32 @@ describe('analysis checkpoint service', () => {
       expect(reference.supersedesReferenceId).toBeNull();
       expect(reference.financialFactsSnapshotId).toBe(draft.financialFactsSnapshotId);
       expect(ports.events.at(-1)?.eventType).toBe('saved');
+    });
+
+    it('copies the economics pin into the immutable reference and compares its facts basis', async () => {
+      const draft = await openDraft();
+      ports.economicsRuns.set(21, {
+        fundId: FUND,
+        runState: 'completed',
+        factsSnapshotId: draft.financialFactsSnapshotId,
+      });
+      await replaceDraftEconomicsReference(ports, {
+        fundId: FUND,
+        draftId: draft.draftId,
+        expectedVersion: 1,
+        economicsReferenceId: 21,
+      });
+
+      const reference = await saveDraft(ports, {
+        fundId: FUND,
+        draftId: draft.draftId,
+        expectedVersion: 2,
+        acknowledgeMixedBasis: false,
+        actorId: 5,
+      });
+
+      expect(reference.economicsReferenceId).toBe(21);
+      expect(reference.mixedBasisAtSave).toBe(false);
     });
 
     it('closes the draft so it can no longer be refreshed or re-saved', async () => {

--- a/tests/unit/services/operating-objects/task-evidence-link-service.test.ts
+++ b/tests/unit/services/operating-objects/task-evidence-link-service.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+
+import type { TaskEvidenceTarget } from '../../../../shared/contracts/operating-objects/task-evidence-link.contract';
+import {
+  TaskEvidenceLinkServiceError,
+  createTaskEvidenceLinkWithPorts,
+  type TaskEvidenceLinkPorts,
+  type TaskEvidenceLinkRecord,
+} from '../../../../server/services/operating-objects/task-evidence-link-service';
+import { IdempotentCommandError } from '../../../../server/lib/idempotent-command';
+
+class FakePorts implements TaskEvidenceLinkPorts {
+  tasks = new Set(['1:2']);
+  targets = new Set(['1:analysis_reference:11', '1:internal_economics_run:12']);
+  rows = new Map<string, { row: TaskEvidenceLinkRecord; requestHash: string }>();
+  nextId = 1;
+
+  async assertTaskOwned(fundId: number, taskId: number) {
+    if (!this.tasks.has(`${fundId}:${taskId}`)) {
+      throw new TaskEvidenceLinkServiceError(404, 'TASK_NOT_FOUND', 'Task not found.');
+    }
+  }
+
+  async assertTargetOwned(fundId: number, target: TaskEvidenceTarget) {
+    if (!this.targets.has(`${fundId}:${target.kind}:${target.id}`)) {
+      throw new TaskEvidenceLinkServiceError(404, 'EVIDENCE_TARGET_NOT_FOUND', 'Target not found.');
+    }
+  }
+
+  async createIdempotent(input: Parameters<TaskEvidenceLinkPorts['createIdempotent']>[0]) {
+    await Promise.resolve();
+    const key = `${input.fundId}:${input.taskId}:${input.idempotencyKey}`;
+    const requestHash = JSON.stringify(input.preimage);
+    const existing = this.rows.get(key);
+    if (existing) {
+      if (existing.requestHash !== requestHash) {
+        throw new IdempotentCommandError(
+          409,
+          'IDEMPOTENCY_KEY_REUSE',
+          'Idempotency-Key was already used for a different request.'
+        );
+      }
+      return { row: existing.row, replayed: true };
+    }
+
+    const row: TaskEvidenceLinkRecord = {
+      id: this.nextId++,
+      fundId: input.fundId,
+      taskId: input.taskId,
+      targetKind: input.target.kind,
+      analysisReferenceId: input.target.kind === 'analysis_reference' ? input.target.id : null,
+      economicsRunId: input.target.kind === 'internal_economics_run' ? input.target.id : null,
+      idempotencyKey: input.idempotencyKey,
+      requestHash,
+      createdBy: input.actorId,
+      createdAt: new Date('2026-08-01T12:00:00.000Z'),
+    };
+    this.rows.set(key, { row, requestHash });
+    return { row, replayed: false };
+  }
+}
+
+function input(overrides: Partial<Parameters<typeof createTaskEvidenceLinkWithPorts>[1]> = {}) {
+  return {
+    fundId: 1,
+    taskId: 2,
+    target: { kind: 'analysis_reference' as const, id: 11 },
+    actorId: 7,
+    idempotencyKey: 'evidence-1',
+    ...overrides,
+  };
+}
+
+describe('task evidence link service', () => {
+  it('creates then replays the same strict public response', async () => {
+    const ports = new FakePorts();
+    const created = await createTaskEvidenceLinkWithPorts(ports, input());
+    const replay = await createTaskEvidenceLinkWithPorts(ports, input());
+
+    expect(created.replayed).toBe(false);
+    expect(replay).toEqual({ ...created, replayed: true });
+    expect(ports.rows).toHaveLength(1);
+    expect(Object.keys(created.evidenceLink).sort()).toEqual(
+      ['contractVersion', 'createdAt', 'fundId', 'linkId', 'target', 'taskId'].sort()
+    );
+  });
+
+  it('excludes actor from the preimage and preserves original creator on cross-actor replay', async () => {
+    const ports = new FakePorts();
+    const created = await createTaskEvidenceLinkWithPorts(ports, input({ actorId: 7 }));
+    const replay = await createTaskEvidenceLinkWithPorts(ports, input({ actorId: 8 }));
+
+    expect(replay.evidenceLink).toEqual(created.evidenceLink);
+    expect([...ports.rows.values()][0]?.row.createdBy).toBe(7);
+  });
+
+  it('conflicts when a scoped key is reused for another target', async () => {
+    const ports = new FakePorts();
+    await createTaskEvidenceLinkWithPorts(ports, input());
+
+    await expect(
+      createTaskEvidenceLinkWithPorts(
+        ports,
+        input({ target: { kind: 'internal_economics_run', id: 12 } })
+      )
+    ).rejects.toMatchObject({ status: 409, code: 'IDEMPOTENCY_KEY_REUSE' });
+  });
+
+  it('supports both target variants', async () => {
+    const ports = new FakePorts();
+    const economics = await createTaskEvidenceLinkWithPorts(
+      ports,
+      input({
+        idempotencyKey: 'evidence-2',
+        target: { kind: 'internal_economics_run', id: 12 },
+      })
+    );
+
+    expect(economics.evidenceLink.target).toEqual({ kind: 'internal_economics_run', id: 12 });
+  });
+
+  it('rejects missing or cross-fund task and target ownership before create', async () => {
+    const ports = new FakePorts();
+
+    await expect(
+      createTaskEvidenceLinkWithPorts(ports, input({ taskId: 99 }))
+    ).rejects.toMatchObject({
+      statusCode: 404,
+      code: 'TASK_NOT_FOUND',
+    });
+    await expect(
+      createTaskEvidenceLinkWithPorts(ports, input({ fundId: 2 }))
+    ).rejects.toMatchObject({ statusCode: 404 });
+    expect(ports.rows).toHaveLength(0);
+  });
+
+  it('collapses concurrent identical requests to one row and one response identity', async () => {
+    const ports = new FakePorts();
+    const results = await Promise.all(
+      Array.from({ length: 8 }, () => createTaskEvidenceLinkWithPorts(ports, input()))
+    );
+
+    expect(ports.rows).toHaveLength(1);
+    expect(new Set(results.map((result) => result.evidenceLink.linkId))).toEqual(new Set([1]));
+    expect(results.filter((result) => !result.replayed)).toHaveLength(1);
+  });
+});

--- a/tests/unit/source/task-evidence-link-boundary.test.ts
+++ b/tests/unit/source/task-evidence-link-boundary.test.ts
@@ -1,0 +1,20 @@
+import { readFile } from 'node:fs/promises';
+
+import { describe, expect, it } from 'vitest';
+
+describe('task evidence append-only boundary', () => {
+  it('exposes creation only: no update or delete route/service', async () => {
+    const [routeSource, serviceSource] = await Promise.all([
+      readFile('server/routes/operating-object-tasks.ts', 'utf8'),
+      readFile('server/services/operating-objects/task-evidence-link-service.ts', 'utf8'),
+    ]);
+
+    expect(routeSource).toContain(
+      "router['post'](\n  '/api/funds/:fundId/tasks/:taskId/evidence-links'"
+    );
+    expect(routeSource).not.toMatch(/router\[['"](?:put|patch|delete)['"]\]\([^)]*evidence-links/i);
+    expect(serviceSource).not.toMatch(
+      /export\s+(?:async\s+)?function\s+(?:update|delete)TaskEvidenceLink/
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add optimistic-concurrency economics-run pinning for open analysis drafts
- add immutable typed task evidence links with database-backed idempotency
- cover strict contracts, authorization, replay/concurrency, dual-runtime behavior, and linkage integration

Closes #1273
Closes #1274

## Verification

- `npm test` — 917 files passed, 11,437 tests passed
- `npm run check`
- `npm run lint`
- `npm run build`

## Known environment gaps

- PostgreSQL integration execution requires Docker/Colima or `TEST_DATABASE_URL`; neither was available locally.
- The handoff's `audit/knowledge-graph` scripts are absent from this baseline checkout.