### PR TITLE
feat: add internal economics comparison workspace

### DIFF
--- a/client/src/app/app-routes.tsx
+++ b/client/src/app/app-routes.tsx
@@ -36,6 +36,7 @@ const FundModelResultsReports = React.lazy(() => import('@/pages/fund-model-resu
 const FundModelResultsInternalAnalysis = React.lazy(
   () => import('@/pages/fund-model-results-internal-analysis')
 );
+const FundModelResultsAnalysis = React.lazy(() => import('@/pages/fund-model-results-analysis'));
 const FinancialModelingPage = React.lazy(() => import('@/pages/financial-modeling'));
 const ForecastingPage = React.lazy(() => import('@/pages/forecasting'));
 const ModelResultsPage = React.lazy(() => import('@/pages/model-results'));
@@ -91,6 +92,7 @@ const APP_ROUTE_COMPONENTS: Record<
   '/fund-model-results/:fundId/moic-analysis': FundModelResultsMoicAnalysis,
   '/fund-model-results/:fundId/reports': FundModelResultsReports,
   '/fund-model-results/:fundId/internal-analysis': FundModelResultsInternalAnalysis,
+  '/fund-model-results/:fundId/analysis': FundModelResultsAnalysis,
   '/fund-model-results/:fundId': FundModelResults,
   '/sensitivity-analysis': SensitivityAnalysisPage,
   '/reports': Reports,

--- a/client/src/components/fund-results/InternalEconomicsPanel.tsx
+++ b/client/src/components/fund-results/InternalEconomicsPanel.tsx
@@ -1,0 +1,395 @@
+/**
+ * Comparison surface for economics receipts pinned to internal analysis.
+ *
+ * Receipt values remain strings through projection and copy. Arithmetic uses
+ * Decimal, and the visible evidence block is the exact clipboard payload.
+ */
+import { useState } from 'react';
+
+import Decimal from '@shared/lib/decimal-config';
+import type { InternalLpEconomicsRunReceiptV1 } from '@shared/contracts/internal-economics/lp-economics-run-receipt-v1.contract';
+import { Button } from '@/components/ui/button';
+import {
+  formatDecimalCurrency,
+  formatDecimalRatio,
+  formatIrr,
+} from '@/lib/format/lp-reporting/decimal';
+
+export const INTERNAL_ECONOMICS_NOTICE =
+  'Internal decision support and communication preparation only. Not an official financial, accounting, tax, legal, compliance, or LP report.';
+
+export interface InternalEconomicsPanelPin {
+  sourceKind: 'draft' | 'reference';
+  sourceId: number;
+  periodStart: string;
+  periodEnd: string;
+  createdAt: string;
+  knowledgeCutoff: string;
+  analysisFactsSnapshotId: number;
+  mixedBasisAtSave: boolean;
+}
+
+export interface InternalEconomicsPanelGroup {
+  runId: number;
+  pins: readonly InternalEconomicsPanelPin[];
+  primaryPin: InternalEconomicsPanelPin;
+}
+
+export interface InternalEconomicsPanelSelection {
+  baselineRunId: number | null;
+  currentRunId: number | null;
+}
+
+export type InternalEconomicsPanelSlot =
+  | { runId: number | null; state: 'empty'; receipt: null; error: null }
+  | { runId: number; state: 'pending'; receipt: null; error: null }
+  | { runId: number; state: 'ready'; receipt: InternalLpEconomicsRunReceiptV1; error: null }
+  | { runId: number; state: 'error'; receipt: null; error: Error };
+
+export interface InternalEconomicsPanelProps {
+  groups: readonly InternalEconomicsPanelGroup[];
+  selection: InternalEconomicsPanelSelection;
+  baseline: InternalEconomicsPanelSlot;
+  current: InternalEconomicsPanelSlot;
+  onSelectionChange: (selection: InternalEconomicsPanelSelection) => void;
+}
+
+type EvidenceInput = Omit<InternalEconomicsPanelProps, 'onSelectionChange'>;
+type ValueResult = Extract<
+  Extract<InternalLpEconomicsRunReceiptV1['outcome'], { runState: 'completed' }>['result'],
+  { resultStatus: 'available' | 'indicative' }
+>;
+
+interface MetricDefinition {
+  key: string;
+  label: string;
+  value: (result: ValueResult) => string | null;
+  format: (value: string | null) => string;
+}
+
+const MONEY = (value: string | null) => formatDecimalCurrency(value);
+const RATIO = (value: string | null) => formatDecimalRatio(value);
+
+const METRICS: readonly MetricDefinition[] = [
+  { key: 'lp-calls', label: 'LP calls', value: (result) => result.totals.lpCapitalCallUsd, format: MONEY },
+  { key: 'management-fees', label: 'Management fees', value: (result) => result.totals.managementFeesUsd, format: MONEY },
+  { key: 'lp-distributions', label: 'LP distributions', value: (result) => result.totals.lpDistributionUsd, format: MONEY },
+  { key: 'gp-carry', label: 'GP carry', value: (result) => result.totals.gpCarryDistributedUsd, format: MONEY },
+  { key: 'ending-cash', label: 'Ending cash', value: (result) => result.totals.endingCashUsd, format: MONEY },
+  { key: 'gross-nav', label: 'Gross NAV', value: (result) => result.totals.grossNavUsd, format: MONEY },
+  { key: 'lp-net-nav', label: 'LP net NAV', value: (result) => result.totals.lpNetNavUsd, format: MONEY },
+  { key: 'dpi', label: 'DPI', value: (result) => result.totals.dpi, format: RATIO },
+  { key: 'rvpi', label: 'RVPI', value: (result) => result.totals.rvpi, format: RATIO },
+  { key: 'tvpi', label: 'TVPI', value: (result) => result.totals.tvpi, format: RATIO },
+  { key: 'lp-net-irr', label: 'LP net IRR', value: (result) => result.lpNetIrr, format: formatIrr },
+] as const;
+
+function valueResult(slot: InternalEconomicsPanelSlot): ValueResult | null {
+  if (slot.state !== 'ready' || slot.receipt.outcome.runState !== 'completed') return null;
+  const result = slot.receipt.outcome.result;
+  return result.resultStatus === 'unavailable' ? null : result;
+}
+
+function groupFor(
+  groups: readonly InternalEconomicsPanelGroup[],
+  runId: number | null
+): InternalEconomicsPanelGroup | null {
+  return groups.find((group) => group.runId === runId) ?? null;
+}
+
+function coherenceWarnings(
+  group: InternalEconomicsPanelGroup | null,
+  slot: InternalEconomicsPanelSlot
+): string[] {
+  if (group === null || slot.state !== 'ready') return [];
+  const warnings: string[] = [];
+  if (slot.receipt.basis.factsSnapshotId !== group.primaryPin.analysisFactsSnapshotId) {
+    warnings.push('Economics pin basis mismatch');
+  }
+  if (group.primaryPin.sourceKind === 'reference' && group.primaryPin.mixedBasisAtSave) {
+    warnings.push('Bundle mixed at save');
+  }
+  return warnings;
+}
+
+function isCoherent(
+  group: InternalEconomicsPanelGroup | null,
+  slot: InternalEconomicsPanelSlot
+): boolean {
+  return slot.state === 'ready' && coherenceWarnings(group, slot).length === 0;
+}
+
+function decimalDelta(baseline: string | null, current: string | null): string | null {
+  if (baseline === null || current === null) return null;
+  return new Decimal(current).minus(new Decimal(baseline)).toFixed();
+}
+
+function sourceLabel(pin: InternalEconomicsPanelPin): string {
+  return pin.sourceKind === 'draft' ? `Open draft #${pin.sourceId}` : `Reference #${pin.sourceId}`;
+}
+
+function groupLabel(group: InternalEconomicsPanelGroup): string {
+  const pin = group.primaryPin;
+  const lineage = group.pins.length === 1 ? '' : ` + ${group.pins.length - 1} linked pin${group.pins.length === 2 ? '' : 's'}`;
+  return `${pin.periodStart} to ${pin.periodEnd} - ${sourceLabel(pin)}${lineage}`;
+}
+
+function titleCase(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function reasonLines(slot: InternalEconomicsPanelSlot): string[] {
+  if (slot.state === 'error') return [`Read error: ${slot.error.message}`];
+  if (slot.state !== 'ready') return [];
+  if (slot.receipt.outcome.runState === 'failed') {
+    return [`Failure: ${slot.receipt.outcome.failure.code}`];
+  }
+  return slot.receipt.outcome.result.reasons.map((reason) =>
+    reason.detail === undefined ? reason.code : `${reason.code}: ${reason.detail}`
+  );
+}
+
+function runStatus(slot: InternalEconomicsPanelSlot): string {
+  if (slot.state === 'empty') return 'Empty';
+  if (slot.state === 'pending') return 'Pending';
+  if (slot.state === 'error') return 'Error';
+  return titleCase(slot.receipt.outcome.runState);
+}
+
+function resultStatus(slot: InternalEconomicsPanelSlot): string {
+  if (slot.state !== 'ready' || slot.receipt.outcome.runState === 'failed') return 'Unavailable';
+  return titleCase(slot.receipt.outcome.result.resultStatus);
+}
+
+function appendSlotEvidence(
+  lines: string[],
+  label: string,
+  group: InternalEconomicsPanelGroup | null,
+  slot: InternalEconomicsPanelSlot
+): void {
+  lines.push(`${label}:`);
+  lines.push(`Pin: ${group === null ? 'None' : `${sourceLabel(group.primaryPin)} (${group.primaryPin.periodStart} to ${group.primaryPin.periodEnd})`}`);
+  lines.push(`Run ID: ${slot.runId ?? 'None'}`);
+  lines.push(`Analysis facts snapshot ID: ${group?.primaryPin.analysisFactsSnapshotId ?? 'None'}`);
+  lines.push(`As of: ${group?.primaryPin.knowledgeCutoff ?? 'Unavailable'}`);
+  lines.push(`Run status: ${runStatus(slot)}`);
+  lines.push(`Result status: ${resultStatus(slot)}`);
+  if (slot.state === 'ready') {
+    const receipt = slot.receipt;
+    lines.push(`Receipt basis cutoff: ${receipt.basis.knowledgeCutoff}`);
+    lines.push(`Receipt facts snapshot ID: ${receipt.basis.factsSnapshotId}`);
+    lines.push(`Facts input hash (short): ${receipt.hashes.factsSnapshotInputHash.slice(0, 12)}`);
+    lines.push('Provenance:');
+    lines.push(`  Policy version ID: ${receipt.basis.policyVersionId}`);
+    lines.push(`  Capital envelope version ID: ${receipt.basis.capitalEnvelopeVersionId}`);
+    lines.push(`  Facts snapshot ID: ${receipt.basis.factsSnapshotId}`);
+    lines.push(`  Plan version ID: ${receipt.basis.planVersionId}`);
+    lines.push(`  Forecast snapshot ID: ${receipt.basis.forecastSnapshotId}`);
+    lines.push(`  Terminal settings: ${receipt.basis.terminalMode} through ${receipt.basis.terminalPeriodEnd} (${receipt.basis.terminalResolutionMethodologyVersion})`);
+    lines.push(`  Calculation contract version: ${receipt.versions.calculationContractVersion}`);
+    lines.push(`  Engine version: ${receipt.versions.engineVersion}`);
+    lines.push(`  Methodology version: ${receipt.versions.methodologyVersion}`);
+    lines.push(`  Waterfall template: ${receipt.outcome.runState === 'completed' ? receipt.outcome.result.waterfallTemplate : 'Unavailable'}`);
+    for (const [hashLabel, hash] of Object.entries(receipt.hashes)) {
+      lines.push(`  ${hashLabel}: ${hash ?? 'Unavailable'}`);
+    }
+  } else {
+    lines.push('Receipt basis cutoff: Unavailable');
+  }
+  for (const warning of coherenceWarnings(group, slot)) lines.push(`Warning: ${warning}`);
+  for (const reason of reasonLines(slot)) lines.push(`Reason: ${reason}`);
+}
+
+/** Pure renderer used by both the visible preformatted block and clipboard. */
+export function renderInternalEconomicsCopyText(input: EvidenceInput): string {
+  const baselineGroup = groupFor(input.groups, input.selection.baselineRunId);
+  const currentGroup = groupFor(input.groups, input.selection.currentRunId);
+  const baselineResult = valueResult(input.baseline);
+  const currentResult = valueResult(input.current);
+  const deltasAllowed =
+    isCoherent(baselineGroup, input.baseline) && isCoherent(currentGroup, input.current);
+  const lines = [INTERNAL_ECONOMICS_NOTICE, ''];
+
+  appendSlotEvidence(lines, 'Baseline', baselineGroup, input.baseline);
+  lines.push('');
+  appendSlotEvidence(lines, 'Comparison', currentGroup, input.current);
+  lines.push('', 'Metrics (raw decimal strings):');
+  for (const metric of METRICS) {
+    const baseline = baselineResult === null ? null : metric.value(baselineResult);
+    const current = currentResult === null ? null : metric.value(currentResult);
+    const delta = deltasAllowed ? decimalDelta(baseline, current) : null;
+    lines.push(`${metric.label}: baseline=${baseline ?? 'Unavailable'}; comparison=${current ?? 'Unavailable'}; delta=${delta ?? 'Unavailable'}`);
+  }
+  lines.push('');
+  lines.push('Methodology disclosure: forecast uses flat annual fee drag compiled from the same tiered inputs; economics applies the tiered schedule quarterly - methodology difference, not input difference.');
+  return lines.join('\n');
+}
+
+interface ProvenanceDefinition {
+  label: string;
+  value: (receipt: InternalLpEconomicsRunReceiptV1) => string;
+}
+
+const PROVENANCE: readonly ProvenanceDefinition[] = [
+  { label: 'Policy', value: (receipt) => String(receipt.basis.policyVersionId) },
+  { label: 'Capital envelope', value: (receipt) => String(receipt.basis.capitalEnvelopeVersionId) },
+  { label: 'Facts', value: (receipt) => String(receipt.basis.factsSnapshotId) },
+  { label: 'Plan', value: (receipt) => String(receipt.basis.planVersionId) },
+  { label: 'Forecast', value: (receipt) => String(receipt.basis.forecastSnapshotId) },
+  { label: 'Terminal settings', value: (receipt) => `${receipt.basis.terminalMode} / ${receipt.basis.terminalPeriodEnd} / ${receipt.basis.terminalResolutionMethodologyVersion}` },
+  { label: 'Calculation contract', value: (receipt) => receipt.versions.calculationContractVersion },
+  { label: 'Engine', value: (receipt) => receipt.versions.engineVersion },
+  { label: 'Methodology', value: (receipt) => receipt.versions.methodologyVersion },
+  { label: 'Waterfall template', value: (receipt) => receipt.outcome.runState === 'completed' ? receipt.outcome.result.waterfallTemplate : 'Unavailable' },
+  { label: 'Capital envelope hash', value: (receipt) => receipt.hashes.capitalEnvelopeHash },
+  { label: 'Policy assumptions hash', value: (receipt) => receipt.hashes.policyAssumptionsHash },
+  { label: 'Facts snapshot input hash', value: (receipt) => receipt.hashes.factsSnapshotInputHash },
+  { label: 'Plan assumptions hash', value: (receipt) => receipt.hashes.planAssumptionsHash },
+  { label: 'Forecast input hash', value: (receipt) => receipt.hashes.forecastInputHash },
+  { label: 'Input hash', value: (receipt) => receipt.hashes.inputHash },
+  { label: 'Result hash', value: (receipt) => receipt.hashes.resultHash ?? 'Unavailable' },
+];
+
+function readyReceipt(slot: InternalEconomicsPanelSlot): InternalLpEconomicsRunReceiptV1 | null {
+  return slot.state === 'ready' ? slot.receipt : null;
+}
+
+function SlotSummary({
+  label,
+  group,
+  slot,
+}: {
+  label: string;
+  group: InternalEconomicsPanelGroup | null;
+  slot: InternalEconomicsPanelSlot;
+}) {
+  const warnings = coherenceWarnings(group, slot);
+  const reasons = reasonLines(slot);
+  return (
+    <div className="space-y-1 rounded-md border border-beige-200 p-3 text-sm">
+      <h3 className="font-semibold text-pov-charcoal">{label}</h3>
+      <p>Run: <span className="tabular-nums">{slot.runId ?? '--'}</span></p>
+      <p>Run status: {runStatus(slot)}</p>
+      <p>Result status: {resultStatus(slot)}</p>
+      {slot.state === 'ready' ? <p>Receipt basis cutoff: {slot.receipt.basis.knowledgeCutoff}</p> : null}
+      {warnings.map((warning) => <p key={warning} role="alert" className="font-medium text-pov-charcoal">{warning}</p>)}
+      {reasons.length === 0 ? null : (
+        <ul className="list-disc space-y-1 pl-5">
+          {reasons.map((reason) => <li key={reason}>{reason}</li>)}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export function InternalEconomicsPanel({
+  groups,
+  selection,
+  baseline,
+  current,
+  onSelectionChange,
+}: InternalEconomicsPanelProps) {
+  const [copyStatus, setCopyStatus] = useState('');
+  const baselineGroup = groupFor(groups, selection.baselineRunId);
+  const currentGroup = groupFor(groups, selection.currentRunId);
+  const baselineResult = valueResult(baseline);
+  const currentResult = valueResult(current);
+  const deltasAllowed = isCoherent(baselineGroup, baseline) && isCoherent(currentGroup, current);
+  const evidence = renderInternalEconomicsCopyText({ groups, selection, baseline, current });
+
+  const selectRun = (slot: 'baseline' | 'current', value: string) => {
+    const selected = value === '' ? null : Number.parseInt(value, 10);
+    if (slot === 'baseline') {
+      onSelectionChange(
+        selected !== null && selected === selection.currentRunId
+          ? { baselineRunId: selection.currentRunId, currentRunId: selection.baselineRunId }
+          : { ...selection, baselineRunId: selected }
+      );
+      return;
+    }
+    onSelectionChange(
+      selected !== null && selected === selection.baselineRunId
+        ? { baselineRunId: selection.currentRunId, currentRunId: selection.baselineRunId }
+        : { ...selection, currentRunId: selected }
+    );
+  };
+
+  return (
+    <section aria-labelledby="internal-economics-heading" className="space-y-5 rounded-lg border border-beige-200 bg-white p-4">
+      <div>
+        <h2 id="internal-economics-heading" className="text-lg font-semibold text-pov-charcoal">Internal economics comparison</h2>
+        <p className="mt-1 text-sm text-presson-textMuted">{INTERNAL_ECONOMICS_NOTICE}</p>
+      </div>
+
+      {groups.length === 0 ? <p className="text-sm text-presson-textMuted">No pinned economics runs are available for comparison.</p> : (
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="space-y-1 text-sm font-medium text-pov-charcoal">
+            <span>Baseline</span>
+            <select aria-label="Baseline economics run" value={selection.baselineRunId ?? ''} onChange={(event) => selectRun('baseline', event.target.value)} className="w-full rounded-md border border-beige-200 bg-white p-2 font-normal">
+              <option value="">No baseline</option>
+              {groups.map((group) => <option key={group.runId} value={group.runId}>{groupLabel(group)}</option>)}
+            </select>
+          </label>
+          <label className="space-y-1 text-sm font-medium text-pov-charcoal">
+            <span>Comparison</span>
+            <select aria-label="Comparison economics run" value={selection.currentRunId ?? ''} onChange={(event) => selectRun('current', event.target.value)} className="w-full rounded-md border border-beige-200 bg-white p-2 font-normal">
+              <option value="">No comparison</option>
+              {groups.map((group) => <option key={group.runId} value={group.runId}>{groupLabel(group)}</option>)}
+            </select>
+          </label>
+        </div>
+      )}
+
+      <div className="grid gap-3 md:grid-cols-2">
+        <SlotSummary label="Baseline receipt" group={baselineGroup} slot={baseline} />
+        <SlotSummary label="Comparison receipt" group={currentGroup} slot={current} />
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse text-left text-sm">
+          <caption className="mb-2 text-left font-semibold text-pov-charcoal">Economics result metrics</caption>
+          <thead><tr className="border-b border-beige-200"><th scope="col" className="p-2">Metric</th><th scope="col" className="p-2">Baseline</th><th scope="col" className="p-2">Comparison</th><th scope="col" className="p-2">Arithmetic delta</th></tr></thead>
+          <tbody>
+            {METRICS.map((metric) => {
+              const baselineValue = baselineResult === null ? null : metric.value(baselineResult);
+              const currentValue = currentResult === null ? null : metric.value(currentResult);
+              const delta = deltasAllowed ? decimalDelta(baselineValue, currentValue) : null;
+              return <tr key={metric.key} className="border-b border-beige-100"><th scope="row" className="p-2 font-medium">{metric.label}</th><td className="p-2 tabular-nums">{metric.format(baselineValue)}</td><td className="p-2 tabular-nums">{metric.format(currentValue)}</td><td className="p-2 tabular-nums">{metric.format(delta)}</td></tr>;
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse text-left text-sm">
+          <caption className="mb-2 text-left font-semibold text-pov-charcoal">Receipt provenance comparison</caption>
+          <thead><tr className="border-b border-beige-200"><th scope="col" className="p-2">Provenance field</th><th scope="col" className="p-2">Baseline</th><th scope="col" className="p-2">Comparison</th><th scope="col" className="p-2">Comparison</th></tr></thead>
+          <tbody>
+            {PROVENANCE.map((field) => {
+              const baselineReceipt = readyReceipt(baseline);
+              const currentReceipt = readyReceipt(current);
+              const baselineValue = baselineReceipt === null ? 'Unavailable' : field.value(baselineReceipt);
+              const currentValue = currentReceipt === null ? 'Unavailable' : field.value(currentReceipt);
+              const comparison = baselineReceipt === null || currentReceipt === null ? 'Unavailable' : baselineValue === currentValue ? 'Same' : 'Changed';
+              return <tr key={field.label} className="border-b border-beige-100"><th scope="row" className="p-2 font-medium">{field.label}</th><td className="max-w-xs break-all p-2 font-mono text-xs">{baselineValue}</td><td className="max-w-xs break-all p-2 font-mono text-xs">{currentValue}</td><td className="p-2">{comparison}</td></tr>;
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <p className="text-sm text-presson-textMuted">Forecast uses flat annual fee drag compiled from the same tiered inputs; economics applies the tiered schedule quarterly - methodology difference, not input difference.</p>
+
+      <div className="space-y-2">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h3 className="text-sm font-semibold text-pov-charcoal">Copyable evidence</h3>
+          <Button type="button" variant="ghost" size="sm" aria-label="Copy the full internal economics evidence block" onClick={() => {
+            if (!navigator.clipboard) { setCopyStatus('Copy failed'); return; }
+            void navigator.clipboard.writeText(evidence).then(() => setCopyStatus('Evidence copied')).catch(() => setCopyStatus('Copy failed'));
+          }}>Copy evidence</Button>
+        </div>
+        <p aria-live="polite" className="text-xs text-presson-textMuted">{copyStatus}</p>
+        <pre data-testid="internal-economics-copy-block" className="whitespace-pre-wrap rounded-md border border-beige-200 bg-white p-3 text-xs text-pov-charcoal">{evidence}</pre>
+      </div>
+    </section>
+  );
+}

--- a/client/src/components/fund-results/InternalEconomicsPanel.tsx
+++ b/client/src/components/fund-results/InternalEconomicsPanel.tsx
@@ -326,9 +326,9 @@ export function InternalEconomicsPanel({
   };
 
   return (
-    <section aria-labelledby="internal-economics-heading" className="space-y-5 rounded-lg border border-beige-200 bg-white p-4">
+    <section aria-labelledby="internal-economics-panel-heading" className="space-y-5 rounded-lg border border-beige-200 bg-white p-4">
       <div>
-        <h2 id="internal-economics-heading" className="text-lg font-semibold text-pov-charcoal">Internal economics comparison</h2>
+        <h2 id="internal-economics-panel-heading" className="text-lg font-semibold text-pov-charcoal">Internal economics comparison</h2>
         <p className="mt-1 text-sm text-presson-textMuted">{INTERNAL_ECONOMICS_NOTICE}</p>
       </div>
 

--- a/client/src/components/fund-results/InternalEconomicsPanel.tsx
+++ b/client/src/components/fund-results/InternalEconomicsPanel.tsx
@@ -142,11 +142,14 @@ function reasonLines(slot: InternalEconomicsPanelSlot): string[] {
   if (slot.state === 'error') return [`Read error: ${slot.error.message}`];
   if (slot.state !== 'ready') return [];
   if (slot.receipt.outcome.runState === 'failed') {
-    return [`Failure: ${slot.receipt.outcome.failure.code}`];
+    const failure = slot.receipt.outcome.failure;
+    return [`Failure: ${failure.code}; context=${JSON.stringify(failure.context)}`];
   }
-  return slot.receipt.outcome.result.reasons.map((reason) =>
-    reason.detail === undefined ? reason.code : `${reason.code}: ${reason.detail}`
-  );
+  return slot.receipt.outcome.result.reasons.map((reason) => {
+    const detail = reason.detail === undefined ? '' : `: ${reason.detail}`;
+    const context = reason.context === undefined ? '' : `; context=${JSON.stringify(reason.context)}`;
+    return `${reason.code}${detail}${context}`;
+  });
 }
 
 function runStatus(slot: InternalEconomicsPanelSlot): string {
@@ -169,6 +172,14 @@ function appendSlotEvidence(
 ): void {
   lines.push(`${label}:`);
   lines.push(`Pin: ${group === null ? 'None' : `${sourceLabel(group.primaryPin)} (${group.primaryPin.periodStart} to ${group.primaryPin.periodEnd})`}`);
+  if (group !== null) {
+    lines.push('Pin lineage:');
+    for (const pin of group.pins) {
+      lines.push(
+        `  ${sourceLabel(pin)}; facts snapshot ID=${pin.analysisFactsSnapshotId}; as of=${pin.knowledgeCutoff}`
+      );
+    }
+  }
   lines.push(`Run ID: ${slot.runId ?? 'None'}`);
   lines.push(`Analysis facts snapshot ID: ${group?.primaryPin.analysisFactsSnapshotId ?? 'None'}`);
   lines.push(`As of: ${group?.primaryPin.knowledgeCutoff ?? 'Unavailable'}`);
@@ -363,7 +374,7 @@ export function InternalEconomicsPanel({
       <div className="overflow-x-auto">
         <table className="w-full border-collapse text-left text-sm">
           <caption className="mb-2 text-left font-semibold text-pov-charcoal">Receipt provenance comparison</caption>
-          <thead><tr className="border-b border-beige-200"><th scope="col" className="p-2">Provenance field</th><th scope="col" className="p-2">Baseline</th><th scope="col" className="p-2">Comparison</th><th scope="col" className="p-2">Comparison</th></tr></thead>
+          <thead><tr className="border-b border-beige-200"><th scope="col" className="p-2">Provenance field</th><th scope="col" className="p-2">Baseline</th><th scope="col" className="p-2">Comparison</th><th scope="col" className="p-2">Same or changed</th></tr></thead>
           <tbody>
             {PROVENANCE.map((field) => {
               const baselineReceipt = readyReceipt(baseline);

--- a/client/src/hooks/useInternalEconomics.ts
+++ b/client/src/hooks/useInternalEconomics.ts
@@ -18,6 +18,8 @@ export interface InternalEconomicsPin {
   sourceId: number;
   runId: number;
   period: AnalysisPeriod;
+  periodStart: string;
+  periodEnd: string;
   createdAt: string;
   knowledgeCutoff: string;
   analysisFactsSnapshotId: number;
@@ -36,15 +38,17 @@ export interface InternalEconomicsSelection {
 }
 
 export type InternalEconomicsSelectionSlot = 'baseline' | 'current';
-export type InternalEconomicsReceiptSlot =
-  | { status: 'empty'; runId: null; receipt: null; error: null }
-  | { status: 'pending'; runId: number; receipt: null; error: null }
-  | { status: 'ready'; runId: number; receipt: InternalLpEconomicsRunReceiptV1; error: null }
-  | { status: 'error'; runId: number; receipt: null; error: Error };
+export type InternalEconomicsSlot =
+  | { state: 'empty'; runId: null; receipt: null; error: null }
+  | { state: 'pending'; runId: number; receipt: null; error: null }
+  | { state: 'ready'; runId: number; receipt: InternalLpEconomicsRunReceiptV1; error: null }
+  | { state: 'error'; runId: number; receipt: null; error: Error };
+
+export type InternalEconomicsReceiptSlot = InternalEconomicsSlot;
 
 export interface InternalEconomicsResult {
-  baseline: InternalEconomicsReceiptSlot;
-  current: InternalEconomicsReceiptSlot;
+  baseline: InternalEconomicsSlot;
+  current: InternalEconomicsSlot;
 }
 
 export const internalEconomicsReceiptQueryKey = (fundId: number, runId: number) =>
@@ -81,6 +85,8 @@ export function projectInternalEconomicsPins(
         sourceId: draft.draftId,
         runId,
         period: draft.period,
+        periodStart: draft.period.periodStart,
+        periodEnd: draft.period.periodEnd,
         createdAt: draft.createdAt,
         knowledgeCutoff: draft.basis.knowledgeCutoff,
         analysisFactsSnapshotId: draft.basis.financialFactsSnapshotId,
@@ -98,6 +104,8 @@ export function projectInternalEconomicsPins(
         sourceId: reference.referenceId,
         runId,
         period: reference.period,
+        periodStart: reference.period.periodStart,
+        periodEnd: reference.period.periodEnd,
         createdAt: reference.createdAt,
         knowledgeCutoff: reference.basis.knowledgeCutoff,
         analysisFactsSnapshotId: reference.basis.financialFactsSnapshotId,
@@ -174,11 +182,11 @@ export function selectInternalEconomicsRun(
 function toReceiptSlot(
   runId: number | null,
   query: UseQueryResult<InternalLpEconomicsRunReceiptV1, Error> | undefined
-): InternalEconomicsReceiptSlot {
-  if (runId === null) return { status: 'empty', runId: null, receipt: null, error: null };
-  if (query?.data) return { status: 'ready', runId, receipt: query.data, error: null };
-  if (query?.error) return { status: 'error', runId, receipt: null, error: query.error };
-  return { status: 'pending', runId, receipt: null, error: null };
+): InternalEconomicsSlot {
+  if (runId === null) return { state: 'empty', runId: null, receipt: null, error: null };
+  if (query?.data) return { state: 'ready', runId, receipt: query.data, error: null };
+  if (query?.error) return { state: 'error', runId, receipt: null, error: query.error };
+  return { state: 'pending', runId, receipt: null, error: null };
 }
 
 export function useInternalEconomics(

--- a/client/src/hooks/useInternalEconomics.ts
+++ b/client/src/hooks/useInternalEconomics.ts
@@ -1,0 +1,226 @@
+import { useQueries, type UseQueryResult } from '@tanstack/react-query';
+
+import type {
+  AnalysisDraftV1,
+  AnalysisPeriod,
+  AnalysisReferenceV1,
+} from '@shared/contracts/internal-analysis/analysis-reference-snapshot-v1.contract';
+import {
+  InternalLpEconomicsRunReceiptV1Schema,
+  type InternalLpEconomicsRunReceiptV1,
+} from '@shared/contracts/internal-economics/lp-economics-run-receipt-v1.contract';
+import { apiRequest } from '@/lib/queryClient';
+
+export type InternalEconomicsPinSourceKind = 'draft' | 'reference';
+
+export interface InternalEconomicsPin {
+  sourceKind: InternalEconomicsPinSourceKind;
+  sourceId: number;
+  runId: number;
+  period: AnalysisPeriod;
+  createdAt: string;
+  knowledgeCutoff: string;
+  analysisFactsSnapshotId: number;
+  mixedBasisAtSave: boolean;
+}
+
+export interface InternalEconomicsCandidateGroup {
+  runId: number;
+  pins: InternalEconomicsPin[];
+  primaryPin: InternalEconomicsPin;
+}
+
+export interface InternalEconomicsSelection {
+  baselineRunId: number | null;
+  currentRunId: number | null;
+}
+
+export type InternalEconomicsSelectionSlot = 'baseline' | 'current';
+export type InternalEconomicsReceiptSlot =
+  | { status: 'empty'; runId: null; receipt: null; error: null }
+  | { status: 'pending'; runId: number; receipt: null; error: null }
+  | { status: 'ready'; runId: number; receipt: InternalLpEconomicsRunReceiptV1; error: null }
+  | { status: 'error'; runId: number; receipt: null; error: Error };
+
+export interface InternalEconomicsResult {
+  baseline: InternalEconomicsReceiptSlot;
+  current: InternalEconomicsReceiptSlot;
+}
+
+export const internalEconomicsReceiptQueryKey = (fundId: number, runId: number) =>
+  ['internal-economics', 'receipt', fundId, runId] as const;
+
+function compareDescending(left: string, right: string): number {
+  return right.localeCompare(left);
+}
+
+export function compareInternalEconomicsPins(
+  left: InternalEconomicsPin,
+  right: InternalEconomicsPin
+): number {
+  return (
+    compareDescending(left.period.periodEnd, right.period.periodEnd) ||
+    compareDescending(left.period.periodStart, right.period.periodStart) ||
+    (left.sourceKind === right.sourceKind ? 0 : left.sourceKind === 'draft' ? -1 : 1) ||
+    compareDescending(left.createdAt, right.createdAt) ||
+    right.sourceId - left.sourceId
+  );
+}
+
+export function projectInternalEconomicsPins(
+  drafts: readonly AnalysisDraftV1[],
+  references: readonly AnalysisReferenceV1[]
+): InternalEconomicsPin[] {
+  const draftPins = drafts.flatMap((draft): InternalEconomicsPin[] => {
+    const runId = draft.basis.economicsReferenceId;
+    if (draft.savedAt !== null || runId === null) return [];
+
+    return [
+      {
+        sourceKind: 'draft',
+        sourceId: draft.draftId,
+        runId,
+        period: draft.period,
+        createdAt: draft.createdAt,
+        knowledgeCutoff: draft.basis.knowledgeCutoff,
+        analysisFactsSnapshotId: draft.basis.financialFactsSnapshotId,
+        mixedBasisAtSave: false,
+      },
+    ];
+  });
+  const referencePins = references.flatMap((reference): InternalEconomicsPin[] => {
+    const runId = reference.basis.economicsReferenceId;
+    if (runId === null) return [];
+
+    return [
+      {
+        sourceKind: 'reference',
+        sourceId: reference.referenceId,
+        runId,
+        period: reference.period,
+        createdAt: reference.createdAt,
+        knowledgeCutoff: reference.basis.knowledgeCutoff,
+        analysisFactsSnapshotId: reference.basis.financialFactsSnapshotId,
+        mixedBasisAtSave: reference.mixedBasisAtSave,
+      },
+    ];
+  });
+
+  return [...draftPins, ...referencePins].sort(compareInternalEconomicsPins);
+}
+
+export function groupInternalEconomicsPins(
+  pins: readonly InternalEconomicsPin[]
+): InternalEconomicsCandidateGroup[] {
+  const pinsByRun = new Map<number, InternalEconomicsPin[]>();
+  for (const pin of pins) {
+    const groupPins = pinsByRun.get(pin.runId) ?? [];
+    groupPins.push(pin);
+    pinsByRun.set(pin.runId, groupPins);
+  }
+
+  return Array.from(pinsByRun, ([runId, unsortedPins]) => {
+    const sortedPins = [...unsortedPins].sort(compareInternalEconomicsPins);
+    const primaryPin = sortedPins[0];
+    if (!primaryPin) throw new Error(`Economics run ${runId} has no analysis pins.`);
+    return { runId, pins: sortedPins, primaryPin };
+  }).sort(
+    (left, right) =>
+      compareInternalEconomicsPins(left.primaryPin, right.primaryPin) || right.runId - left.runId
+  );
+}
+
+export function defaultInternalEconomicsSelection(
+  groups: readonly InternalEconomicsCandidateGroup[]
+): InternalEconomicsSelection {
+  const current = groups[0];
+  if (!current) return { baselineRunId: null, currentRunId: null };
+
+  const baseline =
+    groups.slice(1).find((group) => {
+      const candidatePeriod = group.primaryPin.period;
+      const currentPeriod = current.primaryPin.period;
+      return (
+        candidatePeriod.periodEnd < currentPeriod.periodEnd ||
+        (candidatePeriod.periodEnd === currentPeriod.periodEnd &&
+          candidatePeriod.periodStart < currentPeriod.periodStart)
+      );
+    }) ?? groups[1];
+
+  return {
+    baselineRunId: baseline?.runId ?? null,
+    currentRunId: current.runId,
+  };
+}
+
+export function selectInternalEconomicsRun(
+  selection: InternalEconomicsSelection,
+  slot: InternalEconomicsSelectionSlot,
+  runId: number | null
+): InternalEconomicsSelection {
+  if (slot === 'baseline') {
+    if (runId !== null && runId === selection.currentRunId) {
+      return { baselineRunId: runId, currentRunId: selection.baselineRunId };
+    }
+    return { ...selection, baselineRunId: runId };
+  }
+
+  if (runId !== null && runId === selection.baselineRunId) {
+    return { baselineRunId: selection.currentRunId, currentRunId: runId };
+  }
+  return { ...selection, currentRunId: runId };
+}
+
+function toReceiptSlot(
+  runId: number | null,
+  query: UseQueryResult<InternalLpEconomicsRunReceiptV1, Error> | undefined
+): InternalEconomicsReceiptSlot {
+  if (runId === null) return { status: 'empty', runId: null, receipt: null, error: null };
+  if (query?.data) return { status: 'ready', runId, receipt: query.data, error: null };
+  if (query?.error) return { status: 'error', runId, receipt: null, error: query.error };
+  return { status: 'pending', runId, receipt: null, error: null };
+}
+
+export function useInternalEconomics(
+  fundId: number | undefined,
+  selectedRunIds: readonly [number | null, number | null]
+): InternalEconomicsResult {
+  const isValidFundId = fundId !== undefined && Number.isSafeInteger(fundId) && fundId > 0;
+  const uniqueRunIds = Array.from(
+    new Set(
+      selectedRunIds.filter(
+        (runId): runId is number =>
+          runId !== null && Number.isSafeInteger(runId) && runId > 0
+      )
+    )
+  ).slice(0, 2);
+
+  const queries = useQueries({
+    queries: uniqueRunIds.map((runId) => ({
+      queryKey: internalEconomicsReceiptQueryKey(fundId ?? 0, runId),
+      enabled: isValidFundId,
+      queryFn: async () => {
+        const rawReceipt = await apiRequest<unknown>(
+          'GET',
+          `/api/funds/${fundId}/internal-economics/runs/${runId}`
+        );
+        const receipt = InternalLpEconomicsRunReceiptV1Schema.parse(rawReceipt);
+        if (receipt.fundId !== fundId || receipt.runId !== runId) {
+          throw new Error('Economics receipt identity does not match the selected fund and run.');
+        }
+        return receipt;
+      },
+    })),
+  });
+  const queryByRunId = new Map(
+    uniqueRunIds.map((runId, index) => [
+      runId,
+      queries[index] as UseQueryResult<InternalLpEconomicsRunReceiptV1, Error>,
+    ])
+  );
+
+  return {
+    baseline: toReceiptSlot(selectedRunIds[0], queryByRunId.get(selectedRunIds[0] ?? -1)),
+    current: toReceiptSlot(selectedRunIds[1], queryByRunId.get(selectedRunIds[1] ?? -1)),
+  };
+}

--- a/client/src/hooks/useInternalEconomics.ts
+++ b/client/src/hooks/useInternalEconomics.ts
@@ -18,8 +18,6 @@ export interface InternalEconomicsPin {
   sourceId: number;
   runId: number;
   period: AnalysisPeriod;
-  periodStart: string;
-  periodEnd: string;
   createdAt: string;
   knowledgeCutoff: string;
   analysisFactsSnapshotId: number;
@@ -38,17 +36,15 @@ export interface InternalEconomicsSelection {
 }
 
 export type InternalEconomicsSelectionSlot = 'baseline' | 'current';
-export type InternalEconomicsSlot =
-  | { state: 'empty'; runId: null; receipt: null; error: null }
-  | { state: 'pending'; runId: number; receipt: null; error: null }
-  | { state: 'ready'; runId: number; receipt: InternalLpEconomicsRunReceiptV1; error: null }
-  | { state: 'error'; runId: number; receipt: null; error: Error };
-
-export type InternalEconomicsReceiptSlot = InternalEconomicsSlot;
+export type InternalEconomicsReceiptSlot =
+  | { status: 'empty'; runId: null; receipt: null; error: null }
+  | { status: 'pending'; runId: number; receipt: null; error: null }
+  | { status: 'ready'; runId: number; receipt: InternalLpEconomicsRunReceiptV1; error: null }
+  | { status: 'error'; runId: number; receipt: null; error: Error };
 
 export interface InternalEconomicsResult {
-  baseline: InternalEconomicsSlot;
-  current: InternalEconomicsSlot;
+  baseline: InternalEconomicsReceiptSlot;
+  current: InternalEconomicsReceiptSlot;
 }
 
 export const internalEconomicsReceiptQueryKey = (fundId: number, runId: number) =>
@@ -85,8 +81,6 @@ export function projectInternalEconomicsPins(
         sourceId: draft.draftId,
         runId,
         period: draft.period,
-        periodStart: draft.period.periodStart,
-        periodEnd: draft.period.periodEnd,
         createdAt: draft.createdAt,
         knowledgeCutoff: draft.basis.knowledgeCutoff,
         analysisFactsSnapshotId: draft.basis.financialFactsSnapshotId,
@@ -104,8 +98,6 @@ export function projectInternalEconomicsPins(
         sourceId: reference.referenceId,
         runId,
         period: reference.period,
-        periodStart: reference.period.periodStart,
-        periodEnd: reference.period.periodEnd,
         createdAt: reference.createdAt,
         knowledgeCutoff: reference.basis.knowledgeCutoff,
         analysisFactsSnapshotId: reference.basis.financialFactsSnapshotId,
@@ -182,11 +174,11 @@ export function selectInternalEconomicsRun(
 function toReceiptSlot(
   runId: number | null,
   query: UseQueryResult<InternalLpEconomicsRunReceiptV1, Error> | undefined
-): InternalEconomicsSlot {
-  if (runId === null) return { state: 'empty', runId: null, receipt: null, error: null };
-  if (query?.data) return { state: 'ready', runId, receipt: query.data, error: null };
-  if (query?.error) return { state: 'error', runId, receipt: null, error: query.error };
-  return { state: 'pending', runId, receipt: null, error: null };
+): InternalEconomicsReceiptSlot {
+  if (runId === null) return { status: 'empty', runId: null, receipt: null, error: null };
+  if (query?.data) return { status: 'ready', runId, receipt: query.data, error: null };
+  if (query?.error) return { status: 'error', runId, receipt: null, error: query.error };
+  return { status: 'pending', runId, receipt: null, error: null };
 }
 
 export function useInternalEconomics(

--- a/client/src/pages/fund-model-results-analysis.tsx
+++ b/client/src/pages/fund-model-results-analysis.tsx
@@ -1,0 +1,191 @@
+import { useEffect, useMemo, useState } from 'react';
+import { AlertTriangle, Info } from 'lucide-react';
+import { useRoute } from 'wouter';
+
+import { InternalEconomicsPanel } from '@/components/fund-results/InternalEconomicsPanel';
+import { Card, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { useFundContext } from '@/contexts/FundContext';
+import { useInternalAnalysis } from '@/hooks/useInternalAnalysis';
+import {
+  defaultInternalEconomicsSelection,
+  groupInternalEconomicsPins,
+  projectInternalEconomicsPins,
+  type InternalEconomicsSelection,
+  useInternalEconomics,
+} from '@/hooks/useInternalEconomics';
+import { WorkspaceBasisIndicator, WorkspaceNav } from '@/pages/fund-model-results/workspace-nav';
+
+export type FundIdParseResult =
+  | { status: 'missing'; fundId: null }
+  | { status: 'invalid'; fundId: null }
+  | { status: 'valid'; fundId: number };
+
+export function parseFundIdParam(rawValue: string | undefined): FundIdParseResult {
+  if (rawValue === undefined) return { status: 'missing', fundId: null };
+
+  const trimmed = rawValue.trim();
+  const parsed = Number(trimmed);
+  if (!/^\d+$/.test(trimmed) || !Number.isSafeInteger(parsed) || parsed <= 0) {
+    return { status: 'invalid', fundId: null };
+  }
+  return { status: 'valid', fundId: parsed };
+}
+
+function StateCard({
+  title,
+  description,
+  icon = 'warning',
+}: {
+  title: string;
+  description: string;
+  icon?: 'info' | 'warning';
+}) {
+  const Icon = icon === 'info' ? Info : AlertTriangle;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-pov-charcoal">
+          <Icon className="h-5 w-5" />
+          <span>{title}</span>
+        </CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+    </Card>
+  );
+}
+
+function InternalEconomicsContent({ fundId }: { fundId: number }) {
+  const { drafts, references, isLoading, error } = useInternalAnalysis(fundId, {
+    includeSuperseded: false,
+  });
+  const groups = useMemo(
+    () => groupInternalEconomicsPins(projectInternalEconomicsPins(drafts, references)),
+    [drafts, references]
+  );
+  const [selection, setSelection] = useState<InternalEconomicsSelection>({
+    baselineRunId: null,
+    currentRunId: null,
+  });
+
+  useEffect(() => {
+    const defaults = defaultInternalEconomicsSelection(groups);
+    const availableRunIds = new Set(groups.map((group) => group.runId));
+    setSelection((previous) => {
+      const currentRunId =
+        previous.currentRunId !== null && availableRunIds.has(previous.currentRunId)
+          ? previous.currentRunId
+          : defaults.currentRunId;
+      let baselineRunId =
+        previous.baselineRunId !== null && availableRunIds.has(previous.baselineRunId)
+          ? previous.baselineRunId
+          : defaults.baselineRunId;
+      if (baselineRunId === currentRunId) {
+        baselineRunId = groups.find((group) => group.runId !== currentRunId)?.runId ?? null;
+      }
+
+      if (
+        previous.baselineRunId === baselineRunId &&
+        previous.currentRunId === currentRunId
+      ) {
+        return previous;
+      }
+      return { baselineRunId, currentRunId };
+    });
+  }, [groups]);
+
+  const receipts = useInternalEconomics(fundId, [
+    selection.baselineRunId,
+    selection.currentRunId,
+  ]);
+
+  return (
+    <section aria-labelledby="internal-economics-heading" className="space-y-5">
+      <div>
+        <h2 id="internal-economics-heading" className="text-lg font-semibold text-pov-charcoal">
+          Economics comparison
+        </h2>
+        <p className="mt-1 text-sm text-presson-textMuted">
+          Compare economics receipts already pinned to internal analysis drafts and references.
+        </p>
+      </div>
+
+      {isLoading ? (
+        <p className="text-sm text-presson-textMuted">Loading pinned economics runs...</p>
+      ) : null}
+      {error ? (
+        <p
+          role="alert"
+          className="rounded-md border border-red-300 bg-red-50 p-3 text-sm text-pov-charcoal"
+        >
+          {error.message}
+        </p>
+      ) : null}
+      {!isLoading && !error ? (
+        <InternalEconomicsPanel
+          groups={groups}
+          selection={selection}
+          baseline={receipts.baseline}
+          current={receipts.current}
+          onSelectionChange={setSelection}
+        />
+      ) : null}
+    </section>
+  );
+}
+
+export default function FundModelResultsAnalysisPage() {
+  const [, params] = useRoute('/fund-model-results/:fundId/analysis');
+  const fundIdResult = parseFundIdParam(params?.fundId);
+  const routeFundId = fundIdResult.fundId;
+  const { currentFund, fundId: contextFundId, isLoading } = useFundContext();
+  const fundScopeMatches = fundIdResult.status === 'valid' && contextFundId === routeFundId;
+  const scopedFundName = fundScopeMatches ? currentFund?.name : undefined;
+  const routeFundLabel =
+    fundIdResult.status === 'valid' ? (scopedFundName ?? `Fund ${routeFundId}`) : 'No fund';
+
+  return (
+    <div className="container mx-auto space-y-6 p-6">
+      <header>
+        <h1 className="text-3xl font-bold text-pov-charcoal">Internal Economics</h1>
+        <p className="text-muted-foreground">
+          {fundIdResult.status === 'valid' ? routeFundLabel : 'Fund-scoped economics comparison'}
+        </p>
+      </header>
+
+      <WorkspaceNav
+        fundId={fundScopeMatches ? String(routeFundId) : null}
+        fundLabel={routeFundLabel}
+        active="analysis"
+        indicator={<WorkspaceBasisIndicator mode="current" />}
+      />
+
+      {fundIdResult.status === 'missing' ? (
+        <StateCard
+          title="Fund ID required"
+          description="Economics comparison is unavailable because the route did not include a fund ID."
+          icon="info"
+        />
+      ) : null}
+      {fundIdResult.status === 'invalid' ? (
+        <StateCard
+          title="Invalid fund ID"
+          description="Economics comparison is unavailable because the fund ID is not a positive integer."
+        />
+      ) : null}
+      {fundScopeMatches ? (
+        <InternalEconomicsContent fundId={routeFundId as number} />
+      ) : fundIdResult.status === 'valid' ? (
+        <StateCard
+          title={isLoading ? 'Resolving fund scope' : 'Fund not available'}
+          description={
+            isLoading
+              ? 'Economics comparison loads once the fund context matches this route.'
+              : `Fund ${routeFundId} is not available in your workspace scope, so economics evidence is withheld.`
+          }
+          icon={isLoading ? 'info' : 'warning'}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/client/src/pages/fund-model-results/readiness-rollup.ts
+++ b/client/src/pages/fund-model-results/readiness-rollup.ts
@@ -32,7 +32,7 @@ export type ScenariosSection = FundResultsReadV1['sections']['scenarios'];
 export type ReadinessSourceInput<T> =
   { kind: 'loading' } | { kind: 'error'; message: string | null } | { kind: 'data'; data: T };
 
-export type ReadinessRowKey = Exclude<WorkspaceNavKey, 'summary'>;
+export type ReadinessRowKey = Exclude<WorkspaceNavKey, 'summary' | 'analysis'>;
 
 export interface ReadinessRollupRow {
   key: ReadinessRowKey;

--- a/client/src/pages/fund-model-results/workspace-nav.tsx
+++ b/client/src/pages/fund-model-results/workspace-nav.tsx
@@ -1,8 +1,8 @@
 /**
  * Workspace navigation row (Plan 9 Wave 9B1, D-F.2/D-F.5).
  *
- * The ONE persistent hub-and-spokes row mounted on all six GP workspace
- * destinations: fund context + six underlined text links (ink active state,
+ * The ONE persistent hub-and-spokes row mounted on all seven GP workspace
+ * destinations: fund context + seven underlined text links (ink active state,
  * no tabs/pills/status hues) + the static basis/overlay indicator (D-E: no
  * surface supports live basis switching at launch) + at most one primary
  * action. Fund-scoped destinations without a resolved fund render
@@ -16,7 +16,13 @@ import { Link } from 'wouter';
 import { ForecastBasisControl } from '@/components/fund-results';
 
 export type WorkspaceNavKey =
-  'summary' | 'forecast' | 'portfolio-actuals' | 'reserves' | 'scenarios' | 'reports';
+  | 'summary'
+  | 'forecast'
+  | 'portfolio-actuals'
+  | 'reserves'
+  | 'analysis'
+  | 'scenarios'
+  | 'reports';
 
 export interface WorkspaceNavItem {
   key: WorkspaceNavKey;
@@ -59,6 +65,7 @@ export function workspaceNavItems(fundId: string | null): WorkspaceNavItem[] {
       label: 'Reserves',
       ...fundScoped(`/fund-model-results/${fundId}/moic-analysis`),
     },
+    { key: 'analysis', label: 'Economics', ...fundScoped(`/fund-model-results/${fundId}/analysis`) },
     {
       key: 'scenarios',
       label: 'Scenarios',

--- a/server/route-policy/api-route-policy-registry.ts
+++ b/server/route-policy/api-route-policy-registry.ts
@@ -311,6 +311,18 @@ const GOVERNANCE_ROUTE_POLICY_DECISIONS: Readonly<Record<string, RoutePolicyDeci
     humanReviewRequired: true,
     performanceBudgetMs: null,
   },
+  '/fund-model-results/:fundId/analysis': {
+    lifecycle: 'durable_crud',
+    financialSurface: 'fund_modeling',
+    apiAuthBoundary: 'require_auth_and_fund_access',
+    fundScopeMode: 'route_param_fund_id',
+    workflowRequirement: 'fund_scope_verified',
+    exportPolicy: 'not_exportable',
+    provenanceRequired: true,
+    staleBlocksExport: false,
+    humanReviewRequired: true,
+    performanceBudgetMs: null,
+  },
   '/sensitivity-analysis': {
     lifecycle: 'durable_crud',
     financialSurface: 'fund_modeling',

--- a/shared/routes/app-route-definitions.ts
+++ b/shared/routes/app-route-definitions.ts
@@ -18,6 +18,7 @@ export const APP_ROUTE_DEFINITIONS = [
   { path: '/fund-model-results/:fundId/moic-analysis', isProtected: true },
   { path: '/fund-model-results/:fundId/reports', isProtected: true },
   { path: '/fund-model-results/:fundId/internal-analysis', isProtected: true },
+  { path: '/fund-model-results/:fundId/analysis', isProtected: true },
   { path: '/fund-model-results/:fundId', isProtected: true },
   { path: '/sensitivity-analysis', isProtected: true },
   { path: '/reports', isProtected: true },

--- a/tests/unit/app/internal-economics-route-governance.test.tsx
+++ b/tests/unit/app/internal-economics-route-governance.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { APP_ROUTE_DEFINITIONS, LP_ROUTE_DEFINITIONS } from '@shared/routes/app-route-definitions';
+import {
+  CORE_LIVE_GOVERNED_PATHS,
+  getRouteGovernanceEntry,
+} from '@shared/routes/route-governance-registry';
+
+describe('internal economics route governance', () => {
+  it('defines the exact protected analysis route before the generic fund results route', () => {
+    const paths = APP_ROUTE_DEFINITIONS.map((route) => route.path);
+    const economicsIndex = paths.indexOf('/fund-model-results/:fundId/analysis');
+
+    expect(APP_ROUTE_DEFINITIONS[economicsIndex]).toEqual({
+      path: '/fund-model-results/:fundId/analysis',
+      isProtected: true,
+    });
+    expect(economicsIndex).toBeLessThan(paths.indexOf('/fund-model-results/:fundId'));
+  });
+
+  it('derives protected internal-live governance without expanding core-live paths', () => {
+    expect(getRouteGovernanceEntry('/fund-model-results/:fundId/analysis')).toMatchObject({
+      exposure: 'internal-live',
+      surface: 'app-route',
+      isProtected: true,
+    });
+    expect(CORE_LIVE_GOVERNED_PATHS).not.toContain('/fund-model-results/:fundId/analysis');
+  });
+
+  it('leaves reports, internal-analysis, and LP route contracts unchanged', () => {
+    const paths = APP_ROUTE_DEFINITIONS.map((route) => route.path);
+    expect(paths).toContain('/fund-model-results/:fundId/reports');
+    expect(paths).toContain('/fund-model-results/:fundId/internal-analysis');
+    expect(LP_ROUTE_DEFINITIONS.map((route) => route.path)).toEqual([
+      '/lp/dashboard',
+      '/lp/fund-detail/:fundId',
+      '/lp/capital-account',
+      '/lp/performance',
+      '/lp/reports',
+      '/lp/settings',
+    ]);
+  });
+});

--- a/tests/unit/components/InternalEconomicsPanel.test.tsx
+++ b/tests/unit/components/InternalEconomicsPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 

--- a/tests/unit/components/InternalEconomicsPanel.test.tsx
+++ b/tests/unit/components/InternalEconomicsPanel.test.tsx
@@ -1,0 +1,231 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  INTERNAL_ECONOMICS_NOTICE,
+  InternalEconomicsPanel,
+  renderInternalEconomicsCopyText,
+  type InternalEconomicsPanelGroup,
+  type InternalEconomicsPanelProps,
+} from '@/components/fund-results/InternalEconomicsPanel';
+import { InternalLpEconomicsRunReceiptV1Schema } from '@shared/contracts/internal-economics/lp-economics-run-receipt-v1.contract';
+
+const HASH = 'abcdef0123456789'.repeat(4);
+
+function receipt(
+  runId: number,
+  lpCapitalCallUsd: string,
+  factsSnapshotId = 5
+) {
+  return InternalLpEconomicsRunReceiptV1Schema.parse({
+    receiptVersion: 'internal-lp-economics-run-receipt/1.0.0',
+    runId,
+    fundId: 7,
+    createdAt: '2026-06-30T23:59:59.000Z',
+    basis: {
+      policyVersionId: 3,
+      capitalEnvelopeVersionId: 4,
+      factsSnapshotId,
+      knowledgeCutoff: '2026-06-30T00:00:00.000Z',
+      planVersionId: 6,
+      forecastSnapshotId: 7,
+      evaluationClock: '2026-06-30T23:59:59.000Z',
+      terminalMode: 'hold_unrealized',
+      terminalPeriodEnd: '2026-09-30',
+      terminalResolutionMethodologyVersion: 'terminal-resolution/1.0.0',
+    },
+    versions: {
+      calculationContractVersion: 'lp-economics/1.1.0',
+      engineVersion: 'cash-assembly-period-loop-v1/1.1.0',
+      methodologyVersion: 'cash-assembly-period-loop-methodology/1.1.0',
+      resultCalculationVersion: 'lp-economics/1.1.0',
+    },
+    hashes: {
+      capitalEnvelopeHash: HASH,
+      policyAssumptionsHash: HASH,
+      factsSnapshotInputHash: HASH,
+      planAssumptionsHash: HASH,
+      forecastInputHash: HASH,
+      inputHash: HASH,
+      resultHash: HASH,
+    },
+    outcome: {
+      runState: 'completed',
+      result: {
+        waterfallTemplate: 'deal_by_deal',
+        resultStatus: 'available',
+        clock: '2026-06-30T23:59:59.000Z',
+        currency: 'USD',
+        perspective: 'lp_net',
+        precisionMode: 'decimal_native_with_float64_xirr',
+        quarters: [],
+        waterfallEvents: [],
+        totals: {
+          lpCapitalCallUsd: `${lpCapitalCallUsd}.000000`,
+          gpCommitmentCallUsd: '0.000000',
+          portfolioDeploymentUsd: '0.000000',
+          managementFeesUsd: '10.000000',
+          fundExpensesUsd: '0.000000',
+          grossRealizedProceedsUsd: '0.000000',
+          lpCapitalReturnUsd: '0.000000',
+          lpProfitUsd: '0.000000',
+          lpDistributionUsd: '20.000000',
+          gpInvestmentDistributionUsd: '0.000000',
+          gpCarryDistributedUsd: '3.000000',
+          endingCashUsd: '4.000000',
+          grossNavUsd: '50.000000',
+          lpNetNavUsd: '45.000000',
+          dpi: '0.200000000000',
+          rvpi: '0.450000000000',
+          tvpi: '0.650000000000',
+        },
+        terminalNavBeforeRealizationUsd: '0.000000',
+        lpNetIrr: '0.125000000000',
+        lpNetIrrBasis: 'cash_only',
+        lpNetIrrDiagnostic: {
+          convergence: 'failed',
+          iterations: 0,
+          method: 'none',
+          boundHit: null,
+          failureReason: 'NO_SIGN_CHANGE',
+        },
+        reasons: [],
+      },
+    },
+  });
+}
+
+function group(
+  runId: number,
+  overrides: Partial<InternalEconomicsPanelGroup['primaryPin']> = {}
+): InternalEconomicsPanelGroup {
+  const primaryPin = {
+    sourceKind: 'draft' as const,
+    sourceId: runId,
+    periodStart: '2026-04-01',
+    periodEnd: '2026-06-30',
+    createdAt: '2026-07-01T00:00:00.000Z',
+    knowledgeCutoff: '2026-07-01T00:00:00.000Z',
+    analysisFactsSnapshotId: 5,
+    mixedBasisAtSave: false,
+    ...overrides,
+  };
+  return { runId, pins: [primaryPin], primaryPin };
+}
+
+function props(overrides: Partial<InternalEconomicsPanelProps> = {}): InternalEconomicsPanelProps {
+  const groups = [group(10), group(20)];
+  return {
+    groups,
+    selection: { baselineRunId: 10, currentRunId: 20 },
+    baseline: { state: 'ready', runId: 10, receipt: receipt(10, '100'), error: null },
+    current: { state: 'ready', runId: 20, receipt: receipt(20, '130'), error: null },
+    onSelectionChange: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('InternalEconomicsPanel', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('renders labeled native selectors, semantic scoped tables, Decimal deltas, and methodology disclosure', () => {
+    render(<InternalEconomicsPanel {...props()} />);
+
+    expect(screen.getByRole('combobox', { name: 'Baseline economics run' })).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'Comparison economics run' })).toBeInTheDocument();
+    expect(screen.getByRole('table', { name: 'Economics result metrics' })).toBeInTheDocument();
+    expect(screen.getByRole('table', { name: 'Receipt provenance comparison' })).toBeInTheDocument();
+    for (const header of screen.getAllByRole('columnheader')) expect(header).toHaveAttribute('scope', 'col');
+    for (const header of screen.getAllByRole('rowheader')) expect(header).toHaveAttribute('scope', 'row');
+    expect(screen.getByTestId('internal-economics-copy-block')).toHaveTextContent(
+      'LP calls: baseline=100.000000; comparison=130.000000; delta=30'
+    );
+    expect(screen.getAllByText(/forecast uses flat annual fee drag/i)).toHaveLength(2);
+  });
+
+  it('renders exact evidence text and copies that same payload with polite feedback', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } });
+    const input = props();
+    const evidence = renderInternalEconomicsCopyText(input);
+    render(<InternalEconomicsPanel {...input} />);
+
+    const block = screen.getByTestId('internal-economics-copy-block');
+    expect(block.textContent).toBe(evidence);
+    expect(evidence).toContain(INTERNAL_ECONOMICS_NOTICE);
+    expect(evidence).toContain('As of: 2026-07-01T00:00:00.000Z');
+    expect(evidence).toContain('Receipt basis cutoff: 2026-06-30T00:00:00.000Z');
+    expect(evidence).toContain(`Facts input hash (short): ${HASH.slice(0, 12)}`);
+    expect(evidence).toContain(`factsSnapshotInputHash: ${HASH}`);
+
+    await userEvent.click(screen.getByRole('button', { name: /copy the full internal economics/i }));
+    expect(writeText).toHaveBeenCalledWith(evidence);
+    expect(screen.getByText('Evidence copied')).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('shows both coherence warnings and suppresses numeric deltas', () => {
+    const groups = [
+      group(10),
+      group(20, { sourceKind: 'reference', mixedBasisAtSave: true }),
+    ];
+    render(
+      <InternalEconomicsPanel
+        {...props({
+          groups,
+          baseline: { state: 'ready', runId: 10, receipt: receipt(10, '100', 99), error: null },
+        })}
+      />
+    );
+
+    expect(screen.getAllByText('Economics pin basis mismatch').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Bundle mixed at save').length).toBeGreaterThan(0);
+    expect(screen.getByTestId('internal-economics-copy-block')).toHaveTextContent(
+      'LP calls: baseline=100.000000; comparison=130.000000; delta=Unavailable'
+    );
+  });
+
+  it('supports zero and one-run states and swaps distinct selected runs', async () => {
+    const onSelectionChange = vi.fn();
+    const one = group(10);
+    const { rerender } = render(
+      <InternalEconomicsPanel
+        {...props({
+          groups: [],
+          selection: { baselineRunId: null, currentRunId: null },
+          baseline: { state: 'empty', runId: null, receipt: null, error: null },
+          current: { state: 'empty', runId: null, receipt: null, error: null },
+          onSelectionChange,
+        })}
+      />
+    );
+    expect(screen.getByText('No pinned economics runs are available for comparison.')).toBeInTheDocument();
+
+    rerender(
+      <InternalEconomicsPanel
+        {...props({
+          groups: [one],
+          selection: { baselineRunId: null, currentRunId: 10 },
+          baseline: { state: 'empty', runId: null, receipt: null, error: null },
+          current: { state: 'ready', runId: 10, receipt: receipt(10, '100'), error: null },
+          onSelectionChange,
+        })}
+      />
+    );
+    expect(screen.getByRole('option', { name: 'No baseline' })).toBeInTheDocument();
+
+    rerender(<InternalEconomicsPanel {...props({ onSelectionChange })} />);
+    await userEvent.selectOptions(screen.getByRole('combobox', { name: 'Baseline economics run' }), '20');
+    expect(onSelectionChange).toHaveBeenLastCalledWith({ baselineRunId: 20, currentRunId: 10 });
+  });
+
+  it('keeps copy as the sole action and exposes no forbidden workflow controls', () => {
+    render(<InternalEconomicsPanel {...props()} />);
+    const buttons = screen.getAllByRole('button');
+    expect(buttons).toHaveLength(1);
+    expect(buttons[0]).toHaveAccessibleName(/copy/i);
+    for (const forbidden of ['export', 'share', 'recipient', 'approve', 'deliver', 'payment', 'create run', 'pin', 'save']) {
+      expect(screen.queryByRole('button', { name: new RegExp(forbidden, 'i') })).not.toBeInTheDocument();
+    }
+  });
+});

--- a/tests/unit/hooks/useInternalEconomics.test.tsx
+++ b/tests/unit/hooks/useInternalEconomics.test.tsx
@@ -1,0 +1,251 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  AnalysisDraftV1,
+  AnalysisReferenceV1,
+} from '@shared/contracts/internal-analysis/analysis-reference-snapshot-v1.contract';
+import {
+  defaultInternalEconomicsSelection,
+  groupInternalEconomicsPins,
+  projectInternalEconomicsPins,
+  selectInternalEconomicsRun,
+  useInternalEconomics,
+  type InternalEconomicsPin,
+} from '@/hooks/useInternalEconomics';
+import { apiRequest } from '@/lib/queryClient';
+
+vi.mock('@/lib/queryClient', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/queryClient')>();
+  return { ...actual, apiRequest: vi.fn() };
+});
+
+const mockApiRequest = vi.mocked(apiRequest);
+
+function wrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+function pin(overrides: Partial<InternalEconomicsPin> = {}): InternalEconomicsPin {
+  return {
+    sourceKind: 'draft',
+    sourceId: 1,
+    runId: 1,
+    period: { periodKind: 'quarterly', periodStart: '2026-04-01', periodEnd: '2026-06-30' },
+    periodStart: '2026-04-01',
+    periodEnd: '2026-06-30',
+    createdAt: '2026-07-01T00:00:00.000Z',
+    knowledgeCutoff: '2026-06-30T23:59:59.000Z',
+    analysisFactsSnapshotId: 5,
+    mixedBasisAtSave: false,
+    ...overrides,
+  };
+}
+
+function draft(overrides: Partial<AnalysisDraftV1> = {}): AnalysisDraftV1 {
+  return {
+    contractVersion: 'analysis-reference-snapshot-v1',
+    draftId: 1,
+    fundId: 7,
+    period: { periodKind: 'quarterly', periodStart: '2026-04-01', periodEnd: '2026-06-30' },
+    basis: {
+      financialFactsSnapshotId: 5,
+      knowledgeCutoff: '2026-06-30T23:59:59.000Z',
+      forecastFundSnapshotId: 6,
+      reserveReferenceId: null,
+      economicsReferenceId: 11,
+    },
+    sourceReferenceId: null,
+    savedAt: null,
+    version: 1,
+    createdAt: '2026-07-01T00:00:00.000Z',
+    updatedAt: '2026-07-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function reference(overrides: Partial<AnalysisReferenceV1> = {}): AnalysisReferenceV1 {
+  return {
+    contractVersion: 'analysis-reference-snapshot-v1',
+    referenceId: 2,
+    fundId: 7,
+    period: { periodKind: 'quarterly', periodStart: '2026-04-01', periodEnd: '2026-06-30' },
+    basis: {
+      financialFactsSnapshotId: 5,
+      knowledgeCutoff: '2026-06-30T23:59:59.000Z',
+      forecastFundSnapshotId: 6,
+      reserveReferenceId: null,
+      economicsReferenceId: 11,
+    },
+    mixedBasisAtSave: true,
+    supersedesReferenceId: null,
+    sourceDraftId: 1,
+    createdBy: 3,
+    createdAt: '2026-07-02T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function receipt(runId: number, fundId = 7) {
+  const hash = 'a'.repeat(64);
+  return {
+    receiptVersion: 'internal-lp-economics-run-receipt/1.0.0',
+    runId,
+    fundId,
+    createdAt: '2026-06-30T23:59:59.000Z',
+    basis: {
+      policyVersionId: 3,
+      capitalEnvelopeVersionId: 4,
+      factsSnapshotId: 5,
+      knowledgeCutoff: '2026-06-30T00:00:00.000Z',
+      planVersionId: 6,
+      forecastSnapshotId: 7,
+      evaluationClock: '2026-06-30T23:59:59.000Z',
+      terminalMode: 'hold_unrealized',
+      terminalPeriodEnd: '2026-09-30',
+      terminalResolutionMethodologyVersion: 'terminal-resolution/1.0.0',
+    },
+    versions: {
+      calculationContractVersion: 'lp-economics/1.1.0',
+      engineVersion: 'cash-assembly-period-loop-v1/1.1.0',
+      methodologyVersion: 'cash-assembly-period-loop-methodology/1.1.0',
+      resultCalculationVersion: 'lp-economics/1.1.0',
+    },
+    hashes: {
+      capitalEnvelopeHash: hash,
+      policyAssumptionsHash: hash,
+      factsSnapshotInputHash: hash,
+      planAssumptionsHash: hash,
+      forecastInputHash: hash,
+      inputHash: hash,
+      resultHash: hash,
+    },
+    outcome: {
+      runState: 'completed',
+      result: {
+        waterfallTemplate: 'deal_by_deal',
+        resultStatus: 'unavailable',
+        clock: '2026-06-30T23:59:59.000Z',
+        currency: 'USD',
+        perspective: 'lp_net',
+        precisionMode: 'decimal_native_with_float64_xirr',
+        reasons: [{ code: 'MAIN_FUND_VEHICLE_ABSENT' }],
+      },
+    },
+  } as const;
+}
+
+describe('internal economics pin projection and selection', () => {
+  it('keeps open drafts and references, groups duplicate run lineage, and applies total ordering', () => {
+    const pins = projectInternalEconomicsPins(
+      [
+        draft(),
+        draft({ draftId: 3, savedAt: '2026-07-03T00:00:00.000Z' }),
+        draft({
+          draftId: 4,
+          basis: { ...draft().basis, economicsReferenceId: null },
+        }),
+      ],
+      [reference()]
+    );
+    const groups = groupInternalEconomicsPins([
+      ...pins,
+      pin({ runId: 12, sourceId: 8, period: { periodKind: 'quarterly', periodStart: '2026-07-01', periodEnd: '2026-09-30' } }),
+      pin({ runId: 13, sourceId: 9, period: { periodKind: 'quarterly', periodStart: '2026-07-01', periodEnd: '2026-09-30' } }),
+    ]);
+
+    expect(pins).toHaveLength(2);
+    expect(groups.map((group) => group.runId)).toEqual([13, 12, 11]);
+    expect(groups[2]?.pins.map((candidate) => candidate.sourceKind)).toEqual(['draft', 'reference']);
+    expect(groups[2]?.pins[1]).toMatchObject({ sourceId: 2, mixedBasisAtSave: true });
+  });
+
+  it('chooses latest current plus an earlier-period baseline, with zero/one-group fallbacks', () => {
+    const newest = groupInternalEconomicsPins([
+      pin({ runId: 30, sourceId: 4, period: { periodKind: 'quarterly', periodStart: '2026-07-01', periodEnd: '2026-09-30' } }),
+      pin({ runId: 29, sourceId: 2, period: { periodKind: 'quarterly', periodStart: '2026-07-01', periodEnd: '2026-09-30' } }),
+      pin({ runId: 20, sourceId: 3 }),
+    ]);
+
+    expect(defaultInternalEconomicsSelection([])).toEqual({ baselineRunId: null, currentRunId: null });
+    expect(defaultInternalEconomicsSelection(newest.slice(0, 1))).toEqual({
+      baselineRunId: null,
+      currentRunId: 30,
+    });
+    expect(defaultInternalEconomicsSelection(newest)).toEqual({
+      baselineRunId: 20,
+      currentRunId: 30,
+    });
+  });
+
+  it('swaps slots when the opposite selected run is chosen and otherwise updates one slot', () => {
+    const selection = { baselineRunId: 10, currentRunId: 20 };
+    expect(selectInternalEconomicsRun(selection, 'baseline', 20)).toEqual({
+      baselineRunId: 20,
+      currentRunId: 10,
+    });
+    expect(selectInternalEconomicsRun(selection, 'current', 10)).toEqual({
+      baselineRunId: 20,
+      currentRunId: 10,
+    });
+    expect(selectInternalEconomicsRun(selection, 'baseline', null)).toEqual({
+      baselineRunId: null,
+      currentRunId: 20,
+    });
+  });
+});
+
+describe('useInternalEconomics', () => {
+  beforeEach(() => mockApiRequest.mockReset());
+
+  it('deduplicates equal selections to one receipt read and shares the parsed result', async () => {
+    mockApiRequest.mockResolvedValue(receipt(9));
+    const { result } = renderHook(() => useInternalEconomics(7, [9, 9]), { wrapper: wrapper() });
+
+    await waitFor(() => expect(result.current.baseline.state).toBe('ready'));
+    expect(result.current.current.state).toBe('ready');
+    expect(mockApiRequest).toHaveBeenCalledTimes(1);
+    expect(mockApiRequest).toHaveBeenCalledWith('GET', '/api/funds/7/internal-economics/runs/9');
+  });
+
+  it('performs no read for empty selections or an invalid fund id', () => {
+    const empty = renderHook(() => useInternalEconomics(7, [null, null]), { wrapper: wrapper() });
+    const invalid = renderHook(() => useInternalEconomics(undefined, [9, 10]), {
+      wrapper: wrapper(),
+    });
+
+    expect(empty.result.current.baseline.state).toBe('empty');
+    expect(empty.result.current.current.state).toBe('empty');
+    expect(invalid.result.current.baseline.state).toBe('pending');
+    expect(invalid.result.current.current.state).toBe('pending');
+    expect(mockApiRequest).not.toHaveBeenCalled();
+  });
+
+  it('preserves one successful slot when its peer request fails', async () => {
+    mockApiRequest.mockResolvedValueOnce(receipt(9)).mockRejectedValueOnce(new Error('peer failed'));
+    const { result } = renderHook(() => useInternalEconomics(7, [9, 10]), { wrapper: wrapper() });
+
+    await waitFor(() => expect(result.current.current.state).toBe('error'));
+    expect(result.current.baseline.state).toBe('ready');
+    expect(mockApiRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    ['schema rejection', { unexpected: true }],
+    ['fund identity mismatch', receipt(9, 8)],
+    ['run identity mismatch', receipt(10)],
+  ])('returns an error slot for %s', async (_case, response) => {
+    mockApiRequest.mockResolvedValue(response);
+    const { result } = renderHook(() => useInternalEconomics(7, [9, null]), {
+      wrapper: wrapper(),
+    });
+
+    await waitFor(() => expect(result.current.baseline.state).toBe('error'));
+    expect(result.current.current.state).toBe('empty');
+  });
+});

--- a/tests/unit/pages/fund-model-results-analysis.test.tsx
+++ b/tests/unit/pages/fund-model-results-analysis.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createWouterWrapper } from '../../utils/withWouter';
+import FundModelResultsAnalysisPage, {
+  parseFundIdParam,
+} from '@/pages/fund-model-results-analysis';
+
+const mocks = vi.hoisted(() => ({
+  contextFundId: 7 as number | undefined,
+  currentFund: { id: 7, name: 'Fund Seven' } as { id: number; name: string } | null,
+  isLoading: false,
+  useInternalAnalysis: vi.fn(),
+  useInternalEconomics: vi.fn(),
+}));
+
+vi.mock('@/contexts/FundContext', () => ({
+  useFundContext: () => ({
+    currentFund: mocks.currentFund,
+    fundId: mocks.contextFundId,
+    isLoading: mocks.isLoading,
+  }),
+}));
+
+vi.mock('@/hooks/useInternalAnalysis', () => ({
+  useInternalAnalysis: mocks.useInternalAnalysis,
+}));
+
+vi.mock('@/hooks/useInternalEconomics', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/hooks/useInternalEconomics')>();
+  return { ...actual, useInternalEconomics: mocks.useInternalEconomics };
+});
+
+function renderPage(path: string) {
+  const { Wrapper } = createWouterWrapper(path);
+  return render(
+    <Wrapper>
+      <FundModelResultsAnalysisPage />
+    </Wrapper>
+  );
+}
+
+describe('FundModelResultsAnalysisPage', () => {
+  beforeEach(() => {
+    mocks.contextFundId = 7;
+    mocks.currentFund = { id: 7, name: 'Fund Seven' };
+    mocks.isLoading = false;
+    mocks.useInternalAnalysis.mockReset();
+    mocks.useInternalEconomics.mockReset();
+    mocks.useInternalAnalysis.mockReturnValue({ drafts: [], references: [], isLoading: false, error: null });
+    mocks.useInternalEconomics.mockReturnValue({
+      baseline: { state: 'empty', runId: null, receipt: null, error: null },
+      current: { state: 'empty', runId: null, receipt: null, error: null },
+    });
+  });
+
+  it.each([
+    [undefined, { status: 'missing', fundId: null }],
+    ['', { status: 'invalid', fundId: null }],
+    ['0', { status: 'invalid', fundId: null }],
+    ['-1', { status: 'invalid', fundId: null }],
+    ['1.5', { status: 'invalid', fundId: null }],
+    ['abc', { status: 'invalid', fundId: null }],
+    ['7', { status: 'valid', fundId: 7 }],
+  ])('parses route fund id %s fail-closed', (raw, expected) => {
+    expect(parseFundIdParam(raw)).toEqual(expected);
+  });
+
+  it('withholds discovery and receipt reads for invalid routes', () => {
+    renderPage('/fund-model-results/not-a-fund/analysis');
+
+    expect(screen.getByText('Invalid fund ID')).toBeInTheDocument();
+    expect(mocks.useInternalAnalysis).not.toHaveBeenCalled();
+    expect(mocks.useInternalEconomics).not.toHaveBeenCalled();
+  });
+
+  it('withholds all reads when route fund and FundContext do not match', () => {
+    renderPage('/fund-model-results/8/analysis');
+
+    expect(screen.getByText('Fund not available')).toBeInTheDocument();
+    expect(screen.getByText(/economics evidence is withheld/i)).toBeInTheDocument();
+    expect(mocks.useInternalAnalysis).not.toHaveBeenCalled();
+    expect(mocks.useInternalEconomics).not.toHaveBeenCalled();
+  });
+
+  it('loads matching fund pins, initializes empty receipt slots, and marks Economics active', () => {
+    renderPage('/fund-model-results/7/analysis');
+
+    expect(mocks.useInternalAnalysis).toHaveBeenCalledWith(7, { includeSuperseded: false });
+    expect(mocks.useInternalEconomics).toHaveBeenCalledWith(7, [null, null]);
+    expect(screen.getByRole('link', { name: 'Economics' })).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByText('No pinned economics runs are available for comparison.')).toBeInTheDocument();
+  });
+});

--- a/tests/unit/pages/fund-model-results.test.tsx
+++ b/tests/unit/pages/fund-model-results.test.tsx
@@ -1482,6 +1482,7 @@ describe('FundModelResultsPage (server-backed)', () => {
       'Forecast',
       'Portfolio Actuals',
       'Reserves',
+      'Economics',
       'Scenarios',
       'Reports',
     ]);

--- a/tests/unit/pages/fund-model-results/economics-workspace-contract.test.tsx
+++ b/tests/unit/pages/fund-model-results/economics-workspace-contract.test.tsx
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  deriveReadinessRollup,
+  type ReadinessRollupInputs,
+} from '@/pages/fund-model-results/readiness-rollup';
+import { workspaceNavItems } from '@/pages/fund-model-results/workspace-nav';
+
+const unavailable = { kind: 'error', message: 'Facts unavailable' } as const;
+
+describe('economics workspace navigation and readiness contract', () => {
+  it('adds Economics after Reserves as the seventh fund workspace destination', () => {
+    expect(workspaceNavItems('42').map(({ key, label, href }) => [key, label, href])).toEqual([
+      ['summary', 'Summary', '/fund-model-results/42'],
+      ['forecast', 'Forecast', '/financial-modeling?fundId=42'],
+      ['portfolio-actuals', 'Portfolio Actuals', '/portfolio?tab=reserve-planning&fundId=42'],
+      ['reserves', 'Reserves', '/fund-model-results/42/moic-analysis'],
+      ['analysis', 'Economics', '/fund-model-results/42/analysis'],
+      ['scenarios', 'Scenarios', '/fund-model-results/42/scenarios'],
+      ['reports', 'Reports', '/fund-model-results/42/reports'],
+    ]);
+  });
+
+  it('disables Economics with the standard visible reason until a fund is resolved', () => {
+    expect(workspaceNavItems(null).find((item) => item.key === 'analysis')).toEqual({
+      key: 'analysis',
+      label: 'Economics',
+      href: null,
+      disabledReason: 'Select a fund to open this view',
+    });
+  });
+
+  it('keeps readiness at its existing five rows and excludes Economics', () => {
+    const model = deriveReadinessRollup({
+      fundId: '42',
+      forecast: unavailable,
+      portfolioActuals: unavailable,
+      reserves: unavailable,
+      scenarios: unavailable,
+      scenarioSetList: unavailable,
+    } satisfies ReadinessRollupInputs);
+
+    expect(model.surfaceCount).toBe(5);
+    expect(model.rows.map((row) => row.key)).toEqual([
+      'forecast',
+      'portfolio-actuals',
+      'reserves',
+      'scenarios',
+      'reports',
+    ]);
+    expect(model.rows.some((row) => row.key === ('analysis' as never))).toBe(false);
+  });
+});

--- a/tests/unit/pages/fund-model-results/workspace-nav.test.tsx
+++ b/tests/unit/pages/fund-model-results/workspace-nav.test.tsx
@@ -1,7 +1,7 @@
 /**
  * Workspace navigation row (Plan 9 Wave 9B1, D-F.2/D-F.5).
  *
- * Pins the six-item contract: labels, hrefs, nav-item ORDER (Portfolio
+ * Pins the seven-item contract: labels, hrefs, nav-item ORDER (Portfolio
  * Actuals BEFORE Reserves), per-surface active state, disabled-with-reason
  * gating (D-C), and the static basis indicator (D-E).
  */
@@ -32,7 +32,7 @@ function renderNav(props?: Partial<React.ComponentProps<typeof WorkspaceNav>>) {
 }
 
 describe('workspaceNavItems', () => {
-  it('produces the six-destination contract with fund-carrying hrefs', () => {
+  it('produces the seven-destination contract with fund-carrying hrefs', () => {
     const items = workspaceNavItems('42');
 
     expect(items.map((item) => [item.label, item.href])).toEqual([
@@ -40,6 +40,7 @@ describe('workspaceNavItems', () => {
       ['Forecast', '/financial-modeling?fundId=42'],
       ['Portfolio Actuals', '/portfolio?tab=reserve-planning&fundId=42'],
       ['Reserves', '/fund-model-results/42/moic-analysis'],
+      ['Economics', '/fund-model-results/42/analysis'],
       ['Scenarios', '/fund-model-results/42/scenarios'],
       ['Reports', '/fund-model-results/42/reports'],
     ]);
@@ -55,7 +56,7 @@ describe('workspaceNavItems', () => {
     const items = workspaceNavItems(null);
     const byKey = new Map(items.map((item) => [item.key, item]));
 
-    for (const key of ['summary', 'reserves', 'scenarios', 'reports'] as const) {
+    for (const key of ['summary', 'reserves', 'analysis', 'scenarios', 'reports'] as const) {
       expect(byKey.get(key)?.href).toBeNull();
       expect(byKey.get(key)?.disabledReason).toBe('Select a fund to open this view');
     }
@@ -68,7 +69,7 @@ describe('workspaceNavItems', () => {
 describe('WorkspaceNav', () => {
   afterEach(() => cleanup());
 
-  it('renders fund context plus all six destinations as underlined links', () => {
+  it('renders fund context plus all seven destinations as underlined links', () => {
     renderNav();
 
     expect(screen.getByTestId('workspace-nav-fund')).toHaveTextContent('Fund Forty Two');
@@ -79,6 +80,7 @@ describe('WorkspaceNav', () => {
       'Forecast',
       'Portfolio Actuals',
       'Reserves',
+      'Economics',
       'Scenarios',
       'Reports',
     ]);
@@ -92,6 +94,7 @@ describe('WorkspaceNav', () => {
     ['forecast', 'Forecast'],
     ['portfolio-actuals', 'Portfolio Actuals'],
     ['reserves', 'Reserves'],
+    ['analysis', 'Economics'],
     ['scenarios', 'Scenarios'],
     ['reports', 'Reports'],
   ])('marks only the active destination with aria-current on the %s surface', (key, label) => {
@@ -109,7 +112,7 @@ describe('WorkspaceNav', () => {
   it('renders gated destinations disabled with visible reasons, never dead links', () => {
     renderNav({ fundId: null, active: 'forecast' });
 
-    for (const key of ['summary', 'reserves', 'scenarios', 'reports']) {
+    for (const key of ['summary', 'reserves', 'analysis', 'scenarios', 'reports']) {
       const disabled = screen.getByTestId(`workspace-nav-${key}-disabled`);
       expect(disabled).toHaveAttribute('aria-disabled', 'true');
       expect(disabled).toHaveTextContent('Select a fund to open this view');

--- a/tests/unit/route-policy/route-policy-coverage.test.ts
+++ b/tests/unit/route-policy/route-policy-coverage.test.ts
@@ -324,6 +324,20 @@ describe('route policy coverage', () => {
     }
   });
 
+  it('classifies the internal economics workspace as fund-scoped and non-exportable', () => {
+    const policy = expectPolicy('/fund-model-results/:fundId/analysis');
+
+    expect(policy.governanceRef).toBe('/fund-model-results/:fundId/analysis');
+    expect(policy.financialSurface).toBe('fund_modeling');
+    expect(policy.apiAuthBoundary).toBe('require_auth_and_fund_access');
+    expect(policy.fundScopeMode).toBe('route_param_fund_id');
+    expect(policy.workflowRequirement).toBe('fund_scope_verified');
+    expect(policy.exportPolicy).toBe('not_exportable');
+    expect(policy.provenanceRequired).toBe(true);
+    expect(policy.staleBlocksExport).toBe(false);
+    expect(policy.humanReviewRequired).toBe(true);
+  });
+
   it('covers LP financial routes with the LP auth boundary', () => {
     const lpGovernanceEntries = ROUTE_GOVERNANCE_REGISTRY.filter(
       (entry) => entry.surface === 'lp-route'


### PR DESCRIPTION
## Summary

- Add protected Economics workspace for comparing two pinned internal-analysis scenarios.
- Show Decimal-safe comparison deltas, locked reference/anchor provenance, source readiness, and coherence safeguards.
- Integrate route, navigation, and readiness coverage without changing server economics contracts or LP/Reports output.

## Validation

- `TZ=UTC npm test -- --project=server tests/unit/services/internal-analysis/analysis-checkpoint-service.test.ts -t "copies the economics pin into the immutable reference and compares its facts basis"`
- Focused client suite: 90 passed
- Full client suite: 1,604 passed, 14 skipped
- `npm run check`
- `npm run lint`
- `npm run build`