### PR TITLE
feat(kpi): serve the KPI manager from real routes

### DIFF
--- a/migrations/0049_kpi_observations.sql
+++ b/migrations/0049_kpi_observations.sql
@@ -1,0 +1,363 @@
+-- @drift-patch
+-- Reason: Issue #1300 / ruling GR2-4a adds the internal KPI collection table.
+-- The catalog guards below are hand-written rather than Drizzle-generated so a
+-- raw replay refuses a partial or drifted table instead of silently accepting it.
+--
+-- Issue #1300 / ruling GR2-4a: the internal KPI collection table that turns the
+-- KPI manager from an MSW-only client surface into a real product surface.
+--
+-- Purely additive: one new table, one new index. No existing table, column,
+-- constraint, trigger, or row is touched, so this migration is safe to apply
+-- ahead of or behind any other in-flight side-trail.
+--
+-- Drizzle's PostgreSQL migrator owns the transaction that includes this SQL and
+-- its migration-ledger insert. Do not add BEGIN/COMMIT here: an inner COMMIT
+-- would prematurely persist catalog changes before that ledger write.
+
+-- CREATE TABLE IF NOT EXISTS cannot repair a pre-existing partial or
+-- semantically drifted table. Refuse before any DDL so a journaled migration
+-- never records a catalog that lacks the exact 26-column shape, its four
+-- required foreign keys, and its exact set of 15 non-foreign-key constraints.
+-- The list index is validated separately because its guarded DDL below remains
+-- repairable on a structurally complete table during raw replay.
+DO $$
+DECLARE
+  invalid_columns text[];
+  invalid_constraints text[];
+  observations_present boolean;
+BEGIN
+  observations_present := to_regclass('public.kpi_observations') IS NOT NULL;
+
+  IF NOT observations_present THEN
+    RETURN;
+  END IF;
+
+  WITH required_column(
+    name,
+    data_type,
+    udt_name,
+    is_nullable,
+    character_maximum_length,
+    default_kind
+  ) AS (
+    VALUES
+      ('id', 'integer', 'int4', 'NO', NULL::integer, 'serial'),
+      ('fund_id', 'integer', 'int4', 'NO', NULL::integer, 'none'),
+      ('portfolio_company_id', 'integer', 'int4', 'NO', NULL::integer, 'none'),
+      ('metric', 'character varying', 'varchar', 'NO', 32, 'none'),
+      ('period_start', 'date', 'date', 'NO', NULL::integer, 'none'),
+      ('period_end', 'date', 'date', 'NO', NULL::integer, 'none'),
+      ('basis', 'character varying', 'varchar', 'NO', 16, 'none'),
+      ('value_kind', 'character varying', 'varchar', 'NO', 8, 'none'),
+      ('value_amount', 'numeric', 'numeric', 'YES', NULL::integer, 'none'),
+      ('value_date', 'date', 'date', 'YES', NULL::integer, 'none'),
+      ('value_text', 'text', 'text', 'YES', NULL::integer, 'none'),
+      ('company_kpi_label', 'character varying', 'varchar', 'YES', 120, 'none'),
+      ('source', 'character varying', 'varchar', 'NO', 16, 'none'),
+      ('source_label', 'character varying', 'varchar', 'YES', 200, 'none'),
+      ('comment', 'text', 'text', 'YES', NULL::integer, 'none'),
+      ('submitted_at', 'timestamp with time zone', 'timestamptz', 'NO', NULL::integer, 'none'),
+      ('review_status', 'character varying', 'varchar', 'NO', 16, 'pending'),
+      ('review_comment', 'text', 'text', 'YES', NULL::integer, 'none'),
+      ('reviewed_by', 'integer', 'int4', 'YES', NULL::integer, 'none'),
+      ('reviewed_at', 'timestamp with time zone', 'timestamptz', 'YES', NULL::integer, 'none'),
+      ('version', 'integer', 'int4', 'NO', NULL::integer, 'one'),
+      ('idempotency_key', 'character varying', 'varchar', 'NO', 128, 'none'),
+      ('request_hash', 'character varying', 'varchar', 'NO', 64, 'none'),
+      ('created_by', 'integer', 'int4', 'YES', NULL::integer, 'none'),
+      ('created_at', 'timestamp with time zone', 'timestamptz', 'NO', NULL::integer, 'now'),
+      ('updated_at', 'timestamp with time zone', 'timestamptz', 'NO', NULL::integer, 'now')
+  )
+  SELECT array_agg(invalid_column.name ORDER BY invalid_column.name)
+  INTO invalid_columns
+  FROM (
+    SELECT required_column.name
+    FROM required_column
+    LEFT JOIN information_schema.columns AS column_catalog
+      ON column_catalog.table_schema = 'public'
+      AND column_catalog.table_name = 'kpi_observations'
+      AND column_catalog.column_name = required_column.name
+    WHERE column_catalog.column_name IS NULL
+      OR column_catalog.data_type IS DISTINCT FROM required_column.data_type
+      OR column_catalog.udt_name IS DISTINCT FROM required_column.udt_name
+      OR column_catalog.is_nullable IS DISTINCT FROM required_column.is_nullable
+      OR column_catalog.character_maximum_length
+        IS DISTINCT FROM required_column.character_maximum_length
+      OR column_catalog.is_identity IS DISTINCT FROM 'NO'
+      OR column_catalog.is_generated IS DISTINCT FROM 'NEVER'
+      OR (
+        required_column.default_kind = 'serial'
+        AND (
+          -- Exact information_schema.columns output for the serial declaration
+          -- below: unqualified there, schema-qualified from pg_get_serial_sequence.
+          column_catalog.column_default IS DISTINCT FROM
+            'nextval(''kpi_observations_id_seq''::regclass)'
+          OR pg_get_serial_sequence('public.kpi_observations', 'id')
+            IS DISTINCT FROM 'public.kpi_observations_id_seq'
+        )
+      )
+      OR (
+        required_column.default_kind = 'now'
+        AND column_catalog.column_default IS DISTINCT FROM 'now()'
+      )
+      OR (
+        required_column.default_kind = 'one'
+        AND column_catalog.column_default IS DISTINCT FROM '1'
+      )
+      OR (
+        required_column.default_kind = 'pending'
+        AND column_catalog.column_default IS DISTINCT FROM '''pending''::character varying'
+      )
+      OR (
+        required_column.default_kind = 'none'
+        AND column_catalog.column_default IS NOT NULL
+      )
+    UNION ALL
+    SELECT column_catalog.column_name
+    FROM information_schema.columns AS column_catalog
+    WHERE column_catalog.table_schema = 'public'
+      AND column_catalog.table_name = 'kpi_observations'
+      AND NOT EXISTS (
+        SELECT 1
+        FROM required_column
+        WHERE required_column.name = column_catalog.column_name
+      )
+  ) AS invalid_column;
+
+  SELECT array_agg(missing_constraint.name ORDER BY missing_constraint.name)
+  INTO invalid_constraints
+  FROM (
+    SELECT required_constraint.name
+    FROM (
+      VALUES
+        ('kpi_observations_pkey'),
+        ('kpi_observations_fund_id_funds_id_fk'),
+        ('kpi_observations_portfolio_company_id_fk'),
+        ('kpi_observations_reviewed_by_fk'),
+        ('kpi_observations_created_by_fk'),
+        ('kpi_observations_id_fund_unique'),
+        ('kpi_observations_fund_idempotency_unique'),
+        ('kpi_observations_metric_check'),
+        ('kpi_observations_basis_check'),
+        ('kpi_observations_source_check'),
+        ('kpi_observations_review_status_check'),
+        ('kpi_observations_value_kind_check'),
+        ('kpi_observations_value_coupling_check'),
+        ('kpi_observations_metric_value_kind_check'),
+        ('kpi_observations_non_negative_value_check'),
+        ('kpi_observations_company_kpi_label_check'),
+        ('kpi_observations_period_order_check'),
+        ('kpi_observations_version_check'),
+        ('kpi_observations_review_coupling_check')
+    ) AS required_constraint(name)
+    LEFT JOIN pg_constraint AS constraint_catalog
+      ON constraint_catalog.conrelid = 'public.kpi_observations'::regclass
+      AND constraint_catalog.conname = required_constraint.name
+    WHERE constraint_catalog.oid IS NULL
+    UNION ALL
+    SELECT constraint_catalog.conname
+    FROM pg_constraint AS constraint_catalog
+    WHERE constraint_catalog.conrelid = 'public.kpi_observations'::regclass
+      AND constraint_catalog.contype <> 'f'
+      AND constraint_catalog.conname NOT IN (
+        'kpi_observations_pkey',
+        'kpi_observations_id_fund_unique',
+        'kpi_observations_fund_idempotency_unique',
+        'kpi_observations_metric_check',
+        'kpi_observations_basis_check',
+        'kpi_observations_source_check',
+        'kpi_observations_review_status_check',
+        'kpi_observations_value_kind_check',
+        'kpi_observations_value_coupling_check',
+        'kpi_observations_metric_value_kind_check',
+        'kpi_observations_non_negative_value_check',
+        'kpi_observations_company_kpi_label_check',
+        'kpi_observations_period_order_check',
+        'kpi_observations_version_check',
+        'kpi_observations_review_coupling_check'
+      )
+  ) AS missing_constraint;
+
+  IF invalid_columns IS NOT NULL OR invalid_constraints IS NOT NULL THEN
+    RAISE EXCEPTION
+      'kpi_observations_partial_catalog_state: kpi_observations has missing, extra, or mismatched required columns [%] or constraints [%]',
+      coalesce(array_to_string(invalid_columns, ', '), ''),
+      coalesce(array_to_string(invalid_constraints, ', '), '');
+  END IF;
+END $$;
+--> statement-breakpoint
+
+-- Exact index equivalence closes the replay gap left by CREATE INDEX IF NOT
+-- EXISTS. A same-named relation that is not this index, or an unexpected index
+-- on the table, refuses rather than being silently accepted.
+DO $$
+DECLARE
+  observations_relation regclass;
+  list_index_kind "char";
+  list_index_definition text;
+  unexpected_index_names text[];
+BEGIN
+  observations_relation := to_regclass('public.kpi_observations');
+
+  SELECT relation_catalog.relkind
+  INTO list_index_kind
+  FROM pg_class AS relation_catalog
+  JOIN pg_namespace AS namespace_catalog
+    ON namespace_catalog.oid = relation_catalog.relnamespace
+  WHERE namespace_catalog.nspname = 'public'
+    AND relation_catalog.relname = 'idx_kpi_observations_fund_company_period';
+
+  IF observations_relation IS NULL THEN
+    IF list_index_kind IS NOT NULL THEN
+      RAISE EXCEPTION
+        'kpi_observations_partial_catalog_state: the KPI observation index exists without its table';
+    END IF;
+    RETURN;
+  END IF;
+
+  SELECT pg_get_indexdef(index_catalog.indexrelid)
+  INTO list_index_definition
+  FROM pg_index AS index_catalog
+  JOIN pg_class AS index_relation ON index_relation.oid = index_catalog.indexrelid
+  WHERE index_relation.relnamespace = 'public'::regnamespace
+    AND index_relation.relname = 'idx_kpi_observations_fund_company_period'
+    AND index_catalog.indrelid = observations_relation;
+
+  SELECT array_agg(index_relation.relname ORDER BY index_relation.relname)
+  INTO unexpected_index_names
+  FROM pg_index AS index_catalog
+  JOIN pg_class AS index_relation ON index_relation.oid = index_catalog.indexrelid
+  WHERE index_catalog.indrelid = observations_relation
+    AND index_relation.relname NOT IN (
+      'kpi_observations_pkey',
+      'kpi_observations_id_fund_unique',
+      'kpi_observations_fund_idempotency_unique',
+      'idx_kpi_observations_fund_company_period'
+    );
+
+  IF list_index_kind IS NOT NULL AND (
+    list_index_kind IS DISTINCT FROM 'i'
+    OR list_index_definition IS DISTINCT FROM
+      'CREATE INDEX idx_kpi_observations_fund_company_period ON public.kpi_observations USING btree (fund_id, portfolio_company_id, period_start, id)'
+  ) THEN
+    RAISE EXCEPTION
+      'kpi_observations_partial_catalog_state: the KPI observation index is not replay-equivalent (kind %, definition %)',
+      coalesce(list_index_kind::text, ''),
+      coalesce(list_index_definition, '');
+  END IF;
+
+  IF unexpected_index_names IS NOT NULL THEN
+    RAISE EXCEPTION
+      'kpi_observations_partial_catalog_state: unexpected indexes on kpi_observations [%]',
+      array_to_string(unexpected_index_names, ', ');
+  END IF;
+END $$;
+--> statement-breakpoint
+
+-- Every field the GR2-4a ruling requires is a dedicated column. The typed value
+-- triple plus the metric/value-kind CHECK pair makes a wrong-typed KPI
+-- unrepresentable rather than merely rejected at the API edge.
+CREATE TABLE IF NOT EXISTS "kpi_observations" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "fund_id" integer NOT NULL,
+  "portfolio_company_id" integer NOT NULL,
+  "metric" varchar(32) NOT NULL,
+  "period_start" date NOT NULL,
+  "period_end" date NOT NULL,
+  "basis" varchar(16) NOT NULL,
+  "value_kind" varchar(8) NOT NULL,
+  "value_amount" numeric(20, 6),
+  "value_date" date,
+  "value_text" text,
+  "company_kpi_label" varchar(120),
+  "source" varchar(16) NOT NULL,
+  "source_label" varchar(200),
+  "comment" text,
+  "submitted_at" timestamp with time zone NOT NULL,
+  "review_status" varchar(16) DEFAULT 'pending' NOT NULL,
+  "review_comment" text,
+  "reviewed_by" integer,
+  "reviewed_at" timestamp with time zone,
+  "version" integer DEFAULT 1 NOT NULL,
+  "idempotency_key" varchar(128) NOT NULL,
+  "request_hash" varchar(64) NOT NULL,
+  "created_by" integer,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "kpi_observations_fund_id_funds_id_fk"
+    FOREIGN KEY ("fund_id") REFERENCES "public"."funds"("id") ON DELETE cascade,
+  CONSTRAINT "kpi_observations_portfolio_company_id_fk"
+    FOREIGN KEY ("portfolio_company_id")
+    REFERENCES "public"."portfoliocompanies"("id") ON DELETE restrict,
+  CONSTRAINT "kpi_observations_reviewed_by_fk"
+    FOREIGN KEY ("reviewed_by") REFERENCES "public"."users"("id"),
+  CONSTRAINT "kpi_observations_created_by_fk"
+    FOREIGN KEY ("created_by") REFERENCES "public"."users"("id"),
+  CONSTRAINT "kpi_observations_id_fund_unique" UNIQUE ("id", "fund_id"),
+  CONSTRAINT "kpi_observations_fund_idempotency_unique" UNIQUE ("fund_id", "idempotency_key"),
+  CONSTRAINT "kpi_observations_metric_check" CHECK ("metric" IN (
+    'revenue_arr','cash_balance','monthly_burn','runway_months','headcount',
+    'next_financing_target','next_financing_date','company_specific','qualitative_update'
+  )),
+  CONSTRAINT "kpi_observations_basis_check" CHECK ("basis" IN ('actual','projected')),
+  CONSTRAINT "kpi_observations_source_check" CHECK ("source" IN ('manual','csv_import')),
+  CONSTRAINT "kpi_observations_review_status_check"
+    CHECK ("review_status" IN ('pending','accepted','rejected')),
+  CONSTRAINT "kpi_observations_value_kind_check"
+    CHECK ("value_kind" IN ('money','number','date','text')),
+  CONSTRAINT "kpi_observations_value_coupling_check" CHECK (
+    (
+      "value_kind" IN ('money','number')
+      AND "value_amount" IS NOT NULL
+      AND "value_date" IS NULL
+      AND "value_text" IS NULL
+    )
+    OR (
+      "value_kind" = 'date'
+      AND "value_date" IS NOT NULL
+      AND "value_amount" IS NULL
+      AND "value_text" IS NULL
+    )
+    OR (
+      "value_kind" = 'text'
+      AND "value_text" IS NOT NULL
+      AND "value_amount" IS NULL
+      AND "value_date" IS NULL
+    )
+  ),
+  CONSTRAINT "kpi_observations_metric_value_kind_check" CHECK (
+    "value_kind" = CASE "metric"
+      WHEN 'revenue_arr' THEN 'money'
+      WHEN 'cash_balance' THEN 'money'
+      WHEN 'monthly_burn' THEN 'money'
+      WHEN 'next_financing_target' THEN 'money'
+      WHEN 'runway_months' THEN 'number'
+      WHEN 'headcount' THEN 'number'
+      WHEN 'company_specific' THEN 'number'
+      WHEN 'next_financing_date' THEN 'date'
+      WHEN 'qualitative_update' THEN 'text'
+    END
+  ),
+  CONSTRAINT "kpi_observations_non_negative_value_check" CHECK (
+    "metric" NOT IN (
+      'revenue_arr','cash_balance','monthly_burn','runway_months','headcount','next_financing_target'
+    )
+    OR "value_amount" >= 0
+  ),
+  CONSTRAINT "kpi_observations_company_kpi_label_check"
+    CHECK (("metric" = 'company_specific') = ("company_kpi_label" IS NOT NULL)),
+  CONSTRAINT "kpi_observations_period_order_check" CHECK ("period_end" >= "period_start"),
+  CONSTRAINT "kpi_observations_version_check" CHECK ("version" >= 1),
+  CONSTRAINT "kpi_observations_review_coupling_check" CHECK (
+    ("review_status" = 'pending') = ("reviewed_at" IS NULL AND "review_comment" IS NULL)
+  )
+);
+--> statement-breakpoint
+
+DO $$
+BEGIN
+  IF to_regclass('public.idx_kpi_observations_fund_company_period') IS NULL THEN
+    CREATE INDEX "idx_kpi_observations_fund_company_period"
+      ON "kpi_observations" ("fund_id", "portfolio_company_id", "period_start", "id");
+  END IF;
+END $$;

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -351,6 +351,13 @@
       "when": 1785627600000,
       "tag": "0048_quarterly_review_workflow",
       "breakpoints": true
+    },
+    {
+      "idx": 50,
+      "version": "7",
+      "when": 1785714000000,
+      "tag": "0049_kpi_observations",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/prod-schema-manifests/26-kpi-observations.json
+++ b/scripts/prod-schema-manifests/26-kpi-observations.json
@@ -1,0 +1,67 @@
+{
+  "name": "kpi-observations",
+  "order": 25,
+  "description": "Issue #1300 migration 0049: the internal KPI collection table behind /api/funds/:fundId/kpi-observations. Purely additive - one table and one index, no existing catalog object touched - so it carries no drift patch and no trigger or function DDL.",
+  "missingTablePolicy": "create_or_repair",
+  "sqlFiles": ["migrations/0049_kpi_observations.sql"],
+  "allowedCreateTables": ["kpi_observations"],
+  "expectedTables": [
+    {
+      "name": "kpi_observations",
+      "columns": [
+        { "name": "id", "type": "integer", "nullable": false },
+        { "name": "fund_id", "type": "integer", "nullable": false },
+        {
+          "name": "portfolio_company_id",
+          "type": "integer",
+          "nullable": false
+        },
+        { "name": "metric", "type": "varchar", "nullable": false },
+        { "name": "period_start", "type": "date", "nullable": false },
+        { "name": "period_end", "type": "date", "nullable": false },
+        { "name": "basis", "type": "varchar", "nullable": false },
+        { "name": "value_kind", "type": "varchar", "nullable": false },
+        { "name": "value_amount", "type": "numeric", "nullable": true },
+        { "name": "value_date", "type": "date", "nullable": true },
+        { "name": "value_text", "type": "text", "nullable": true },
+        { "name": "company_kpi_label", "type": "varchar", "nullable": true },
+        { "name": "source", "type": "varchar", "nullable": false },
+        { "name": "source_label", "type": "varchar", "nullable": true },
+        { "name": "comment", "type": "text", "nullable": true },
+        { "name": "submitted_at", "type": "timestamptz", "nullable": false },
+        { "name": "review_status", "type": "varchar", "nullable": false },
+        { "name": "review_comment", "type": "text", "nullable": true },
+        { "name": "reviewed_by", "type": "integer", "nullable": true },
+        { "name": "reviewed_at", "type": "timestamptz", "nullable": true },
+        { "name": "version", "type": "integer", "nullable": false },
+        { "name": "idempotency_key", "type": "varchar", "nullable": false },
+        { "name": "request_hash", "type": "varchar", "nullable": false },
+        { "name": "created_by", "type": "integer", "nullable": true },
+        { "name": "created_at", "type": "timestamptz", "nullable": false },
+        { "name": "updated_at", "type": "timestamptz", "nullable": false }
+      ],
+      "constraints": [
+        "kpi_observations_pkey",
+        "kpi_observations_fund_id_funds_id_fk",
+        "kpi_observations_portfolio_company_id_fk",
+        "kpi_observations_reviewed_by_fk",
+        "kpi_observations_created_by_fk",
+        "kpi_observations_id_fund_unique",
+        "kpi_observations_fund_idempotency_unique",
+        "kpi_observations_metric_check",
+        "kpi_observations_basis_check",
+        "kpi_observations_source_check",
+        "kpi_observations_review_status_check",
+        "kpi_observations_value_kind_check",
+        "kpi_observations_value_coupling_check",
+        "kpi_observations_metric_value_kind_check",
+        "kpi_observations_non_negative_value_check",
+        "kpi_observations_company_kpi_label_check",
+        "kpi_observations_period_order_check",
+        "kpi_observations_version_check",
+        "kpi_observations_review_coupling_check"
+      ],
+      "indexes": ["idx_kpi_observations_fund_company_period"]
+    }
+  ]
+}

--- a/scripts/prod-schema-manifests/26-kpi-observations.json
+++ b/scripts/prod-schema-manifests/26-kpi-observations.json
@@ -1,6 +1,6 @@
 {
   "name": "kpi-observations",
-  "order": 25,
+  "order": 26,
   "description": "Issue #1300 migration 0049: the internal KPI collection table behind /api/funds/:fundId/kpi-observations. Purely additive - one table and one index, no existing catalog object touched - so it carries no drift patch and no trigger or function DDL.",
   "missingTablePolicy": "create_or_repair",
   "sqlFiles": ["migrations/0049_kpi_observations.sql"],

--- a/server/lib/database-backed-idempotency-routes.ts
+++ b/server/lib/database-backed-idempotency-routes.ts
@@ -2,6 +2,10 @@ const INTERNAL_ECONOMICS_RUN_CREATION_PATH =
   /^\/api\/funds\/[^/?#]+\/internal-economics\/runs\/?$/i;
 const TASK_EVIDENCE_LINK_CREATION_PATH =
   /^\/api\/funds\/[^/?#]+\/tasks\/[^/?#]+\/evidence-links\/?$/i;
+// KPI collection stores its own idempotency key and request hash on the row, so
+// both write paths bypass the generic in-memory idempotency middleware.
+const KPI_OBSERVATION_CREATION_PATH = /^\/api\/funds\/[^/?#]+\/kpi-observations\/?$/i;
+const KPI_OBSERVATION_IMPORT_PATH = /^\/api\/funds\/[^/?#]+\/kpi-observations\/imports\/?$/i;
 
 export function isDatabaseBackedIdempotencyRoute(method: string, path: string): boolean {
   const pathnameEnd = path.search(/[?#]/);
@@ -9,6 +13,8 @@ export function isDatabaseBackedIdempotencyRoute(method: string, path: string): 
   return (
     method === 'POST' &&
     (INTERNAL_ECONOMICS_RUN_CREATION_PATH.test(pathname) ||
-      TASK_EVIDENCE_LINK_CREATION_PATH.test(pathname))
+      TASK_EVIDENCE_LINK_CREATION_PATH.test(pathname) ||
+      KPI_OBSERVATION_CREATION_PATH.test(pathname) ||
+      KPI_OBSERVATION_IMPORT_PATH.test(pathname))
   );
 }

--- a/server/lib/fund-scoped-ownership.ts
+++ b/server/lib/fund-scoped-ownership.ts
@@ -11,6 +11,7 @@ import {
 } from '../../shared/schema/internal-economics';
 import { financingEvents, financingTranches } from '../../shared/schema/investment-ledger';
 import { vehicles } from '../../shared/schema/lp-reporting-evidence';
+import { portfolioCompanies } from '../../shared/schema/portfolio';
 import { vehicleFinancingParticipations } from '../../shared/schema/vehicle-financing-participations';
 
 export type FundScopedReference = {
@@ -25,7 +26,8 @@ export type FundScopedReference = {
     | 'participation'
     | 'capital_envelope_version'
     | 'economics_policy_version'
-    | 'lp_economics_run';
+    | 'lp_economics_run'
+    | 'portfolio_company';
   id: string | number;
 };
 
@@ -246,6 +248,22 @@ export async function assertOwnedByFund(opts: {
       .where(
         and(eq(internalLpEconomicsRuns.id, id), eq(internalLpEconomicsRuns.fundId, opts.fundId))
       )
+      .limit(1);
+
+    if (rows.length === 0) {
+      throw new FundScopeError(opts.ref);
+    }
+    return;
+  }
+
+  // `portfoliocompanies` has a nullable fund_id and no (id, fund_id) sibling key,
+  // so a KPI observation's company FK is plain and this is the only same-fund
+  // check on it (issue #1300).
+  if (opts.ref.kind === 'portfolio_company') {
+    const rows = await opts.db
+      .select({ id: portfolioCompanies.id })
+      .from(portfolioCompanies)
+      .where(and(eq(portfolioCompanies.id, id), eq(portfolioCompanies.fundId, opts.fundId)))
       .limit(1);
 
     if (rows.length === 0) {

--- a/server/route-policy/api-route-policy-registry.ts
+++ b/server/route-policy/api-route-policy-registry.ts
@@ -1977,6 +1977,56 @@ export const EXPLICIT_API_ROUTE_POLICY_ENTRIES: RoutePolicyEntry[] = [
     [
       [
         'GET',
+        '/api/funds/:fundId/kpi-observations',
+        'List collected KPI observations for a fund, filtered by company, metric, basis, review state, or period.',
+      ],
+      [
+        'GET',
+        '/api/funds/:fundId/kpi-observations/:observationId',
+        'Read one observation; the response ETag is what a review must echo in If-Match.',
+      ],
+      [
+        'POST',
+        '/api/funds/:fundId/kpi-observations',
+        'Record one manually entered observation under a required Idempotency-Key.',
+      ],
+      [
+        'POST',
+        '/api/funds/:fundId/kpi-observations/imports',
+        'Import a fixed-template CSV batch; each row lands through the same idempotent command.',
+      ],
+      [
+        'PATCH',
+        '/api/funds/:fundId/kpi-observations/:observationId/review',
+        'Record a reviewer decision under If-Match optimistic locking.',
+      ],
+    ] as const
+  ).map(([method, path, notes]): RoutePolicyEntry => ({
+    id: `api:${method.toLowerCase()}:${path}`,
+    method,
+    path,
+    lifecycle: 'durable_crud',
+    governanceRef: '/portfolio',
+    surface: 'kpi-observations-api',
+    owner: ownerForFinancialSurface('portfolio_management'),
+    telemetryKey: telemetryKeyForRoute('api.route', path),
+    financialSurface: 'portfolio_management',
+    apiAuthBoundary: 'require_auth_and_fund_access',
+    fundScopeMode: 'route_param_fund_id',
+    workflowRequirement: 'fund_scope_and_idempotency_verified',
+    // Internal KPI collection is internal-only and CSV-first: no company-facing
+    // request form, no recipient, no send, and no export path at all (GR2-4a).
+    exportPolicy: 'not_exportable',
+    provenanceRequired: true,
+    staleBlocksExport: false,
+    humanReviewRequired: true,
+    performanceBudgetMs: null,
+    notes: `Issue #1300. ${notes}`,
+  })),
+  ...(
+    [
+      [
+        'GET',
         '/api/funds/:fundId/internal-analysis/narratives',
         'Read the terminal source-linked narrative for an anchor (draft or reference).',
       ],
@@ -2140,6 +2190,13 @@ export const COMMON_API_ROUTE_POLICY_IDS = {
   reallocation: ['client:/portfolio'],
   'cash-flow-events': ['client:/lp-reporting/ledger'],
   'operating-object-tasks': ['client:/dashboard'],
+  'kpi-observations': [
+    'api:get:/api/funds/:fundId/kpi-observations',
+    'api:get:/api/funds/:fundId/kpi-observations/:observationId',
+    'api:post:/api/funds/:fundId/kpi-observations',
+    'api:post:/api/funds/:fundId/kpi-observations/imports',
+    'api:patch:/api/funds/:fundId/kpi-observations/:observationId/review',
+  ],
   'deal-pipeline': ['client:/pipeline'],
   'cohort-analysis': ['client:/portfolio'],
   sensitivity: ['client:/sensitivity-analysis'],

--- a/server/routes/kpi-observations.ts
+++ b/server/routes/kpi-observations.ts
@@ -1,0 +1,408 @@
+/**
+ * Internal KPI collection routes (issue #1300, ruling GR2-4a).
+ *
+ * This lands BACKEND-ONLY: the routes stay archived through the soak window and
+ * have no client consumer yet. Wiring `client/src/pages/kpi-manager/` and
+ * `kpi-submission.tsx` off their MSW-only backing is separate, post-activation
+ * work. Creation is `Idempotency-Key`-guarded and database
+ * backed; review is `If-Match`-guarded against the row version that backs the
+ * ETag (missing header -> 428, stale header -> 412).
+ *
+ * This surface is INTERNAL-ONLY and CSV-first. There is deliberately no
+ * company-facing request form, no recipient, no send, no share, and no export
+ * endpoint here, and `tests/unit/source/kpi-observation-boundary.test.ts` keeps
+ * it that way.
+ *
+ * @module server/routes/kpi-observations
+ */
+
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import rateLimit from 'express-rate-limit';
+
+import { parseFundIdParam } from '@shared/number';
+import {
+  KpiObservationImportRequestSchema,
+  KpiObservationCreateRequestSchema,
+  KpiObservationImportResponseSchema,
+  KpiObservationListQuerySchema,
+  KpiObservationListResponseSchema,
+  KpiObservationReviewRequestSchema,
+  type KpiCsvRowRejection,
+  type KpiObservationV1,
+} from '@shared/contracts/kpi/kpi-observation-v1.contract';
+
+import { enforceProvidedFundScope } from '../lib/auth/provided-fund-scope';
+import { parseETag, setETagHeaders, weakETag } from '../lib/http-preconditions';
+import { IdempotentCommandError } from '../lib/idempotent-command';
+import { parseInternalEconomicsIdempotencyKey } from '../lib/internal-economics-idempotency-key';
+import { firstString } from '../lib/request-values';
+import { KpiCsvBatchError, parseKpiObservationCsv } from '../services/kpi/kpi-observation-csv';
+import {
+  KpiObservationServiceError,
+  createKpiObservation,
+  listKpiObservations,
+  loadKpiObservation,
+  reviewKpiObservation,
+  toKpiObservationContract,
+} from '../services/kpi/kpi-observation-service';
+
+const router = Router();
+
+const readLimiter = rateLimit({
+  windowMs: 60_000,
+  max: 120,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+/**
+ * Writes are bounded tighter than reads: a CSV batch does one idempotent command
+ * per row, so an import is far more work than a single-row create.
+ */
+const writeLimiter = rateLimit({
+  windowMs: 60_000,
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+function numericIdentity(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isInteger(value) && value > 0) return value;
+  if (typeof value === 'string' && /^[1-9]\d*$/.test(value)) return Number.parseInt(value, 10);
+  return null;
+}
+
+/**
+ * Best-effort actor id. JWT subs are not guaranteed numeric and both actor
+ * columns are nullable users.id FKs, so an unresolved identity stores NULL
+ * rather than failing an otherwise authorized write.
+ */
+function resolveActorId(req: Request): number | null {
+  return numericIdentity(req.user?.id) ?? numericIdentity(req.user?.sub) ?? null;
+}
+
+/**
+ * Observation-scoped ETag. Hashing the bare version would collide across
+ * observations that happen to share one, so the fund and observation fold in.
+ */
+function observationETag(observation: { fundId: number; observationId: number; version: number }) {
+  return weakETag(
+    `kpi-observation:${observation.fundId}:${observation.observationId}:${observation.version}`
+  );
+}
+
+function respondToTypedError(error: unknown, res: Response): boolean {
+  if (error instanceof KpiObservationServiceError) {
+    res.status(error.statusCode).json({
+      error: error.code,
+      message: error.message,
+      ...(error.details === undefined ? {} : { details: error.details }),
+    });
+    return true;
+  }
+  if (error instanceof KpiCsvBatchError) {
+    res.status(error.status).json({ error: error.code, message: error.message });
+    return true;
+  }
+  if (error instanceof IdempotentCommandError) {
+    res.status(error.status).json({ error: error.code, message: error.message });
+    return true;
+  }
+  return false;
+}
+
+/** Path fund id, or a 400 already written to the response. */
+function fundIdOrNull(req: Request, res: Response): number | null {
+  const fundId = parseFundIdParam(firstString(req.params['fundId']));
+  if (fundId === null) {
+    res.status(400).json({ error: 'Invalid fund ID' });
+    return null;
+  }
+  return fundId;
+}
+
+function observationIdOrNull(req: Request, res: Response): number | null {
+  const observationId = parseFundIdParam(firstString(req.params['observationId']));
+  if (observationId === null) {
+    res.status(400).json({ error: 'Invalid observation ID' });
+    return null;
+  }
+  return observationId;
+}
+
+/** Required `Idempotency-Key`, or a 428/400 already written to the response. */
+function idempotencyKeyOrNull(req: Request, res: Response): string | null {
+  const parsed = parseInternalEconomicsIdempotencyKey(req.headers['idempotency-key']);
+  if (parsed.kind === 'missing') {
+    res
+      .status(428)
+      .json({ error: 'IDEMPOTENCY_KEY_REQUIRED', message: 'Idempotency-Key header is required.' });
+    return null;
+  }
+  if (parsed.kind === 'invalid') {
+    res.status(400).json({
+      error: 'INVALID_IDEMPOTENCY_KEY',
+      message: 'Idempotency-Key must contain 1 to 128 RFC token characters.',
+    });
+    return null;
+  }
+  return parsed.value;
+}
+
+router.get(
+  '/api/funds/:fundId/kpi-observations',
+  readLimiter,
+  async (req: Request, res: Response) => {
+    const fundId = fundIdOrNull(req, res);
+    if (fundId === null) return undefined;
+
+    const parsedQuery = KpiObservationListQuerySchema.safeParse(req.query);
+    if (!parsedQuery.success) {
+      return res.status(400).json({
+        error: 'INVALID_KPI_OBSERVATION_QUERY',
+        message: 'Unsupported KPI observation filter.',
+        details: parsedQuery.error.flatten(),
+      });
+    }
+    if (!(await enforceProvidedFundScope(req, res, fundId))) return undefined;
+
+    try {
+      const data = await listKpiObservations(fundId, parsedQuery.data);
+      res.setHeader('Cache-Control', 'private, no-store');
+      return res.status(200).json(KpiObservationListResponseSchema.parse({ data }));
+    } catch (error) {
+      if (respondToTypedError(error, res)) return undefined;
+      return res.status(500).json({ error: 'Failed to list KPI observations' });
+    }
+  }
+);
+
+router.get(
+  '/api/funds/:fundId/kpi-observations/:observationId',
+  readLimiter,
+  async (req: Request, res: Response) => {
+    const fundId = fundIdOrNull(req, res);
+    if (fundId === null) return undefined;
+    const observationId = observationIdOrNull(req, res);
+    if (observationId === null) return undefined;
+    if (!(await enforceProvidedFundScope(req, res, fundId))) return undefined;
+
+    try {
+      const row = await loadKpiObservation(fundId, observationId);
+      if (row === null) {
+        return res
+          .status(404)
+          .json({ error: 'KPI_OBSERVATION_NOT_FOUND', message: 'KPI observation not found.' });
+      }
+      const observation = toKpiObservationContract(row);
+      // The ETag a subsequent review must echo back in If-Match.
+      setETagHeaders(res, observationETag(observation));
+      return res.status(200).json(observation);
+    } catch (error) {
+      if (respondToTypedError(error, res)) return undefined;
+      return res.status(500).json({ error: 'Failed to read KPI observation' });
+    }
+  }
+);
+
+router.post(
+  '/api/funds/:fundId/kpi-observations',
+  writeLimiter,
+  async (req: Request, res: Response) => {
+    const fundId = fundIdOrNull(req, res);
+    if (fundId === null) return undefined;
+    if (!(await enforceProvidedFundScope(req, res, fundId, { forWrite: true }))) return undefined;
+
+    const idempotencyKey = idempotencyKeyOrNull(req, res);
+    if (idempotencyKey === null) return undefined;
+
+    const parsedBody = KpiObservationCreateRequestSchema.safeParse(req.body);
+    if (!parsedBody.success) {
+      return res.status(400).json({
+        error: 'INVALID_KPI_OBSERVATION_BODY',
+        message: 'Request body does not satisfy the KPI observation contract.',
+        details: parsedBody.error.flatten(),
+      });
+    }
+
+    try {
+      const result = await createKpiObservation({
+        fundId,
+        request: parsedBody.data,
+        // The channel is server-decided; a caller cannot claim a CSV provenance.
+        source: 'manual',
+        actorId: resolveActorId(req),
+        idempotencyKey,
+      });
+      setETagHeaders(res, observationETag(result.observation));
+      res.setHeader('Cache-Control', 'private, no-store');
+      return res.status(result.replayed ? 200 : 201).json(result.observation);
+    } catch (error) {
+      if (respondToTypedError(error, res)) return undefined;
+      return res.status(500).json({ error: 'Failed to create KPI observation' });
+    }
+  }
+);
+
+/**
+ * Fixed-template CSV import. Every row is created through the same idempotent
+ * command as a manual entry, keyed `<batch key>:row:<n>`, so re-posting an
+ * identical batch after a partial failure replays the rows that landed instead
+ * of duplicating them.
+ */
+router.post(
+  '/api/funds/:fundId/kpi-observations/imports',
+  writeLimiter,
+  async (req: Request, res: Response) => {
+    const fundId = fundIdOrNull(req, res);
+    if (fundId === null) return undefined;
+    if (!(await enforceProvidedFundScope(req, res, fundId, { forWrite: true }))) return undefined;
+
+    const idempotencyKey = idempotencyKeyOrNull(req, res);
+    if (idempotencyKey === null) return undefined;
+
+    const parsedBody = KpiObservationImportRequestSchema.safeParse(req.body);
+    if (!parsedBody.success) {
+      return res.status(400).json({
+        error: 'INVALID_KPI_IMPORT_BODY',
+        message: 'Request body does not satisfy the KPI import contract.',
+        details: parsedBody.error.flatten(),
+      });
+    }
+
+    try {
+      const parsed = parseKpiObservationCsv(Buffer.from(parsedBody.data.csvBase64, 'base64'));
+      const actorId = resolveActorId(req);
+      const imported: KpiObservationV1[] = [];
+      const rejected: KpiCsvRowRejection[] = [...parsed.rejected];
+      let allReplayed = parsed.accepted.length > 0;
+
+      for (const row of parsed.accepted) {
+        try {
+          const result = await createKpiObservation({
+            fundId,
+            request: {
+              ...row.request,
+              sourceLabel: row.request.sourceLabel ?? parsedBody.data.sourceLabel ?? null,
+            },
+            source: 'csv_import',
+            actorId,
+            idempotencyKey: `${idempotencyKey}:row:${row.row}`,
+          });
+          imported.push(result.observation);
+          if (!result.replayed) allReplayed = false;
+        } catch (error) {
+          if (error instanceof KpiObservationServiceError) {
+            rejected.push({ row: row.row, code: error.code, message: error.message });
+            continue;
+          }
+          if (error instanceof IdempotentCommandError) {
+            rejected.push({ row: row.row, code: error.code, message: error.message });
+            continue;
+          }
+          throw error;
+        }
+      }
+
+      rejected.sort((left, right) => left.row - right.row);
+      res.setHeader('Cache-Control', 'private, no-store');
+      return res
+        .status(imported.length > 0 && !allReplayed ? 201 : 200)
+        .json(
+          KpiObservationImportResponseSchema.parse({ imported, rejected, replayed: allReplayed })
+        );
+    } catch (error) {
+      if (respondToTypedError(error, res)) return undefined;
+      return res.status(500).json({ error: 'Failed to import KPI observations' });
+    }
+  }
+);
+
+/**
+ * Record a reviewer's decision under optimistic concurrency. Error order mirrors
+ * operating-object-tasks: parse (400) -> scope (403) -> If-Match present (428)
+ * -> body (400) -> load (404) -> etag (412) -> compare-and-set -> zero-row
+ * disambiguation. There is no 409: a review has no immutable precondition of its
+ * own, so a zero-row update after a passing precondition means a concurrent
+ * review (412) or a deleted fund (404) only.
+ */
+router.patch(
+  '/api/funds/:fundId/kpi-observations/:observationId/review',
+  writeLimiter,
+  async (req: Request, res: Response) => {
+    const fundId = fundIdOrNull(req, res);
+    if (fundId === null) return undefined;
+    const observationId = observationIdOrNull(req, res);
+    if (observationId === null) return undefined;
+    if (!(await enforceProvidedFundScope(req, res, fundId, { forWrite: true }))) return undefined;
+
+    const ifMatch = firstString(req.headers['if-match']);
+    if (ifMatch === undefined) {
+      return res
+        .status(428)
+        .json({ error: 'precondition_required', message: 'If-Match header is required' });
+    }
+
+    const parsedBody = KpiObservationReviewRequestSchema.safeParse(req.body);
+    if (!parsedBody.success) {
+      return res.status(400).json({
+        error: 'INVALID_KPI_REVIEW_BODY',
+        message: 'Request body does not satisfy the KPI review contract.',
+        details: parsedBody.error.flatten(),
+      });
+    }
+
+    try {
+      const current = await loadKpiObservation(fundId, observationId);
+      if (current === null) {
+        return res
+          .status(404)
+          .json({ error: 'KPI_OBSERVATION_NOT_FOUND', message: 'KPI observation not found.' });
+      }
+      const currentETag = observationETag({
+        fundId,
+        observationId,
+        version: current.version,
+      });
+      if (parseETag(ifMatch) !== parseETag(currentETag)) {
+        return res.status(412).json({
+          error: 'precondition_failed',
+          message: 'KPI observation has been modified',
+          current: currentETag,
+        });
+      }
+
+      const updated = await reviewKpiObservation({
+        fundId,
+        observationId,
+        expectedVersion: current.version,
+        reviewStatus: parsedBody.data.reviewStatus,
+        reviewComment: parsedBody.data.reviewComment ?? null,
+        actorId: resolveActorId(req),
+      });
+      if (updated === null) {
+        const recheck = await loadKpiObservation(fundId, observationId);
+        if (recheck === null) {
+          return res
+            .status(404)
+            .json({ error: 'KPI_OBSERVATION_NOT_FOUND', message: 'KPI observation not found.' });
+        }
+        return res.status(412).json({
+          error: 'precondition_failed',
+          message: 'KPI observation has been modified',
+          current: observationETag({ fundId, observationId, version: recheck.version }),
+        });
+      }
+
+      const observation = toKpiObservationContract(updated);
+      setETagHeaders(res, observationETag(observation));
+      return res.status(200).json(observation);
+    } catch (error) {
+      if (respondToTypedError(error, res)) return undefined;
+      return res.status(500).json({ error: 'Failed to review KPI observation' });
+    }
+  }
+);
+
+export default router;

--- a/server/routes/mount-common-routes.ts
+++ b/server/routes/mount-common-routes.ts
@@ -28,6 +28,7 @@ import internalAnalysisRouter from './internal-analysis.js';
 import internalEconomicsRouter from './internal-economics.js';
 import investmentLedgerRouter from './investment-ledger.js';
 import investmentsRouter from './investments.js';
+import kpiObservationsRouter from './kpi-observations.js';
 import liquidityRouter from './liquidity.js';
 import lpApiRouter from './lp-api.js';
 import lpCapitalCallsRouter from './lp-capital-calls.js';
@@ -94,6 +95,7 @@ export const COMMON_ROUTE_IMPLEMENTATIONS: Record<CommonApiRouteId, RouteMountIm
   reallocation: at(null, reallocationRouter),
   'cash-flow-events': at(null, cashFlowEventsRouter),
   'operating-object-tasks': at(null, operatingObjectTasksRouter),
+  'kpi-observations': at(null, kpiObservationsRouter),
   'deal-pipeline': at('/api/deals', dealPipelineRouter),
   'cohort-analysis': at('/api/cohorts', cohortAnalysisRouter),
   sensitivity: at('/api', sensitivityRouter),
@@ -139,6 +141,7 @@ export const COMMON_ROUTE_SURFACE_ORDER = {
     'reallocation',
     'cash-flow-events',
     'operating-object-tasks',
+    'kpi-observations',
     'fund-metrics',
     'dual-forecast',
     'performance-api',

--- a/server/services/kpi/kpi-observation-csv.ts
+++ b/server/services/kpi/kpi-observation-csv.ts
@@ -1,0 +1,225 @@
+/**
+ * Fixed-template KPI CSV import (issue #1300, ruling GR2-4a).
+ *
+ * v1 is CSV-first and internal-only: there is one frozen header, no mapping
+ * profile, and no caller-supplied column mapping. Tokenizing reuses the shared
+ * `server/lib/csv-tokenizer` primitives that `financial-observations/csv-adapter`
+ * itself consumes -- there is exactly one CSV tokenizer in this repository and
+ * this module adds no second parser.
+ *
+ * Batch-level structural problems (embedded newline, wrong header, row overflow)
+ * reject the whole batch. Per-row problems reject only that row, so one bad cell
+ * in a quarterly collection does not discard the other companies' numbers.
+ *
+ * @module server/services/kpi/kpi-observation-csv
+ */
+
+import {
+  KPI_CSV_MAX_ROWS,
+  KPI_CSV_TEMPLATE_HEADER,
+  KPI_METRIC_VALUE_KIND,
+  KpiObservationCreateRequestSchema,
+  type KpiCsvRowRejection,
+  type KpiMetric,
+  type KpiObservationCreateRequest,
+  type KpiObservationValue,
+} from '@shared/contracts/kpi/kpi-observation-v1.contract';
+
+import {
+  hasEmbeddedQuotedNewline,
+  normalizeHeaderToken,
+  parseCsvBufferRaw,
+} from '../../lib/csv-tokenizer';
+
+const NUMERIC_SCALE = 6;
+
+export class KpiCsvBatchError extends Error {
+  readonly status = 400;
+
+  constructor(
+    readonly code: string,
+    message: string
+  ) {
+    super(message);
+    this.name = 'KpiCsvBatchError';
+  }
+}
+
+export interface ParsedKpiCsvRow {
+  /** 1-based data row number, excluding the header. */
+  row: number;
+  request: KpiObservationCreateRequest;
+}
+
+export interface ParsedKpiCsv {
+  accepted: ParsedKpiCsvRow[];
+  rejected: KpiCsvRowRejection[];
+}
+
+/**
+ * Accepts the shapes a spreadsheet actually produces -- thousands separators, a
+ * leading currency symbol, a parenthesised negative -- and rejects everything
+ * else rather than guessing. More than six decimal places is a rejection, not a
+ * silent truncation of someone's money.
+ */
+function toFixedDecimalCell(raw: string): string | null {
+  let text = raw.trim().replace(/[\s,$]/g, '');
+  if (text === '') return null;
+
+  let negative = false;
+  if (/^\(.*\)$/.test(text)) {
+    negative = true;
+    text = text.slice(1, -1);
+  }
+  if (text.startsWith('-')) {
+    negative = !negative;
+    text = text.slice(1);
+  }
+  if (text.endsWith('%')) return null;
+  if (!/^\d+(?:\.\d+)?$/.test(text)) return null;
+
+  const [whole = '0', fraction = ''] = text.split('.');
+  if (fraction.length > NUMERIC_SCALE) return null;
+  const normalizedWhole = whole.replace(/^0+(?=\d)/, '');
+  return `${negative && /[1-9]/.test(text) ? '-' : ''}${normalizedWhole}.${fraction.padEnd(NUMERIC_SCALE, '0')}`;
+}
+
+function toValue(metric: KpiMetric, raw: string): KpiObservationValue | null {
+  const kind = KPI_METRIC_VALUE_KIND[metric];
+  if (kind === 'money' || kind === 'number') {
+    const decimal = toFixedDecimalCell(raw);
+    if (decimal === null) return null;
+    return kind === 'money'
+      ? { valueKind: 'money', amountUsd: decimal }
+      : { valueKind: 'number', number: decimal };
+  }
+  if (kind === 'date') {
+    const text = raw.trim();
+    return /^\d{4}-\d{2}-\d{2}$/.test(text) ? { valueKind: 'date', date: text } : null;
+  }
+  const text = raw.trim();
+  return text === '' ? null : { valueKind: 'text', text };
+}
+
+/** A date-only submission cell means midnight UTC, not "whenever we imported it". */
+function toSubmittedAt(raw: string): string | null {
+  const text = raw.trim();
+  if (/^\d{4}-\d{2}-\d{2}$/.test(text)) return `${text}T00:00:00.000Z`;
+  const parsed = new Date(text);
+  return text !== '' && !Number.isNaN(parsed.getTime()) ? parsed.toISOString() : null;
+}
+
+function optional(raw: string | undefined): string | null {
+  const text = (raw ?? '').trim();
+  return text === '' ? null : text;
+}
+
+export function parseKpiObservationCsv(buffer: Buffer): ParsedKpiCsv {
+  if (hasEmbeddedQuotedNewline(buffer)) {
+    throw new KpiCsvBatchError(
+      'EMBEDDED_LINE_BREAK_UNSUPPORTED',
+      'A quoted field spans a newline; not supported.'
+    );
+  }
+
+  const { header, rows } = parseCsvBufferRaw(buffer);
+  if (rows.length > KPI_CSV_MAX_ROWS) {
+    throw new KpiCsvBatchError(
+      'ROW_LIMIT_EXCEEDED',
+      `Row count ${rows.length} exceeds the limit of ${KPI_CSV_MAX_ROWS}.`
+    );
+  }
+
+  const expected = new Set<string>(KPI_CSV_TEMPLATE_HEADER);
+  const columnIndex = new Map<string, number>();
+  for (const [index, token] of header.entries()) {
+    const normalized = normalizeHeaderToken(token);
+    if (columnIndex.has(normalized)) {
+      throw new KpiCsvBatchError('DUPLICATE_HEADER', `Duplicate column "${normalized}".`);
+    }
+    columnIndex.set(normalized, index);
+  }
+  const missing = [...expected].filter((column) => !columnIndex.has(column));
+  const extra = [...columnIndex.keys()].filter((column) => !expected.has(column));
+  if (missing.length > 0 || extra.length > 0) {
+    throw new KpiCsvBatchError(
+      'TEMPLATE_HEADER_MISMATCH',
+      `The KPI import template header is fixed. Missing [${missing.join(', ')}], unexpected [${extra.join(', ')}].`
+    );
+  }
+
+  const accepted: ParsedKpiCsvRow[] = [];
+  const rejected: KpiCsvRowRejection[] = [];
+
+  for (const [index, cells] of rows.entries()) {
+    const rowNumber = index + 1;
+    const cell = (column: string): string => cells[columnIndex.get(column) as number] ?? '';
+
+    const companyIdText = cell('portfolio_company_id').trim();
+    if (!/^[1-9]\d*$/.test(companyIdText)) {
+      rejected.push({
+        row: rowNumber,
+        code: 'INVALID_PORTFOLIO_COMPANY_ID',
+        message: 'portfolio_company_id must be a positive integer.',
+      });
+      continue;
+    }
+
+    const metricText = cell('metric').trim() as KpiMetric;
+    if (!(metricText in KPI_METRIC_VALUE_KIND)) {
+      rejected.push({
+        row: rowNumber,
+        code: 'UNKNOWN_METRIC',
+        message: `Metric "${metricText}" is not in the fixed v1 metric set.`,
+      });
+      continue;
+    }
+
+    const value = toValue(metricText, cell('value'));
+    if (value === null) {
+      rejected.push({
+        row: rowNumber,
+        code: 'INVALID_VALUE',
+        message: `Value "${cell('value').trim()}" is not a valid ${KPI_METRIC_VALUE_KIND[metricText]} for metric "${metricText}".`,
+      });
+      continue;
+    }
+
+    const submittedAt = toSubmittedAt(cell('submitted_at'));
+    if (submittedAt === null) {
+      rejected.push({
+        row: rowNumber,
+        code: 'INVALID_SUBMITTED_AT',
+        message: 'submitted_at must be a YYYY-MM-DD date or an ISO timestamp.',
+      });
+      continue;
+    }
+
+    const candidate = {
+      portfolioCompanyId: Number.parseInt(companyIdText, 10),
+      metric: metricText,
+      periodStart: cell('period_start').trim(),
+      periodEnd: cell('period_end').trim(),
+      basis: cell('basis').trim(),
+      value,
+      companyKpiLabel: optional(cell('company_kpi_label')),
+      sourceLabel: optional(cell('source_label')),
+      comment: optional(cell('comment')),
+      submittedAt,
+    };
+
+    const parsed = KpiObservationCreateRequestSchema.safeParse(candidate);
+    if (!parsed.success) {
+      rejected.push({
+        row: rowNumber,
+        code: 'INVALID_ROW',
+        message: parsed.error.issues.map((issue) => issue.message).join(' '),
+      });
+      continue;
+    }
+
+    accepted.push({ row: rowNumber, request: parsed.data });
+  }
+
+  return { accepted, rejected };
+}

--- a/server/services/kpi/kpi-observation-service.ts
+++ b/server/services/kpi/kpi-observation-service.ts
@@ -1,0 +1,390 @@
+/**
+ * Internal KPI collection service (issue #1300, ruling GR2-4a).
+ *
+ * Creation is idempotent through the shared idempotent-command primitive, and
+ * review is an optimistic-locking update keyed on the row version that backs the
+ * ETag. There is deliberately no delete, no approval hierarchy, no recipient, and
+ * no export path on this surface.
+ *
+ * @module server/services/kpi/kpi-observation-service
+ */
+
+import { and, asc, eq, gte, lte, type SQL } from 'drizzle-orm';
+
+import {
+  KPI_METRIC_VALUE_KIND,
+  KPI_OBSERVATION_CONTRACT_VERSION,
+  KpiObservationV1Schema,
+  metricShapeIssues,
+  type KpiBasis,
+  type KpiMetric,
+  type KpiObservationCreateRequest,
+  type KpiObservationListQuery,
+  type KpiObservationV1,
+  type KpiObservationValue,
+  type KpiReviewDecision,
+  type KpiSource,
+} from '@shared/contracts/kpi/kpi-observation-v1.contract';
+import { kpiObservations, type KpiObservationRow } from '@shared/schema/kpi-observations';
+
+import { db } from '../../db';
+import {
+  FundScopeError,
+  assertOwnedByFund,
+  type FundScopedOwnershipDatabase,
+} from '../../lib/fund-scoped-ownership';
+import { runIdempotentCommand } from '../../lib/idempotent-command';
+
+type KpiDatabase = typeof db;
+
+/** Money and non-money numerics alike cross the wire at six decimal places. */
+const NUMERIC_SCALE = 6;
+
+export class KpiObservationServiceError extends Error {
+  readonly status: number;
+
+  constructor(
+    readonly statusCode: number,
+    readonly code: string,
+    message: string,
+    readonly details?: Readonly<Record<string, unknown>>
+  ) {
+    super(message);
+    this.name = 'KpiObservationServiceError';
+    this.status = statusCode;
+  }
+}
+
+/**
+ * Postgres renders numeric(20,6) with its full scale, but a hand-written row or a
+ * future scale change must not leak a short string past the contract boundary.
+ */
+function toFixedScale(raw: string): string {
+  const negative = raw.startsWith('-');
+  const magnitude = negative ? raw.slice(1) : raw;
+  const [whole = '0', fraction = ''] = magnitude.split('.');
+  const padded = fraction.padEnd(NUMERIC_SCALE, '0').slice(0, NUMERIC_SCALE);
+  return `${negative ? '-' : ''}${whole}.${padded}`;
+}
+
+function valueOfRow(row: KpiObservationRow): KpiObservationValue {
+  if (row.valueKind === 'money' && row.valueAmount !== null) {
+    return { valueKind: 'money', amountUsd: toFixedScale(row.valueAmount) };
+  }
+  if (row.valueKind === 'number' && row.valueAmount !== null) {
+    return { valueKind: 'number', number: toFixedScale(row.valueAmount) };
+  }
+  if (row.valueKind === 'date' && row.valueDate !== null) {
+    return { valueKind: 'date', date: row.valueDate };
+  }
+  if (row.valueKind === 'text' && row.valueText !== null) {
+    return { valueKind: 'text', text: row.valueText };
+  }
+  throw new KpiObservationServiceError(
+    500,
+    'KPI_OBSERVATION_CORRUPT',
+    'Stored KPI observation value is inconsistent with its value kind.'
+  );
+}
+
+/** Whitelist map then strict-schema validate, so no internal column can leak. */
+export function toKpiObservationContract(row: KpiObservationRow): KpiObservationV1 {
+  return KpiObservationV1Schema.parse({
+    contractVersion: KPI_OBSERVATION_CONTRACT_VERSION,
+    observationId: row.id,
+    fundId: row.fundId,
+    portfolioCompanyId: row.portfolioCompanyId,
+    metric: row.metric,
+    periodStart: row.periodStart,
+    periodEnd: row.periodEnd,
+    basis: row.basis,
+    value: valueOfRow(row),
+    companyKpiLabel: row.companyKpiLabel,
+    source: row.source,
+    sourceLabel: row.sourceLabel,
+    comment: row.comment,
+    submittedAt: row.submittedAt.toISOString(),
+    reviewStatus: row.reviewStatus,
+    reviewComment: row.reviewComment,
+    reviewedAt: row.reviewedAt === null ? null : row.reviewedAt.toISOString(),
+    version: row.version,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  });
+}
+
+export interface KpiObservationCommandPreimage extends Record<string, unknown> {
+  commandKind: 'create_kpi_observation';
+  contractVersion: typeof KPI_OBSERVATION_CONTRACT_VERSION;
+  fundId: number;
+  portfolioCompanyId: number;
+  metric: KpiMetric;
+  periodStart: string;
+  periodEnd: string;
+  basis: KpiBasis;
+  value: KpiObservationValue;
+  companyKpiLabel: string | null;
+  source: KpiSource;
+  sourceLabel: string | null;
+  comment: string | null;
+  submittedAt: string;
+}
+
+export interface CreateKpiObservationInput {
+  fundId: number;
+  request: KpiObservationCreateRequest;
+  source: KpiSource;
+  actorId: number | null;
+  idempotencyKey: string;
+}
+
+export interface CreateKpiObservationResult {
+  observation: KpiObservationV1;
+  replayed: boolean;
+}
+
+export interface ReviewKpiObservationInput {
+  fundId: number;
+  observationId: number;
+  expectedVersion: number;
+  reviewStatus: KpiReviewDecision;
+  reviewComment: string | null;
+  actorId: number | null;
+}
+
+export interface KpiObservationPorts {
+  assertCompanyOwned(fundId: number, portfolioCompanyId: number): Promise<void>;
+  createIdempotent(input: {
+    fundId: number;
+    request: KpiObservationCreateRequest;
+    source: KpiSource;
+    actorId: number | null;
+    idempotencyKey: string;
+    preimage: KpiObservationCommandPreimage;
+  }): Promise<{ row: KpiObservationRow; replayed: boolean }>;
+}
+
+function preimageOf(input: CreateKpiObservationInput): KpiObservationCommandPreimage {
+  return {
+    commandKind: 'create_kpi_observation',
+    contractVersion: KPI_OBSERVATION_CONTRACT_VERSION,
+    fundId: input.fundId,
+    portfolioCompanyId: input.request.portfolioCompanyId,
+    metric: input.request.metric,
+    periodStart: input.request.periodStart,
+    periodEnd: input.request.periodEnd,
+    basis: input.request.basis,
+    value: input.request.value,
+    companyKpiLabel: input.request.companyKpiLabel ?? null,
+    source: input.source,
+    sourceLabel: input.request.sourceLabel ?? null,
+    comment: input.request.comment ?? null,
+    submittedAt: input.request.submittedAt,
+  };
+}
+
+/**
+ * The Zod request schema already enforces these three rules, but CSV rows and
+ * future callers reach the service through more than one path, so the invariant
+ * is re-asserted here rather than assumed.
+ */
+function assertRequestShape(request: KpiObservationCreateRequest): void {
+  const issues = metricShapeIssues({
+    metric: request.metric,
+    value: request.value,
+    companyKpiLabel: request.companyKpiLabel,
+  });
+  if (issues.length > 0) {
+    throw new KpiObservationServiceError(400, 'INVALID_KPI_OBSERVATION_SHAPE', issues.join(' '), {
+      issues,
+    });
+  }
+}
+
+export async function createKpiObservationWithPorts(
+  ports: KpiObservationPorts,
+  input: CreateKpiObservationInput
+): Promise<CreateKpiObservationResult> {
+  assertRequestShape(input.request);
+  await ports.assertCompanyOwned(input.fundId, input.request.portfolioCompanyId);
+
+  const result = await ports.createIdempotent({ ...input, preimage: preimageOf(input) });
+  return { observation: toKpiObservationContract(result.row), replayed: result.replayed };
+}
+
+function insertValuesFor(input: CreateKpiObservationInput) {
+  const { request } = input;
+  const value = request.value;
+  return {
+    fundId: input.fundId,
+    portfolioCompanyId: request.portfolioCompanyId,
+    metric: request.metric,
+    periodStart: request.periodStart,
+    periodEnd: request.periodEnd,
+    basis: request.basis,
+    valueKind: KPI_METRIC_VALUE_KIND[request.metric],
+    valueAmount:
+      value.valueKind === 'money'
+        ? value.amountUsd
+        : value.valueKind === 'number'
+          ? value.number
+          : null,
+    valueDate: value.valueKind === 'date' ? value.date : null,
+    valueText: value.valueKind === 'text' ? value.text : null,
+    companyKpiLabel: request.companyKpiLabel ?? null,
+    source: input.source,
+    sourceLabel: request.sourceLabel ?? null,
+    comment: request.comment ?? null,
+    submittedAt: new Date(request.submittedAt),
+    createdBy: input.actorId,
+  };
+}
+
+export function createKpiObservationPorts(database: KpiDatabase): KpiObservationPorts {
+  return {
+    async assertCompanyOwned(fundId, portfolioCompanyId) {
+      try {
+        await assertOwnedByFund({
+          db: database as unknown as FundScopedOwnershipDatabase,
+          fundId,
+          ref: { kind: 'portfolio_company', id: portfolioCompanyId },
+        });
+      } catch (error) {
+        if (error instanceof FundScopeError) {
+          throw new KpiObservationServiceError(
+            404,
+            'PORTFOLIO_COMPANY_NOT_FOUND',
+            'Portfolio company not found in this fund.'
+          );
+        }
+        throw error;
+      }
+    },
+
+    async createIdempotent(input) {
+      const loadExisting = async () => {
+        const [existing] = await database
+          .select()
+          .from(kpiObservations)
+          .where(
+            and(
+              eq(kpiObservations.fundId, input.fundId),
+              eq(kpiObservations.idempotencyKey, input.idempotencyKey)
+            )
+          )
+          .limit(1);
+        return existing ? { row: existing, requestHash: existing.requestHash } : null;
+      };
+
+      return runIdempotentCommand<KpiObservationRow>({
+        db: database,
+        fundId: input.fundId,
+        idempotencyKey: input.idempotencyKey,
+        contractVersion: KPI_OBSERVATION_CONTRACT_VERSION,
+        request: input.preimage,
+        loadExisting,
+        insert: async (requestHash) => {
+          const [inserted] = await database
+            .insert(kpiObservations)
+            .values({
+              ...insertValuesFor(input),
+              idempotencyKey: input.idempotencyKey,
+              requestHash,
+            })
+            .onConflictDoNothing({
+              target: [kpiObservations.fundId, kpiObservations.idempotencyKey],
+            })
+            .returning();
+          return inserted ?? null;
+        },
+      });
+    },
+  };
+}
+
+export async function createKpiObservation(
+  input: CreateKpiObservationInput,
+  options: { database?: KpiDatabase } = {}
+): Promise<CreateKpiObservationResult> {
+  const database = options.database ?? db;
+  return database.transaction(async (transaction) =>
+    createKpiObservationWithPorts(
+      createKpiObservationPorts(transaction as unknown as KpiDatabase),
+      input
+    )
+  );
+}
+
+export async function listKpiObservations(
+  fundId: number,
+  query: KpiObservationListQuery,
+  options: { database?: KpiDatabase } = {}
+): Promise<KpiObservationV1[]> {
+  const database = options.database ?? db;
+  const filters: SQL[] = [eq(kpiObservations.fundId, fundId)];
+  if (query.portfolioCompanyId !== undefined) {
+    filters.push(eq(kpiObservations.portfolioCompanyId, query.portfolioCompanyId));
+  }
+  if (query.metric !== undefined) filters.push(eq(kpiObservations.metric, query.metric));
+  if (query.basis !== undefined) filters.push(eq(kpiObservations.basis, query.basis));
+  if (query.reviewStatus !== undefined) {
+    filters.push(eq(kpiObservations.reviewStatus, query.reviewStatus));
+  }
+  if (query.periodFrom !== undefined) {
+    filters.push(gte(kpiObservations.periodStart, query.periodFrom));
+  }
+  if (query.periodTo !== undefined) filters.push(lte(kpiObservations.periodEnd, query.periodTo));
+
+  const rows = await database
+    .select()
+    .from(kpiObservations)
+    .where(and(...filters))
+    .orderBy(asc(kpiObservations.periodStart), asc(kpiObservations.id))
+    .limit(500);
+  return rows.map(toKpiObservationContract);
+}
+
+export async function loadKpiObservation(
+  fundId: number,
+  observationId: number,
+  options: { database?: KpiDatabase } = {}
+): Promise<KpiObservationRow | null> {
+  const database = options.database ?? db;
+  const [row] = await database
+    .select()
+    .from(kpiObservations)
+    .where(and(eq(kpiObservations.fundId, fundId), eq(kpiObservations.id, observationId)))
+    .limit(1);
+  return row ?? null;
+}
+
+/**
+ * Compare-and-set on the row version. A zero-row result means another reviewer
+ * moved first; the route re-reads to tell 412 (modified) from 404 (gone).
+ */
+export async function reviewKpiObservation(
+  input: ReviewKpiObservationInput,
+  options: { database?: KpiDatabase } = {}
+): Promise<KpiObservationRow | null> {
+  const database = options.database ?? db;
+  const now = new Date();
+  const [updated] = await database
+    .update(kpiObservations)
+    .set({
+      reviewStatus: input.reviewStatus,
+      reviewComment: input.reviewComment,
+      reviewedBy: input.actorId,
+      reviewedAt: now,
+      version: input.expectedVersion + 1,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(kpiObservations.fundId, input.fundId),
+        eq(kpiObservations.id, input.observationId),
+        eq(kpiObservations.version, input.expectedVersion)
+      )
+    )
+    .returning();
+  return updated ?? null;
+}

--- a/shared/contracts/kpi/kpi-observation-v1.contract.ts
+++ b/shared/contracts/kpi/kpi-observation-v1.contract.ts
@@ -1,0 +1,312 @@
+/**
+ * KPI OBSERVATION CONTRACT v1 (issue #1300, ruling GR2-4a).
+ *
+ * One KPI observation is one measured or projected value, for one portfolio
+ * company, for one metric, over one period. The metric set is the managing
+ * partner's fixed v1 list and is deliberately closed: a new metric is a contract
+ * version, not a free-text row.
+ *
+ * This surface is INTERNAL-ONLY and CSV-first. There is deliberately no
+ * company-facing request form, no recipient, no send, and no export endpoint in
+ * v1, and `tests/unit/source/kpi-observation-boundary.test.ts` keeps it that way.
+ *
+ * Money crosses the wire as a fixed 6-decimal-place string (never a float), the
+ * same boundary the economics and current-plan contracts use.
+ *
+ * @module shared/contracts/kpi/kpi-observation-v1.contract
+ */
+
+import { z } from 'zod';
+
+import { MoneyDecimalStringSchema } from '../../lib/decimal-string';
+
+export const KPI_OBSERVATION_CONTRACT_VERSION = 'kpi-observation/1.0.0' as const;
+
+/**
+ * The fixed v1 metric set: revenue/ARR, cash balance, monthly burn, runway,
+ * headcount, next financing target and date, one company-specific KPI, and a
+ * qualitative update.
+ */
+export const KPI_METRICS = [
+  'revenue_arr',
+  'cash_balance',
+  'monthly_burn',
+  'runway_months',
+  'headcount',
+  'next_financing_target',
+  'next_financing_date',
+  'company_specific',
+  'qualitative_update',
+] as const;
+
+export const KpiMetricSchema = z.enum(KPI_METRICS);
+export type KpiMetric = z.infer<typeof KpiMetricSchema>;
+
+export const KPI_VALUE_KINDS = ['money', 'number', 'date', 'text'] as const;
+export const KpiValueKindSchema = z.enum(KPI_VALUE_KINDS);
+export type KpiValueKind = z.infer<typeof KpiValueKindSchema>;
+
+/**
+ * Metric -> value kind is fixed, not caller-chosen. The database mirrors this map
+ * as a CHECK constraint, so a drifting client cannot store a text runway.
+ */
+export const KPI_METRIC_VALUE_KIND: Readonly<Record<KpiMetric, KpiValueKind>> = {
+  revenue_arr: 'money',
+  cash_balance: 'money',
+  monthly_burn: 'money',
+  runway_months: 'number',
+  headcount: 'number',
+  next_financing_target: 'money',
+  next_financing_date: 'date',
+  company_specific: 'number',
+  qualitative_update: 'text',
+};
+
+/** Metrics whose value is a magnitude and can never be negative. */
+export const KPI_NON_NEGATIVE_METRICS: ReadonlySet<KpiMetric> = new Set<KpiMetric>([
+  'revenue_arr',
+  'cash_balance',
+  'monthly_burn',
+  'runway_months',
+  'headcount',
+  'next_financing_target',
+]);
+
+export const KPI_BASES = ['actual', 'projected'] as const;
+export const KpiBasisSchema = z.enum(KPI_BASES);
+export type KpiBasis = z.infer<typeof KpiBasisSchema>;
+
+/** How the row entered the system. Set by the server, never by the caller. */
+export const KPI_SOURCES = ['manual', 'csv_import'] as const;
+export const KpiSourceSchema = z.enum(KPI_SOURCES);
+export type KpiSource = z.infer<typeof KpiSourceSchema>;
+
+export const KPI_REVIEW_STATUSES = ['pending', 'accepted', 'rejected'] as const;
+export const KpiReviewStatusSchema = z.enum(KPI_REVIEW_STATUSES);
+export type KpiReviewStatus = z.infer<typeof KpiReviewStatusSchema>;
+
+const PositiveIntSchema = z.number().int().positive();
+const IsoDateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Expected a YYYY-MM-DD date.');
+
+/**
+ * Non-money numerics (runway months, headcount, the company-specific KPI) use the
+ * same fixed 6-decimal-place string boundary as money so no KPI value is ever a
+ * float on the wire.
+ */
+export const KpiNumberDecimalStringSchema = z
+  .string()
+  .regex(/^-?(?:0|[1-9]\d*)\.\d{6}$/, 'Expected a fixed 6-decimal-place numeric string.');
+
+export const KpiObservationValueSchema = z.discriminatedUnion('valueKind', [
+  z.object({ valueKind: z.literal('money'), amountUsd: MoneyDecimalStringSchema }).strict(),
+  z.object({ valueKind: z.literal('number'), number: KpiNumberDecimalStringSchema }).strict(),
+  z.object({ valueKind: z.literal('date'), date: IsoDateSchema }).strict(),
+  z.object({ valueKind: z.literal('text'), text: z.string().min(1).max(4000) }).strict(),
+]);
+export type KpiObservationValue = z.infer<typeof KpiObservationValueSchema>;
+
+/** The decimal string carried by a money or number value, or null for the rest. */
+export function numericStringOfValue(value: KpiObservationValue): string | null {
+  if (value.valueKind === 'money') return value.amountUsd;
+  if (value.valueKind === 'number') return value.number;
+  return null;
+}
+
+interface MetricShapeIssueContext {
+  metric: KpiMetric;
+  value: KpiObservationValue;
+  companyKpiLabel: string | null | undefined;
+}
+
+/**
+ * The three cross-field rules every request and every stored row must satisfy:
+ * the value kind matches the metric, magnitude metrics are non-negative, and the
+ * company-specific KPI carries exactly the label that names it.
+ */
+export function metricShapeIssues(context: MetricShapeIssueContext): string[] {
+  const issues: string[] = [];
+  const expectedKind = KPI_METRIC_VALUE_KIND[context.metric];
+  if (context.value.valueKind !== expectedKind) {
+    issues.push(`Metric "${context.metric}" requires a "${expectedKind}" value.`);
+    return issues;
+  }
+
+  const numeric = numericStringOfValue(context.value);
+  if (numeric !== null && numeric.startsWith('-') && KPI_NON_NEGATIVE_METRICS.has(context.metric)) {
+    issues.push(`Metric "${context.metric}" cannot be negative.`);
+  }
+
+  const hasLabel = context.companyKpiLabel !== null && context.companyKpiLabel !== undefined;
+  if (context.metric === 'company_specific' && !hasLabel) {
+    issues.push('Metric "company_specific" requires companyKpiLabel.');
+  }
+  if (context.metric !== 'company_specific' && hasLabel) {
+    issues.push('companyKpiLabel is only valid for metric "company_specific".');
+  }
+
+  return issues;
+}
+
+const ObservationCoreShape = {
+  portfolioCompanyId: PositiveIntSchema,
+  metric: KpiMetricSchema,
+  periodStart: IsoDateSchema,
+  periodEnd: IsoDateSchema,
+  basis: KpiBasisSchema,
+  value: KpiObservationValueSchema,
+  /** Names the metric when it is the one company-specific KPI; null otherwise. */
+  companyKpiLabel: z.string().min(1).max(120).nullable().optional(),
+  /** Free-text provenance, e.g. "AlphaTech June board deck". */
+  sourceLabel: z.string().min(1).max(200).nullable().optional(),
+  /** The submitter's note about this value. */
+  comment: z.string().min(1).max(4000).nullable().optional(),
+  /** When the company reported it, which is not when we recorded it. */
+  submittedAt: z.string().datetime(),
+};
+
+function refineObservationShape(
+  data: {
+    metric: KpiMetric;
+    value: KpiObservationValue;
+    companyKpiLabel?: string | null | undefined;
+    periodStart: string;
+    periodEnd: string;
+  },
+  ctx: z.RefinementCtx
+): void {
+  for (const message of metricShapeIssues({
+    metric: data.metric,
+    value: data.value,
+    companyKpiLabel: data.companyKpiLabel,
+  })) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message });
+  }
+  if (data.periodEnd < data.periodStart) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['periodEnd'],
+      message: 'periodEnd must not precede periodStart.',
+    });
+  }
+}
+
+export const KpiObservationCreateRequestSchema = z
+  .object(ObservationCoreShape)
+  .strict()
+  .superRefine(refineObservationShape);
+export type KpiObservationCreateRequest = z.infer<typeof KpiObservationCreateRequestSchema>;
+
+/**
+ * A review decides; it never un-decides. Returning a row to `pending` would
+ * erase who reviewed it and when, so the request set is the two terminal
+ * outcomes only.
+ */
+export const KpiReviewDecisionSchema = z.enum(['accepted', 'rejected']);
+export type KpiReviewDecision = z.infer<typeof KpiReviewDecisionSchema>;
+
+export const KpiObservationReviewRequestSchema = z
+  .object({
+    reviewStatus: KpiReviewDecisionSchema,
+    reviewComment: z.string().min(1).max(4000).nullable().optional(),
+  })
+  .strict();
+export type KpiObservationReviewRequest = z.infer<typeof KpiObservationReviewRequestSchema>;
+
+export const KpiObservationListQuerySchema = z
+  .object({
+    portfolioCompanyId: z.coerce.number().int().positive().optional(),
+    metric: KpiMetricSchema.optional(),
+    basis: KpiBasisSchema.optional(),
+    reviewStatus: KpiReviewStatusSchema.optional(),
+    /** Inclusive lower bound on periodStart. */
+    periodFrom: IsoDateSchema.optional(),
+    /** Inclusive upper bound on periodEnd. */
+    periodTo: IsoDateSchema.optional(),
+  })
+  .strict();
+export type KpiObservationListQuery = z.infer<typeof KpiObservationListQuerySchema>;
+
+export const KpiObservationV1Schema = z
+  .object({
+    contractVersion: z.literal(KPI_OBSERVATION_CONTRACT_VERSION),
+    observationId: PositiveIntSchema,
+    fundId: PositiveIntSchema,
+    portfolioCompanyId: PositiveIntSchema,
+    metric: KpiMetricSchema,
+    periodStart: IsoDateSchema,
+    periodEnd: IsoDateSchema,
+    basis: KpiBasisSchema,
+    value: KpiObservationValueSchema,
+    companyKpiLabel: z.string().min(1).max(120).nullable(),
+    source: KpiSourceSchema,
+    sourceLabel: z.string().min(1).max(200).nullable(),
+    comment: z.string().min(1).max(4000).nullable(),
+    submittedAt: z.string().datetime(),
+    reviewStatus: KpiReviewStatusSchema,
+    reviewComment: z.string().min(1).max(4000).nullable(),
+    reviewedAt: z.string().datetime().nullable(),
+    /** Monotonic row version; it backs the ETag a review must echo in If-Match. */
+    version: PositiveIntSchema,
+    createdAt: z.string().datetime(),
+    updatedAt: z.string().datetime(),
+  })
+  .strict()
+  .superRefine(refineObservationShape);
+export type KpiObservationV1 = z.infer<typeof KpiObservationV1Schema>;
+
+export const KpiObservationListResponseSchema = z
+  .object({ data: z.array(KpiObservationV1Schema) })
+  .strict();
+export type KpiObservationListResponse = z.infer<typeof KpiObservationListResponseSchema>;
+
+/** One rejected CSV row. Accepted rows come back as full observations. */
+export const KpiCsvRowRejectionSchema = z
+  .object({ row: PositiveIntSchema, code: z.string().min(1), message: z.string().min(1) })
+  .strict();
+export type KpiCsvRowRejection = z.infer<typeof KpiCsvRowRejectionSchema>;
+
+/**
+ * CSV content rides as base64 inside JSON, the same transport the LP reporting
+ * import lane uses, so one body shape carries both the file and its metadata.
+ */
+export const KpiObservationImportRequestSchema = z
+  .object({
+    csvBase64: z.string().min(1),
+    /** Applied to every row that does not carry its own source_label. */
+    sourceLabel: z.string().min(1).max(200).nullable().optional(),
+  })
+  .strict();
+export type KpiObservationImportRequest = z.infer<typeof KpiObservationImportRequestSchema>;
+
+export const KpiObservationImportResponseSchema = z
+  .object({
+    imported: z.array(KpiObservationV1Schema),
+    rejected: z.array(KpiCsvRowRejectionSchema),
+    replayed: z.boolean(),
+  })
+  .strict();
+export type KpiObservationImportResponse = z.infer<typeof KpiObservationImportResponseSchema>;
+
+/**
+ * The fixed v1 import template. The header is exact and ordered; there is no
+ * mapping profile and no caller-supplied column mapping in v1.
+ */
+export const KPI_CSV_TEMPLATE_HEADER = [
+  'portfolio_company_id',
+  'metric',
+  'period_start',
+  'period_end',
+  'basis',
+  'value',
+  'company_kpi_label',
+  'source_label',
+  'comment',
+  'submitted_at',
+] as const;
+
+/**
+ * Deliberately tighter than the financial-observations lane's 5000: each KPI row
+ * lands through its own idempotent command so partial batches stay recoverable,
+ * and one quarterly collection for a 4-person team is tens of rows, not thousands.
+ */
+export const KPI_CSV_MAX_ROWS = 1000;

--- a/shared/routes/api-route-manifest.ts
+++ b/shared/routes/api-route-manifest.ts
@@ -651,6 +651,25 @@ export const COMMON_API_ROUTE_MANIFEST = [
     },
   },
   {
+    id: 'kpi-observations',
+    sourceModule: './routes/kpi-observations.js',
+    // The router declares full `/api/...` paths (operating-object-tasks style),
+    // so it mounts bare.
+    mountPath: null,
+    authBoundary: 'global_authenticated',
+    fundScope: 'path',
+    financial: true,
+    migrationParity: { kind: 'c1', tables: ['kpi_observations'] },
+    schemaTables: ['kpi_observations', 'portfoliocompanies', 'funds', 'users'],
+    owner: 'gp-team',
+    probe: {
+      method: 'GET',
+      path: '/api/funds/abc/kpi-observations',
+      expectedStatus: 400,
+      authenticated: true,
+    },
+  },
+  {
     id: 'deal-pipeline',
     sourceModule: './routes/deal-pipeline.js',
     mountPath: '/api/deals',

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -55,6 +55,7 @@ export * from './schema/investment-positions';
 export * from './schema/vehicle-financing-participations';
 export * from './schema/internal-analysis';
 export * from './schema/internal-economics';
+export * from './schema/kpi-observations';
 export * from './schemas/flags';
 export * from './schemas/reserve-approvals';
 

--- a/shared/schema/index.ts
+++ b/shared/schema/index.ts
@@ -27,6 +27,7 @@ export * from './investment-round-model-overrides';
 export * from './current-plans';
 export * from './current-forecast-references';
 export * from './financial-observations';
+export * from './kpi-observations';
 export * from './investment-ledger';
 export * from './investment-positions';
 export * from './vehicle-financing-participations';

--- a/shared/schema/kpi-observations.ts
+++ b/shared/schema/kpi-observations.ts
@@ -1,0 +1,199 @@
+import { sql } from 'drizzle-orm';
+import {
+  check,
+  date,
+  foreignKey,
+  index,
+  integer,
+  numeric,
+  pgTable,
+  serial,
+  text,
+  timestamp,
+  unique,
+  varchar,
+} from 'drizzle-orm/pg-core';
+
+import type {
+  KpiBasis,
+  KpiMetric,
+  KpiReviewStatus,
+  KpiSource,
+  KpiValueKind,
+} from '../contracts/kpi/kpi-observation-v1.contract';
+import { funds } from './fund';
+import { portfolioCompanies } from './portfolio';
+import { users } from './user';
+
+/**
+ * Internal KPI collection (issue #1300, ruling GR2-4a).
+ *
+ * One row is one metric, for one company, over one period. Every field the
+ * ruling requires is a dedicated column -- metric, period, actual/projected
+ * basis, value, source, submission date, reviewer status, comment -- and nothing
+ * is nested into a JSONB blob.
+ *
+ * The typed value triple (`value_amount`, `value_date`, `value_text`) plus the
+ * metric/value-kind CHECK pair makes a wrong-typed KPI unrepresentable rather
+ * than merely rejected at the edge: a text runway or a money headcount cannot be
+ * stored even by a direct SQL write.
+ *
+ * Fund scoping follows the Wave C/D ledger convention: `fund_id` cascades from
+ * `funds`, a sibling `UNIQUE (id, fund_id)` is available for future composite
+ * child FKs (the quarterly review trail, #1301), and FK names are declared
+ * explicitly so migration 0049 and a Drizzle push produce byte-identical catalog
+ * constraint names. `portfoliocompanies` carries no `(id, fund_id)` sibling key
+ * and a nullable `fund_id`, so that FK is plain and same-fund ownership is
+ * enforced in code via `assertOwnedByFund({ kind: 'portfolio_company' })`.
+ */
+export const kpiObservations = pgTable(
+  'kpi_observations',
+  {
+    id: serial('id').primaryKey(),
+    fundId: integer('fund_id').notNull(),
+    portfolioCompanyId: integer('portfolio_company_id').notNull(),
+    metric: varchar('metric', { length: 32 }).notNull().$type<KpiMetric>(),
+    periodStart: date('period_start').notNull(),
+    periodEnd: date('period_end').notNull(),
+    basis: varchar('basis', { length: 16 }).notNull().$type<KpiBasis>(),
+    valueKind: varchar('value_kind', { length: 8 }).notNull().$type<KpiValueKind>(),
+    /** Money and non-money numerics alike; read and written as a decimal string. */
+    valueAmount: numeric('value_amount', { precision: 20, scale: 6 }),
+    valueDate: date('value_date'),
+    valueText: text('value_text'),
+    companyKpiLabel: varchar('company_kpi_label', { length: 120 }),
+    source: varchar('source', { length: 16 }).notNull().$type<KpiSource>(),
+    sourceLabel: varchar('source_label', { length: 200 }),
+    comment: text('comment'),
+    submittedAt: timestamp('submitted_at', { withTimezone: true }).notNull(),
+    reviewStatus: varchar('review_status', { length: 16 })
+      .notNull()
+      .default('pending')
+      .$type<KpiReviewStatus>(),
+    reviewComment: text('review_comment'),
+    reviewedBy: integer('reviewed_by'),
+    reviewedAt: timestamp('reviewed_at', { withTimezone: true }),
+    /** Monotonic; backs the ETag. A review bumps it. */
+    version: integer('version').notNull().default(1),
+    idempotencyKey: varchar('idempotency_key', { length: 128 }).notNull(),
+    requestHash: varchar('request_hash', { length: 64 }).notNull(),
+    createdBy: integer('created_by'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    fundFk: foreignKey({
+      columns: [table.fundId],
+      foreignColumns: [funds.id],
+      name: 'kpi_observations_fund_id_funds_id_fk',
+    }).onDelete('cascade'),
+    portfolioCompanyFk: foreignKey({
+      columns: [table.portfolioCompanyId],
+      foreignColumns: [portfolioCompanies.id],
+      name: 'kpi_observations_portfolio_company_id_fk',
+    }).onDelete('restrict'),
+    reviewedByFk: foreignKey({
+      columns: [table.reviewedBy],
+      foreignColumns: [users.id],
+      name: 'kpi_observations_reviewed_by_fk',
+    }),
+    createdByFk: foreignKey({
+      columns: [table.createdBy],
+      foreignColumns: [users.id],
+      name: 'kpi_observations_created_by_fk',
+    }),
+    idFundUnique: unique('kpi_observations_id_fund_unique').on(table.id, table.fundId),
+    fundIdempotencyUnique: unique('kpi_observations_fund_idempotency_unique').on(
+      table.fundId,
+      table.idempotencyKey
+    ),
+    metricCheck: check(
+      'kpi_observations_metric_check',
+      sql`${table.metric} IN (
+        'revenue_arr','cash_balance','monthly_burn','runway_months','headcount',
+        'next_financing_target','next_financing_date','company_specific','qualitative_update'
+      )`
+    ),
+    basisCheck: check(
+      'kpi_observations_basis_check',
+      sql`${table.basis} IN ('actual','projected')`
+    ),
+    sourceCheck: check(
+      'kpi_observations_source_check',
+      sql`${table.source} IN ('manual','csv_import')`
+    ),
+    reviewStatusCheck: check(
+      'kpi_observations_review_status_check',
+      sql`${table.reviewStatus} IN ('pending','accepted','rejected')`
+    ),
+    valueKindCheck: check(
+      'kpi_observations_value_kind_check',
+      sql`${table.valueKind} IN ('money','number','date','text')`
+    ),
+    /** Exactly one of the three value columns is populated, per value kind. */
+    valueCouplingCheck: check(
+      'kpi_observations_value_coupling_check',
+      sql`(
+        (${table.valueKind} IN ('money','number')
+          AND ${table.valueAmount} IS NOT NULL
+          AND ${table.valueDate} IS NULL
+          AND ${table.valueText} IS NULL)
+        OR (${table.valueKind} = 'date'
+          AND ${table.valueDate} IS NOT NULL
+          AND ${table.valueAmount} IS NULL
+          AND ${table.valueText} IS NULL)
+        OR (${table.valueKind} = 'text'
+          AND ${table.valueText} IS NOT NULL
+          AND ${table.valueAmount} IS NULL
+          AND ${table.valueDate} IS NULL)
+      )`
+    ),
+    /** The contract's metric -> value-kind map, enforced by the catalog. */
+    metricValueKindCheck: check(
+      'kpi_observations_metric_value_kind_check',
+      sql`${table.valueKind} = CASE ${table.metric}
+        WHEN 'revenue_arr' THEN 'money'
+        WHEN 'cash_balance' THEN 'money'
+        WHEN 'monthly_burn' THEN 'money'
+        WHEN 'next_financing_target' THEN 'money'
+        WHEN 'runway_months' THEN 'number'
+        WHEN 'headcount' THEN 'number'
+        WHEN 'company_specific' THEN 'number'
+        WHEN 'next_financing_date' THEN 'date'
+        WHEN 'qualitative_update' THEN 'text'
+      END`
+    ),
+    /** Magnitude metrics can never be negative. */
+    nonNegativeValueCheck: check(
+      'kpi_observations_non_negative_value_check',
+      sql`${table.metric} NOT IN (
+        'revenue_arr','cash_balance','monthly_burn','runway_months','headcount','next_financing_target'
+      ) OR ${table.valueAmount} >= 0`
+    ),
+    /** The company-specific KPI carries its label; nothing else may. */
+    companyKpiLabelCheck: check(
+      'kpi_observations_company_kpi_label_check',
+      sql`(${table.metric} = 'company_specific') = (${table.companyKpiLabel} IS NOT NULL)`
+    ),
+    periodOrderCheck: check(
+      'kpi_observations_period_order_check',
+      sql`${table.periodEnd} >= ${table.periodStart}`
+    ),
+    versionCheck: check('kpi_observations_version_check', sql`${table.version} >= 1`),
+    /** A reviewed row records who and when; a pending row records neither. */
+    reviewCouplingCheck: check(
+      'kpi_observations_review_coupling_check',
+      sql`(${table.reviewStatus} = 'pending')
+        = (${table.reviewedAt} IS NULL AND ${table.reviewComment} IS NULL)`
+    ),
+    fundCompanyPeriodIdx: index('idx_kpi_observations_fund_company_period').on(
+      table.fundId,
+      table.portfolioCompanyId,
+      table.periodStart,
+      table.id
+    ),
+  })
+);
+
+export type KpiObservationRow = typeof kpiObservations.$inferSelect;
+export type InsertKpiObservation = typeof kpiObservations.$inferInsert;

--- a/tests/fixtures/kpi-observation.ts
+++ b/tests/fixtures/kpi-observation.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared KPI observation fixture (issue #1300).
+ *
+ * Contract-shaped observation used by the route, service, and contract tests.
+ * `msw/handlers/kpis.ts` is unrelated: it fixtures the separate fund raw-facts
+ * read and is not used to back any product surface.
+ */
+import {
+  KPI_OBSERVATION_CONTRACT_VERSION,
+  type KpiObservationV1,
+} from '../../shared/contracts/kpi/kpi-observation-v1.contract';
+
+export const sampleKpiObservation: KpiObservationV1 = {
+  contractVersion: KPI_OBSERVATION_CONTRACT_VERSION,
+  observationId: 1,
+  fundId: 1,
+  portfolioCompanyId: 4,
+  metric: 'revenue_arr',
+  periodStart: '2026-04-01',
+  periodEnd: '2026-06-30',
+  basis: 'actual',
+  value: { valueKind: 'money', amountUsd: '2100000.000000' },
+  companyKpiLabel: null,
+  source: 'manual',
+  sourceLabel: 'Q2 board deck',
+  comment: null,
+  submittedAt: '2026-07-05T00:00:00.000Z',
+  reviewStatus: 'pending',
+  reviewComment: null,
+  reviewedAt: null,
+  version: 1,
+  createdAt: '2026-07-06T00:00:00.000Z',
+  updatedAt: '2026-07-06T00:00:00.000Z',
+};

--- a/tests/integration/kpi/kpi-observation-persistence.pg.test.ts
+++ b/tests/integration/kpi/kpi-observation-persistence.pg.test.ts
@@ -1,0 +1,326 @@
+/**
+ * Native PostgreSQL proof that an ACCEPTED KPI observation SURVIVES persistence.
+ *
+ * The unit suites around this feature all stub the store: the route tests mock
+ * `kpi-observation-service` wholesale, and the service test drives an in-memory
+ * `FakePorts` map. Both can only prove the handler serialized whatever it was
+ * handed. This file closes that gap: it writes through the real service against
+ * a real database, then RE-READS the row on a fresh connection and asserts the
+ * stored values -- including the six-decimal numeric and the version bump.
+ *
+ * Uses a uniquely named disposable database. TEST_DATABASE_URL is preferred;
+ * testcontainers remains the fallback used by existing PostgreSQL suites.
+ */
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import * as schema from '@shared/schema';
+import type { KpiObservationCreateRequest } from '../../../shared/contracts/kpi/kpi-observation-v1.contract';
+import {
+  createKpiObservation,
+  listKpiObservations,
+  loadKpiObservation,
+  reviewKpiObservation,
+  toKpiObservationContract,
+} from '../../../server/services/kpi/kpi-observation-service';
+
+import {
+  cleanupTestContainers,
+  getPostgresConnectionString,
+  setupTestContainers,
+} from '../../helpers/testcontainers';
+import { runMigrationsWithConnectionString } from '../../helpers/testcontainers-migration';
+
+/**
+ * The service types its injectable handle as `typeof db`, which it does not
+ * export. Recover it from a signature rather than restating it, so this proof
+ * cannot drift from the service it is proving.
+ */
+type KpiDatabase = NonNullable<Parameters<typeof loadKpiObservation>[2]>['database'];
+
+/** A real node-postgres drizzle handle, presented as the service's db type. */
+function kpiDb(pool: Pool): KpiDatabase {
+  return drizzle(pool, { schema }) as unknown as KpiDatabase;
+}
+
+const MIGRATION_TAG = '0049_kpi_observations';
+const PERIOD = { start: '2026-04-01', end: '2026-06-30' };
+const skipIfNoDocker =
+  !process.env.TEST_DATABASE_URL && !process.env.CI && process.platform === 'win32';
+
+let adminPool: Pool | undefined;
+let connectionString = '';
+let databaseName = '';
+let startedTestContainers = false;
+let labelCounter = 0;
+
+describe.skipIf(skipIfNoDocker)('KPI observation persistence PostgreSQL proof', () => {
+  beforeAll(async () => {
+    if (!process.env.TEST_DATABASE_URL) {
+      await setupTestContainers();
+      startedTestContainers = true;
+    }
+
+    adminPool = new Pool({ connectionString: adminConnectionString(), max: 1 });
+    databaseName = `kpi0049_${process.pid}_${Date.now()}`.toLowerCase();
+    await adminPool.query(`CREATE DATABASE ${quoteIdentifier(databaseName)}`);
+    connectionString = databaseConnectionString(databaseName);
+
+    await runMigrationsWithConnectionString(connectionString, MIGRATION_TAG);
+  }, 120_000);
+
+  afterAll(async () => {
+    if (adminPool && databaseName.startsWith('kpi0049_')) {
+      await adminPool.query(
+        `DROP DATABASE IF EXISTS ${quoteIdentifier(databaseName)} WITH (FORCE)`
+      );
+      await adminPool.end();
+    }
+    if (startedTestContainers) await cleanupTestContainers();
+  });
+
+  it('an accepted observation survives persistence and is re-readable', async () => {
+    const seeded = await withPool((pool) => seedBasis(pool, 'kpi-accept'));
+
+    // Write through the real service, on its own connection.
+    const created = await withPool(async (pool) => {
+      return createKpiObservation(
+        {
+          fundId: seeded.fundId,
+          request: requestFor(seeded.portfolioCompanyId),
+          source: 'manual',
+          actorId: seeded.userId,
+          idempotencyKey: uniqueLabel('idem'),
+        },
+        { database: kpiDb(pool) }
+      );
+    });
+
+    expect(created.replayed).toBe(false);
+    expect(created.observation.reviewStatus).toBe('pending');
+    expect(created.observation.version).toBe(1);
+
+    // Accept it, on a second connection.
+    const reviewed = await withPool(async (pool) => {
+      return reviewKpiObservation(
+        {
+          fundId: seeded.fundId,
+          observationId: created.observation.observationId,
+          expectedVersion: created.observation.version,
+          reviewStatus: 'accepted',
+          reviewComment: 'Matches the Q2 board deck',
+          actorId: seeded.userId,
+        },
+        { database: kpiDb(pool) }
+      );
+    });
+
+    expect(reviewed).not.toBeNull();
+
+    // THE POINT: re-read on a THIRD, fresh connection. Nothing in this block
+    // shares state with the writers above, so a pass means the database really
+    // holds the accepted row rather than a handler having echoed it back.
+    await withPool(async (pool) => {
+      const database = kpiDb(pool);
+      const row = await loadKpiObservation(
+        seeded.fundId,
+        created.observation.observationId,
+        { database }
+      );
+      expect(row).not.toBeNull();
+
+      const persisted = toKpiObservationContract(row!);
+      expect(persisted.reviewStatus).toBe('accepted');
+      expect(persisted.reviewComment).toBe('Matches the Q2 board deck');
+      expect(persisted.reviewedAt).not.toBeNull();
+      expect(persisted.version).toBe(2);
+      expect(persisted.fundId).toBe(seeded.fundId);
+      expect(persisted.portfolioCompanyId).toBe(seeded.portfolioCompanyId);
+      expect(persisted.metric).toBe('revenue_arr');
+      expect(persisted.periodStart).toBe(PERIOD.start);
+      expect(persisted.periodEnd).toBe(PERIOD.end);
+      expect(persisted.basis).toBe('actual');
+
+      // Money keeps its exact six-decimal string through the numeric column;
+      // a float round-trip would surface here.
+      expect(persisted.value).toEqual({
+        valueKind: 'money',
+        amountUsd: '2100000.000000',
+      });
+
+      // Raw catalog read, bypassing the service's own mapping entirely.
+      const raw = await pool.query(
+        `SELECT review_status, review_comment, version, value_amount::text AS value_amount,
+                reviewed_by, reviewed_at
+           FROM kpi_observations WHERE id = $1 AND fund_id = $2`,
+        [created.observation.observationId, seeded.fundId]
+      );
+      expect(raw.rowCount).toBe(1);
+      expect(raw.rows[0].review_status).toBe('accepted');
+      expect(raw.rows[0].review_comment).toBe('Matches the Q2 board deck');
+      expect(Number(raw.rows[0].version)).toBe(2);
+      expect(Number(raw.rows[0].value_amount)).toBe(2100000);
+      expect(Number(raw.rows[0].reviewed_by)).toBe(seeded.userId);
+      expect(raw.rows[0].reviewed_at).not.toBeNull();
+
+      // And it is visible to the fund-scoped list read.
+      const listed = await listKpiObservations(
+        seeded.fundId,
+        { reviewStatus: 'accepted' },
+        { database }
+      );
+      expect(listed.map((entry) => entry.observationId)).toContain(
+        created.observation.observationId
+      );
+    });
+  }, 120_000);
+
+  it('a stale expected version loses the compare-and-set and leaves the row untouched', async () => {
+    const seeded = await withPool((pool) => seedBasis(pool, 'kpi-stale'));
+
+    const created = await withPool(async (pool) =>
+      createKpiObservation(
+        {
+          fundId: seeded.fundId,
+          request: requestFor(seeded.portfolioCompanyId),
+          source: 'manual',
+          actorId: seeded.userId,
+          idempotencyKey: uniqueLabel('idem'),
+        },
+        { database: kpiDb(pool) }
+      )
+    );
+
+    // First reviewer wins.
+    const won = await withPool(async (pool) =>
+      reviewKpiObservation(
+        {
+          fundId: seeded.fundId,
+          observationId: created.observation.observationId,
+          expectedVersion: 1,
+          reviewStatus: 'accepted',
+          reviewComment: 'First in',
+          actorId: seeded.userId,
+        },
+        { database: kpiDb(pool) }
+      )
+    );
+    expect(won).not.toBeNull();
+
+    // Second reviewer, still holding version 1, must lose.
+    const lost = await withPool(async (pool) =>
+      reviewKpiObservation(
+        {
+          fundId: seeded.fundId,
+          observationId: created.observation.observationId,
+          expectedVersion: 1,
+          reviewStatus: 'rejected',
+          reviewComment: 'Too late',
+          actorId: seeded.userId,
+        },
+        { database: kpiDb(pool) }
+      )
+    );
+    expect(lost).toBeNull();
+
+    await withPool(async (pool) => {
+      const raw = await pool.query(
+        `SELECT review_status, review_comment, version FROM kpi_observations WHERE id = $1`,
+        [created.observation.observationId]
+      );
+      expect(raw.rows[0].review_status).toBe('accepted');
+      expect(raw.rows[0].review_comment).toBe('First in');
+      expect(Number(raw.rows[0].version)).toBe(2);
+    });
+  }, 120_000);
+});
+
+function requestFor(portfolioCompanyId: number): KpiObservationCreateRequest {
+  return {
+    portfolioCompanyId,
+    metric: 'revenue_arr',
+    periodStart: PERIOD.start,
+    periodEnd: PERIOD.end,
+    basis: 'actual',
+    value: { valueKind: 'money', amountUsd: '2100000.000000' },
+    sourceLabel: 'Q2 board deck',
+    submittedAt: '2026-07-05T00:00:00.000Z',
+  } as KpiObservationCreateRequest;
+}
+
+interface Basis {
+  fundId: number;
+  userId: number;
+  portfolioCompanyId: number;
+}
+
+async function seedBasis(pool: Pool, label: string): Promise<Basis> {
+  const suffix = uniqueLabel(label);
+  const fundId = await insertedId(
+    pool,
+    `
+      INSERT INTO funds (name, size, management_fee, carry_percentage, vintage_year)
+      VALUES ($1, 10000000, '0.0200', '0.2000', 2026)
+      RETURNING id
+    `,
+    [`KPI Observations ${suffix}`]
+  );
+  const userId = await insertedId(
+    pool,
+    `INSERT INTO users (username, password, role) VALUES ($1, 'x', 'admin') RETURNING id`,
+    [`kpi-${suffix}`]
+  );
+  const portfolioCompanyId = await insertedId(
+    pool,
+    `
+      INSERT INTO portfoliocompanies (
+        fund_id, name, sector, stage, investment_amount, status
+      ) VALUES ($1, $2, 'Software', 'Series A', 1000000, 'active')
+      RETURNING id
+    `,
+    [fundId, `Company ${suffix}`]
+  );
+  return { fundId, userId, portfolioCompanyId };
+}
+
+function adminConnectionString(): string {
+  return process.env.TEST_DATABASE_URL ?? getPostgresConnectionString();
+}
+
+function databaseConnectionString(name: string): string {
+  const url = new URL(adminConnectionString());
+  url.pathname = `/${name}`;
+  return url.toString();
+}
+
+async function withPool<T>(callback: (pool: Pool) => Promise<T>): Promise<T> {
+  const pool = new Pool({
+    connectionString,
+    max: 6,
+    statement_timeout: 5_000,
+    query_timeout: 7_000,
+    application_name: 'kpi-observation-pg-proof',
+  });
+  try {
+    return await callback(pool);
+  } finally {
+    await pool.end();
+  }
+}
+
+async function insertedId(pool: Pool, sql: string, values: unknown[]): Promise<number> {
+  const result = await pool.query(sql, values);
+  const id = result.rows[0]?.id;
+  if (typeof id !== 'number') throw new Error('Expected inserted id.');
+  return id;
+}
+
+function quoteIdentifier(identifier: string): string {
+  return `"${identifier.replace(/"/g, '""')}"`;
+}
+
+function uniqueLabel(prefix: string): string {
+  labelCounter += 1;
+  return `${prefix}-${process.pid}-${labelCounter}`;
+}

--- a/tests/integration/prod-schema-clone.test.ts
+++ b/tests/integration/prod-schema-clone.test.ts
@@ -179,6 +179,7 @@ const QUARTERLY_REVIEW_WORKFLOW_MANIFEST_TABLES = [
   'quarterly_review_items',
   'quarterly_review_command_receipts',
 ] as const;
+const KPI_OBSERVATIONS_MANIFEST_TABLES = ['kpi_observations'] as const;
 const EXPECTED_PRODUCTION_MANIFEST_NAMES = [
   'M1-cohort',
   'M2-fund-moic',
@@ -205,6 +206,7 @@ const EXPECTED_PRODUCTION_MANIFEST_NAMES = [
   'internal-economics-certification',
   'internal-economics-linkage',
   'quarterly-review-workflow',
+  'kpi-observations',
 ] as const;
 const SHAPE_ONLY_NOT_JOURNALED = [
   'flag_changes',
@@ -850,6 +852,7 @@ describe.skipIf(skipIfNoDocker)('prod schema synthetic clone', () => {
         ...INTERNAL_ECONOMICS_MANIFEST_TABLES,
         ...INTERNAL_ECONOMICS_LINKAGE_MANIFEST_TABLES,
         ...QUARTERLY_REVIEW_WORKFLOW_MANIFEST_TABLES,
+        ...KPI_OBSERVATIONS_MANIFEST_TABLES,
       ])
     );
 

--- a/tests/unit/contract/kpi/kpi-observation-v1.contract.test.ts
+++ b/tests/unit/contract/kpi/kpi-observation-v1.contract.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  KPI_CSV_TEMPLATE_HEADER,
+  KPI_METRICS,
+  KPI_METRIC_VALUE_KIND,
+  KPI_OBSERVATION_CONTRACT_VERSION,
+  KpiObservationCreateRequestSchema,
+  KpiObservationListQuerySchema,
+  KpiObservationReviewRequestSchema,
+  KpiObservationV1Schema,
+  metricShapeIssues,
+  numericStringOfValue,
+} from '../../../../shared/contracts/kpi/kpi-observation-v1.contract';
+
+function createRequest(overrides: Record<string, unknown> = {}) {
+  return {
+    portfolioCompanyId: 4,
+    metric: 'revenue_arr',
+    periodStart: '2026-04-01',
+    periodEnd: '2026-06-30',
+    basis: 'actual',
+    value: { valueKind: 'money', amountUsd: '2100000.000000' },
+    submittedAt: '2026-07-05T09:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('KPI observation contract v1', () => {
+  it('assigns exactly one value kind to every metric in the fixed set', () => {
+    expect(Object.keys(KPI_METRIC_VALUE_KIND).sort()).toEqual([...KPI_METRICS].sort());
+  });
+
+  it('accepts a well-formed money observation request', () => {
+    const parsed = KpiObservationCreateRequestSchema.safeParse(createRequest());
+    expect(parsed.success).toBe(true);
+  });
+
+  it('rejects a value kind that does not match the metric', () => {
+    const parsed = KpiObservationCreateRequestSchema.safeParse(
+      createRequest({ metric: 'qualitative_update' })
+    );
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects float money and accepts only fixed 6-decimal strings', () => {
+    expect(
+      KpiObservationCreateRequestSchema.safeParse(
+        createRequest({ value: { valueKind: 'money', amountUsd: 2100000 } })
+      ).success
+    ).toBe(false);
+    expect(
+      KpiObservationCreateRequestSchema.safeParse(
+        createRequest({ value: { valueKind: 'money', amountUsd: '2100000.00' } })
+      ).success
+    ).toBe(false);
+  });
+
+  it('rejects a negative magnitude metric but allows a negative company KPI', () => {
+    expect(
+      metricShapeIssues({
+        metric: 'headcount',
+        value: { valueKind: 'number', number: '-1.000000' },
+        companyKpiLabel: null,
+      })
+    ).toHaveLength(1);
+    expect(
+      metricShapeIssues({
+        metric: 'company_specific',
+        value: { valueKind: 'number', number: '-4.000000' },
+        companyKpiLabel: 'Net revenue retention delta',
+      })
+    ).toEqual([]);
+  });
+
+  it('couples companyKpiLabel to the company_specific metric in both directions', () => {
+    expect(
+      KpiObservationCreateRequestSchema.safeParse(
+        createRequest({
+          metric: 'company_specific',
+          value: { valueKind: 'number', number: '1.230000' },
+        })
+      ).success
+    ).toBe(false);
+    expect(
+      KpiObservationCreateRequestSchema.safeParse(
+        createRequest({ companyKpiLabel: 'Weekly active teams' })
+      ).success
+    ).toBe(false);
+  });
+
+  it('rejects an inverted period', () => {
+    expect(
+      KpiObservationCreateRequestSchema.safeParse(
+        createRequest({ periodStart: '2026-06-30', periodEnd: '2026-04-01' })
+      ).success
+    ).toBe(false);
+  });
+
+  it('refuses caller-supplied source and any unknown field', () => {
+    expect(
+      KpiObservationCreateRequestSchema.safeParse(createRequest({ source: 'manual' })).success
+    ).toBe(false);
+    expect(
+      KpiObservationCreateRequestSchema.safeParse(createRequest({ reviewStatus: 'accepted' }))
+        .success
+    ).toBe(false);
+  });
+
+  it('round-trips a stored observation and exposes its numeric string', () => {
+    const observation = {
+      contractVersion: KPI_OBSERVATION_CONTRACT_VERSION,
+      observationId: 9,
+      fundId: 1,
+      portfolioCompanyId: 4,
+      metric: 'runway_months' as const,
+      periodStart: '2026-04-01',
+      periodEnd: '2026-06-30',
+      basis: 'actual' as const,
+      value: { valueKind: 'number' as const, number: '14.500000' },
+      companyKpiLabel: null,
+      source: 'csv_import' as const,
+      sourceLabel: 'Q2 collection',
+      comment: null,
+      submittedAt: '2026-07-05T09:00:00.000Z',
+      reviewStatus: 'pending' as const,
+      reviewComment: null,
+      reviewedAt: null,
+      version: 1,
+      createdAt: '2026-07-05T09:00:01.000Z',
+      updatedAt: '2026-07-05T09:00:01.000Z',
+    };
+    const parsed = KpiObservationV1Schema.parse(observation);
+    expect(parsed).toEqual(observation);
+    expect(numericStringOfValue(parsed.value)).toBe('14.500000');
+  });
+
+  it('constrains review requests and list filters', () => {
+    expect(KpiObservationReviewRequestSchema.safeParse({ reviewStatus: 'accepted' }).success).toBe(
+      true
+    );
+    expect(KpiObservationReviewRequestSchema.safeParse({ reviewStatus: 'unknown' }).success).toBe(
+      false
+    );
+    // A review decides; returning a row to pending would erase the reviewer.
+    expect(KpiObservationReviewRequestSchema.safeParse({ reviewStatus: 'pending' }).success).toBe(
+      false
+    );
+    expect(KpiObservationListQuerySchema.safeParse({ portfolioCompanyId: '4' })).toMatchObject({
+      success: true,
+      data: { portfolioCompanyId: 4 },
+    });
+    expect(KpiObservationListQuerySchema.safeParse({ sortBy: 'value' }).success).toBe(false);
+  });
+
+  it('freezes the fixed CSV template header', () => {
+    expect([...KPI_CSV_TEMPLATE_HEADER]).toEqual([
+      'portfolio_company_id',
+      'metric',
+      'period_start',
+      'period_end',
+      'basis',
+      'value',
+      'company_kpi_label',
+      'source_label',
+      'comment',
+      'submitted_at',
+    ]);
+  });
+});

--- a/tests/unit/migration-ledger.test.ts
+++ b/tests/unit/migration-ledger.test.ts
@@ -59,6 +59,7 @@ const expectedJournaledDriftPatchFiles = [
   '0046_internal_economics_certification.sql',
   '0047_internal_economics_linkage.sql',
   '0048_quarterly_review_workflow.sql',
+  '0049_kpi_observations.sql',
 ].sort();
 
 afterEach(() => {

--- a/tests/unit/prod-schema-manifest-sentinels.test.ts
+++ b/tests/unit/prod-schema-manifest-sentinels.test.ts
@@ -153,6 +153,7 @@ describe('prod-schema manifest sentinels', () => {
       '23-internal-economics-certification.json',
       '24-internal-economics-linkage.json',
       '25-quarterly-review-workflow.json',
+      '26-kpi-observations.json',
     ]);
   });
 

--- a/tests/unit/routes/kpi-observations-dual-runtime.contract.test.ts
+++ b/tests/unit/routes/kpi-observations-dual-runtime.contract.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Issue #1300: the KPI collection routes must answer identically on both fully
+ * composed server surfaces -- `makeApp()` and `registerRoutes()` -- because they
+ * are mounted through the common route triad rather than one entrypoint.
+ */
+import express from 'express';
+import type { Express } from 'express';
+import type { Server } from 'node:http';
+import request from 'supertest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const kpiService = vi.hoisted(() => ({
+  createKpiObservation: vi.fn(),
+  listKpiObservations: vi.fn(),
+  loadKpiObservation: vi.fn(),
+  reviewKpiObservation: vi.fn(),
+}));
+
+vi.mock('../../../server/services/kpi/kpi-observation-service', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../../server/services/kpi/kpi-observation-service')
+  >('../../../server/services/kpi/kpi-observation-service');
+  return {
+    ...actual,
+    createKpiObservation: kpiService.createKpiObservation,
+    listKpiObservations: kpiService.listKpiObservations,
+    loadKpiObservation: kpiService.loadKpiObservation,
+    reviewKpiObservation: kpiService.reviewKpiObservation,
+  };
+});
+
+const ENV_KEYS = [
+  'NODE_ENV',
+  '_EXPLICIT_NODE_ENV',
+  'VITEST',
+  'ALLOW_MEMORY_STORAGE',
+  'DATABASE_URL',
+  'NEON_DATABASE_URL',
+  'REDIS_URL',
+  '_EXPLICIT_REDIS_URL',
+  'RATE_LIMIT_REDIS_URL',
+  'QUEUE_REDIS_URL',
+  'SESSION_REDIS_URL',
+  'ENABLE_QUEUES',
+  'REQUIRE_AUTH',
+  'DEFAULT_USER_ID',
+  'JWT_ALG',
+  '_EXPLICIT_JWT_ALG',
+  'JWT_SECRET',
+  '_EXPLICIT_JWT_SECRET',
+  'JWT_AUDIENCE',
+  '_EXPLICIT_JWT_AUDIENCE',
+  'JWT_ISSUER',
+  '_EXPLICIT_JWT_ISSUER',
+  'JWT_JWKS_URL',
+  '_EXPLICIT_JWT_JWKS_URL',
+  'SESSION_SECRET',
+] as const;
+
+const originalEnv = new Map<string, string | undefined>();
+
+const OBSERVATION = {
+  contractVersion: 'kpi-observation/1.0.0' as const,
+  observationId: 9,
+  fundId: 1,
+  portfolioCompanyId: 4,
+  metric: 'revenue_arr' as const,
+  periodStart: '2026-04-01',
+  periodEnd: '2026-06-30',
+  basis: 'actual' as const,
+  value: { valueKind: 'money' as const, amountUsd: '2100000.000000' },
+  companyKpiLabel: null,
+  source: 'manual' as const,
+  sourceLabel: null,
+  comment: null,
+  submittedAt: '2026-07-05T09:00:00.000Z',
+  reviewStatus: 'pending' as const,
+  reviewComment: null,
+  reviewedAt: null,
+  version: 1,
+  createdAt: '2026-07-06T00:00:00.000Z',
+  updatedAt: '2026-07-06T00:00:00.000Z',
+};
+
+const CREATE_BODY = {
+  portfolioCompanyId: 4,
+  metric: 'revenue_arr',
+  periodStart: '2026-04-01',
+  periodEnd: '2026-06-30',
+  basis: 'actual',
+  value: { valueKind: 'money', amountUsd: '2100000.000000' },
+  submittedAt: '2026-07-05T09:00:00.000Z',
+};
+
+type Surface = { name: 'makeApp' | 'registerRoutes'; app: Express };
+let surfaces: readonly Surface[] = [];
+let registerRoutesServer: Server | undefined;
+
+function configureEnvironment() {
+  process.env.NODE_ENV = 'test';
+  process.env._EXPLICIT_NODE_ENV = 'test';
+  process.env.VITEST = 'true';
+  process.env.ALLOW_MEMORY_STORAGE = '1';
+  delete process.env.DATABASE_URL;
+  delete process.env.NEON_DATABASE_URL;
+  process.env.REDIS_URL = 'memory://';
+  process.env._EXPLICIT_REDIS_URL = 'memory://';
+  delete process.env.RATE_LIMIT_REDIS_URL;
+  delete process.env.QUEUE_REDIS_URL;
+  delete process.env.SESSION_REDIS_URL;
+  process.env.ENABLE_QUEUES = '0';
+  process.env.REQUIRE_AUTH = '1';
+  process.env.DEFAULT_USER_ID = '1';
+  process.env.JWT_ALG = 'HS256';
+  process.env._EXPLICIT_JWT_ALG = 'HS256';
+  process.env.JWT_SECRET = 'test'.repeat(8);
+  process.env._EXPLICIT_JWT_SECRET = process.env.JWT_SECRET;
+  process.env.JWT_AUDIENCE = 'updog-test';
+  process.env._EXPLICIT_JWT_AUDIENCE = process.env.JWT_AUDIENCE;
+  process.env.JWT_ISSUER = 'updog-test';
+  process.env._EXPLICIT_JWT_ISSUER = process.env.JWT_ISSUER;
+  delete process.env.JWT_JWKS_URL;
+  delete process.env._EXPLICIT_JWT_JWKS_URL;
+  process.env.SESSION_SECRET = 'kpi-observations-dual-runtime-secret-32';
+}
+
+async function authorizationHeader(
+  fundIds: readonly number[] = [1],
+  role = 'admin'
+): Promise<string> {
+  const { signToken } = await import('../../../server/lib/auth/jwt');
+  return `Bearer ${signToken({
+    sub: '9',
+    email: 'kpi-collection@example.com',
+    role,
+    fundIds,
+  })}`;
+}
+
+async function closeServer(server: Server | undefined) {
+  if (!server?.listening) return;
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+beforeAll(async () => {
+  for (const key of ENV_KEYS) originalEnv.set(key, process.env[key]);
+  configureEnvironment();
+  vi.resetModules();
+
+  const { makeApp } = await import('../../../server/app');
+  const registerRoutesApp = express();
+  registerRoutesApp.set('trust proxy', false);
+  registerRoutesApp.use(express.json({ limit: '1mb' }));
+  const { requireSecureContext } = await import('../../../server/lib/secure-context');
+  registerRoutesApp.use('/api', requireSecureContext);
+  const { registerRoutes } = await import('../../../server/routes');
+  registerRoutesServer = await registerRoutes(registerRoutesApp);
+  surfaces = [
+    { name: 'makeApp', app: makeApp() },
+    { name: 'registerRoutes', app: registerRoutesApp },
+  ];
+}, 30_000);
+
+afterAll(async () => {
+  await closeServer(registerRoutesServer);
+  for (const key of ENV_KEYS) {
+    const value = originalEnv.get(key);
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+beforeEach(() => {
+  for (const mock of Object.values(kpiService)) mock.mockReset();
+  kpiService.listKpiObservations.mockResolvedValue([OBSERVATION]);
+  kpiService.loadKpiObservation.mockResolvedValue(null);
+  kpiService.createKpiObservation.mockResolvedValue({
+    observation: OBSERVATION,
+    replayed: false,
+  });
+});
+
+describe('KPI observation dual-runtime parity', () => {
+  it('rejects unauthenticated reads and writes identically on both runtimes', async () => {
+    const reads = await Promise.all(
+      surfaces.map((surface) => request(surface.app).get('/api/funds/1/kpi-observations'))
+    );
+    expect(reads.map((response) => response.status)).toEqual([401, 401]);
+    expect(reads[1]?.body).toEqual(reads[0]?.body);
+
+    const writes = await Promise.all(
+      surfaces.map((surface) =>
+        request(surface.app)
+          .post('/api/funds/1/kpi-observations')
+          .set('Idempotency-Key', 'kpi-1')
+          .send(CREATE_BODY)
+      )
+    );
+    expect(writes.map((response) => response.status)).toEqual([401, 401]);
+    expect(kpiService.createKpiObservation).not.toHaveBeenCalled();
+  });
+
+  it('serves the same list payload to an authorized reader on both runtimes', async () => {
+    const authorization = await authorizationHeader();
+    const responses = await Promise.all(
+      surfaces.map((surface) =>
+        request(surface.app)
+          .get('/api/funds/1/kpi-observations')
+          .set('Authorization', authorization)
+      )
+    );
+
+    expect(responses.map((response) => response.status)).toEqual([200, 200]);
+    expect(responses[1]?.body).toEqual(responses[0]?.body);
+    expect(responses[0]?.body.data).toHaveLength(1);
+  });
+
+  it('denies an out-of-scope write identically on both runtimes', async () => {
+    // `admin` and `service` principals allow any fund by design, so out-of-scope
+    // denial is asserted with an ordinary `user` principal. Writes are where
+    // fund scope bites: team members keep the repo-wide universal READ posture.
+    const authorization = await authorizationHeader([2], 'user');
+    const responses = await Promise.all(
+      surfaces.map((surface) =>
+        request(surface.app)
+          .post('/api/funds/1/kpi-observations')
+          .set('Authorization', authorization)
+          .set('Idempotency-Key', 'kpi-out-of-scope')
+          .send(CREATE_BODY)
+      )
+    );
+
+    expect(responses.map((response) => response.status)).toEqual([403, 403]);
+    expect(responses[1]?.body).toEqual(responses[0]?.body);
+    expect(kpiService.createKpiObservation).not.toHaveBeenCalled();
+  });
+
+  it('requires an Idempotency-Key for creation on both runtimes', async () => {
+    const authorization = await authorizationHeader();
+    const responses = await Promise.all(
+      surfaces.map((surface) =>
+        request(surface.app)
+          .post('/api/funds/1/kpi-observations')
+          .set('Authorization', authorization)
+          .send(CREATE_BODY)
+      )
+    );
+
+    expect(responses.map((response) => response.status)).toEqual([428, 428]);
+    expect(responses[1]?.body).toEqual(responses[0]?.body);
+    expect(kpiService.createKpiObservation).not.toHaveBeenCalled();
+  });
+
+  it('reaches the database-backed idempotent command on both runtimes', async () => {
+    const authorization = await authorizationHeader();
+    const responses = await Promise.all(
+      surfaces.map((surface) =>
+        request(surface.app)
+          .post('/api/funds/1/kpi-observations')
+          .set('Authorization', authorization)
+          .set('Idempotency-Key', 'kpi-dual-1')
+          .send(CREATE_BODY)
+      )
+    );
+
+    expect(responses.map((response) => response.status)).toEqual([201, 201]);
+    expect(responses[1]?.body).toEqual(responses[0]?.body);
+    // The generic in-memory idempotency middleware must not shadow the
+    // database-backed command: both surfaces call the service.
+    expect(kpiService.createKpiObservation).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/routes/kpi-observations.contract.test.ts
+++ b/tests/unit/routes/kpi-observations.contract.test.ts
@@ -1,0 +1,371 @@
+import express from 'express';
+import type { Request, Response } from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { KPI_CSV_TEMPLATE_HEADER } from '../../../shared/contracts/kpi/kpi-observation-v1.contract';
+
+const fundScopeState = vi.hoisted(() => ({
+  enforceProvidedFundScope: vi.fn(async (_req: Request, _res: Response, _fundId: number) => true),
+}));
+
+const serviceState = vi.hoisted(() => ({
+  createKpiObservation: vi.fn(),
+  listKpiObservations: vi.fn(),
+  loadKpiObservation: vi.fn(),
+  reviewKpiObservation: vi.fn(),
+}));
+
+vi.mock('../../../server/lib/auth/provided-fund-scope', () => ({
+  enforceProvidedFundScope: fundScopeState.enforceProvidedFundScope,
+}));
+
+vi.mock('../../../server/services/kpi/kpi-observation-service', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../../server/services/kpi/kpi-observation-service')
+  >('../../../server/services/kpi/kpi-observation-service');
+  return {
+    ...actual,
+    createKpiObservation: serviceState.createKpiObservation,
+    listKpiObservations: serviceState.listKpiObservations,
+    loadKpiObservation: serviceState.loadKpiObservation,
+    reviewKpiObservation: serviceState.reviewKpiObservation,
+  };
+});
+
+import kpiObservationsRouter from '../../../server/routes/kpi-observations';
+import { KpiObservationServiceError } from '../../../server/services/kpi/kpi-observation-service';
+
+const AT = new Date('2026-07-06T00:00:00.000Z');
+
+function row(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 9,
+    fundId: 1,
+    portfolioCompanyId: 4,
+    metric: 'revenue_arr',
+    periodStart: '2026-04-01',
+    periodEnd: '2026-06-30',
+    basis: 'actual',
+    valueKind: 'money',
+    valueAmount: '2100000.000000',
+    valueDate: null,
+    valueText: null,
+    companyKpiLabel: null,
+    source: 'manual',
+    sourceLabel: null,
+    comment: null,
+    submittedAt: AT,
+    reviewStatus: 'pending',
+    reviewComment: null,
+    reviewedBy: null,
+    reviewedAt: null,
+    version: 1,
+    idempotencyKey: 'kpi-1',
+    requestHash: 'hash',
+    createdBy: null,
+    createdAt: AT,
+    updatedAt: AT,
+    ...overrides,
+  };
+}
+
+/** A full contract observation; the import route re-validates what it serves. */
+const OBSERVATION = {
+  contractVersion: 'kpi-observation/1.0.0',
+  observationId: 9,
+  fundId: 1,
+  portfolioCompanyId: 4,
+  metric: 'revenue_arr',
+  periodStart: '2026-04-01',
+  periodEnd: '2026-06-30',
+  basis: 'actual',
+  value: { valueKind: 'money', amountUsd: '2100000.000000' },
+  companyKpiLabel: null,
+  source: 'csv_import',
+  sourceLabel: 'Q2 collection',
+  comment: null,
+  submittedAt: '2026-07-05T00:00:00.000Z',
+  reviewStatus: 'pending',
+  reviewComment: null,
+  reviewedAt: null,
+  version: 1,
+  createdAt: '2026-07-06T00:00:00.000Z',
+  updatedAt: '2026-07-06T00:00:00.000Z',
+} as const;
+
+const CREATE_BODY = {
+  portfolioCompanyId: 4,
+  metric: 'revenue_arr',
+  periodStart: '2026-04-01',
+  periodEnd: '2026-06-30',
+  basis: 'actual',
+  value: { valueKind: 'money', amountUsd: '2100000.000000' },
+  submittedAt: '2026-07-05T09:00:00.000Z',
+};
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(kpiObservationsRouter);
+  app.use((_req, res) => res.status(404).json({ error: 'not_found' }));
+  return app;
+}
+
+function csvBase64(...rows: string[]): string {
+  return Buffer.from([KPI_CSV_TEMPLATE_HEADER.join(','), ...rows].join('\n'), 'utf8').toString(
+    'base64'
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fundScopeState.enforceProvidedFundScope.mockImplementation(async () => true);
+});
+
+describe('KPI observation routes', () => {
+  it('rejects a non-numeric fund id before touching the service', async () => {
+    const response = await request(makeApp()).get('/api/funds/abc/kpi-observations');
+
+    expect(response.status).toBe(400);
+    expect(serviceState.listKpiObservations).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unsupported list filter', async () => {
+    const response = await request(makeApp()).get('/api/funds/1/kpi-observations?sortBy=value');
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('INVALID_KPI_OBSERVATION_QUERY');
+  });
+
+  it('passes parsed filters through and never caches the response', async () => {
+    serviceState.listKpiObservations.mockResolvedValue([]);
+    const response = await request(makeApp()).get(
+      '/api/funds/1/kpi-observations?portfolioCompanyId=4&metric=headcount'
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers['cache-control']).toBe('private, no-store');
+    expect(serviceState.listKpiObservations).toHaveBeenCalledWith(1, {
+      portfolioCompanyId: 4,
+      metric: 'headcount',
+    });
+  });
+
+  it('serves a read with the ETag a review must echo', async () => {
+    serviceState.loadKpiObservation.mockResolvedValue(row());
+    const response = await request(makeApp()).get('/api/funds/1/kpi-observations/9');
+
+    expect(response.status).toBe(200);
+    expect(response.headers.etag).toMatch(/^W\//);
+    expect(response.body.observationId).toBe(9);
+    expect(response.body).not.toHaveProperty('idempotencyKey');
+    expect(response.body).not.toHaveProperty('requestHash');
+  });
+
+  it('404s a read for an observation outside the fund', async () => {
+    serviceState.loadKpiObservation.mockResolvedValue(null);
+    const response = await request(makeApp()).get('/api/funds/1/kpi-observations/9');
+
+    expect(response.status).toBe(404);
+    expect(response.body.error).toBe('KPI_OBSERVATION_NOT_FOUND');
+  });
+
+  it('requires an Idempotency-Key before validating the create body', async () => {
+    const response = await request(makeApp()).post('/api/funds/1/kpi-observations').send({});
+
+    expect(response.status).toBe(428);
+    expect(response.body.error).toBe('IDEMPOTENCY_KEY_REQUIRED');
+  });
+
+  it('rejects a malformed Idempotency-Key', async () => {
+    const response = await request(makeApp())
+      .post('/api/funds/1/kpi-observations')
+      .set('Idempotency-Key', 'not a token')
+      .send(CREATE_BODY);
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('INVALID_IDEMPOTENCY_KEY');
+  });
+
+  it('creates with 201 and replays with 200, always as source "manual"', async () => {
+    serviceState.createKpiObservation.mockResolvedValueOnce({
+      observation: { fundId: 1, observationId: 9, version: 1 },
+      replayed: false,
+    });
+    const created = await request(makeApp())
+      .post('/api/funds/1/kpi-observations')
+      .set('Idempotency-Key', 'kpi-1')
+      .send(CREATE_BODY);
+
+    expect(created.status).toBe(201);
+    expect(serviceState.createKpiObservation).toHaveBeenCalledWith(
+      expect.objectContaining({ fundId: 1, source: 'manual', idempotencyKey: 'kpi-1' })
+    );
+
+    serviceState.createKpiObservation.mockResolvedValueOnce({
+      observation: { fundId: 1, observationId: 9, version: 1 },
+      replayed: true,
+    });
+    const replay = await request(makeApp())
+      .post('/api/funds/1/kpi-observations')
+      .set('Idempotency-Key', 'kpi-1')
+      .send(CREATE_BODY);
+
+    expect(replay.status).toBe(200);
+  });
+
+  it('refuses a caller-declared source', async () => {
+    const response = await request(makeApp())
+      .post('/api/funds/1/kpi-observations')
+      .set('Idempotency-Key', 'kpi-1')
+      .send({ ...CREATE_BODY, source: 'csv_import' });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('INVALID_KPI_OBSERVATION_BODY');
+    expect(serviceState.createKpiObservation).not.toHaveBeenCalled();
+  });
+
+  it('maps a cross-fund company to 404 through the typed service error', async () => {
+    serviceState.createKpiObservation.mockRejectedValue(
+      new KpiObservationServiceError(
+        404,
+        'PORTFOLIO_COMPANY_NOT_FOUND',
+        'Portfolio company not found in this fund.'
+      )
+    );
+    const response = await request(makeApp())
+      .post('/api/funds/1/kpi-observations')
+      .set('Idempotency-Key', 'kpi-1')
+      .send(CREATE_BODY);
+
+    expect(response.status).toBe(404);
+    expect(response.body.error).toBe('PORTFOLIO_COMPANY_NOT_FOUND');
+  });
+
+  it('imports accepted CSV rows and reports rejected ones per row', async () => {
+    serviceState.createKpiObservation.mockResolvedValue({
+      observation: OBSERVATION,
+      replayed: false,
+    });
+    const response = await request(makeApp())
+      .post('/api/funds/1/kpi-observations/imports')
+      .set('Idempotency-Key', 'batch-1')
+      .send({
+        csvBase64: csvBase64(
+          '4,revenue_arr,2026-04-01,2026-06-30,actual,2100000,,,,2026-07-05',
+          '4,made_up,2026-04-01,2026-06-30,actual,1,,,,2026-07-05'
+        ),
+        sourceLabel: 'Q2 collection',
+      });
+
+    expect(response.status).toBe(201);
+    expect(response.body.imported).toHaveLength(1);
+    expect(response.body.rejected).toEqual([
+      { row: 2, code: 'UNKNOWN_METRIC', message: expect.any(String) },
+    ]);
+    expect(serviceState.createKpiObservation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'csv_import',
+        idempotencyKey: 'batch-1:row:1',
+        request: expect.objectContaining({ sourceLabel: 'Q2 collection' }),
+      })
+    );
+  });
+
+  it('rejects a whole batch whose header is not the fixed template', async () => {
+    const response = await request(makeApp())
+      .post('/api/funds/1/kpi-observations/imports')
+      .set('Idempotency-Key', 'batch-1')
+      .send({ csvBase64: Buffer.from('a,b\n1,2\n', 'utf8').toString('base64') });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('TEMPLATE_HEADER_MISMATCH');
+    expect(serviceState.createKpiObservation).not.toHaveBeenCalled();
+  });
+
+  it('requires If-Match on review and answers 412 when the version moved', async () => {
+    const missing = await request(makeApp())
+      .patch('/api/funds/1/kpi-observations/9/review')
+      .send({ reviewStatus: 'accepted' });
+    expect(missing.status).toBe(428);
+
+    serviceState.loadKpiObservation.mockResolvedValue(row({ version: 3 }));
+    const stale = await request(makeApp())
+      .patch('/api/funds/1/kpi-observations/9/review')
+      .set('If-Match', 'W/"deadbeefdeadbeef"')
+      .send({ reviewStatus: 'accepted' });
+
+    expect(stale.status).toBe(412);
+    expect(serviceState.reviewKpiObservation).not.toHaveBeenCalled();
+  });
+
+  it('records a review under a matching If-Match and rotates the ETag', async () => {
+    serviceState.loadKpiObservation.mockResolvedValue(row());
+    const read = await request(makeApp()).get('/api/funds/1/kpi-observations/9');
+    const etag = read.headers.etag as string;
+
+    serviceState.reviewKpiObservation.mockResolvedValue(
+      row({
+        version: 2,
+        reviewStatus: 'accepted',
+        reviewComment: 'Matches the board deck',
+        reviewedAt: AT,
+      })
+    );
+    const response = await request(makeApp())
+      .patch('/api/funds/1/kpi-observations/9/review')
+      .set('If-Match', etag)
+      .send({ reviewStatus: 'accepted', reviewComment: 'Matches the board deck' });
+
+    expect(response.status).toBe(200);
+    expect(response.body.reviewStatus).toBe('accepted');
+    expect(response.headers.etag).not.toBe(etag);
+    expect(serviceState.reviewKpiObservation).toHaveBeenCalledWith(
+      expect.objectContaining({ expectedVersion: 1, reviewStatus: 'accepted' })
+    );
+  });
+
+  it('answers 412 when the compare-and-set loses a race after a passing precondition', async () => {
+    serviceState.loadKpiObservation.mockResolvedValueOnce(row());
+    const read = await request(makeApp()).get('/api/funds/1/kpi-observations/9');
+    const etag = read.headers.etag as string;
+
+    serviceState.loadKpiObservation.mockResolvedValueOnce(row());
+    serviceState.reviewKpiObservation.mockResolvedValue(null);
+    serviceState.loadKpiObservation.mockResolvedValueOnce(row({ version: 2 }));
+
+    const response = await request(makeApp())
+      .patch('/api/funds/1/kpi-observations/9/review')
+      .set('If-Match', etag)
+      .send({ reviewStatus: 'rejected' });
+
+    expect(response.status).toBe(412);
+  });
+
+  it('refuses to return a reviewed row to pending', async () => {
+    serviceState.loadKpiObservation.mockResolvedValue(row());
+    const response = await request(makeApp())
+      .patch('/api/funds/1/kpi-observations/9/review')
+      .set('If-Match', 'W/"anything"')
+      .send({ reviewStatus: 'pending' });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('INVALID_KPI_REVIEW_BODY');
+  });
+
+  it('stops at the fund-scope boundary before any write', async () => {
+    fundScopeState.enforceProvidedFundScope.mockImplementation(async (_req, res) => {
+      (res as Response).status(403).json({ error: 'Forbidden' });
+      return false;
+    });
+
+    const response = await request(makeApp())
+      .post('/api/funds/1/kpi-observations')
+      .set('Idempotency-Key', 'kpi-1')
+      .send(CREATE_BODY);
+
+    expect(response.status).toBe(403);
+    expect(serviceState.createKpiObservation).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/server/common-route-manifest.test.ts
+++ b/tests/unit/server/common-route-manifest.test.ts
@@ -143,6 +143,7 @@ describe('canonical common API route manifest', () => {
         "reallocation:<bare>",
         "cash-flow-events:<bare>",
         "operating-object-tasks:<bare>",
+        "kpi-observations:<bare>",
         "deal-pipeline:/api/deals",
         "cohort-analysis:/api/cohorts",
         "sensitivity:/api",

--- a/tests/unit/services/kpi/kpi-observation-csv.test.ts
+++ b/tests/unit/services/kpi/kpi-observation-csv.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  KPI_CSV_TEMPLATE_HEADER,
+  KPI_CSV_MAX_ROWS,
+} from '../../../../shared/contracts/kpi/kpi-observation-v1.contract';
+import {
+  KpiCsvBatchError,
+  parseKpiObservationCsv,
+} from '../../../../server/services/kpi/kpi-observation-csv';
+
+const HEADER = KPI_CSV_TEMPLATE_HEADER.join(',');
+
+function csv(...rows: string[]): Buffer {
+  return Buffer.from([HEADER, ...rows].join('\n'), 'utf8');
+}
+
+const ARR_ROW = '4,revenue_arr,2026-04-01,2026-06-30,actual,"$2,100,000",,Q2 deck,,2026-07-05';
+
+describe('KPI observation CSV template', () => {
+  it('parses a spreadsheet-shaped money row into a fixed decimal string', () => {
+    const parsed = parseKpiObservationCsv(csv(ARR_ROW));
+
+    expect(parsed.rejected).toEqual([]);
+    expect(parsed.accepted).toHaveLength(1);
+    expect(parsed.accepted[0]).toMatchObject({
+      row: 1,
+      request: {
+        portfolioCompanyId: 4,
+        metric: 'revenue_arr',
+        basis: 'actual',
+        value: { valueKind: 'money', amountUsd: '2100000.000000' },
+        sourceLabel: 'Q2 deck',
+        companyKpiLabel: null,
+        comment: null,
+        submittedAt: '2026-07-05T00:00:00.000Z',
+      },
+    });
+  });
+
+  it('rejects the whole batch when the fixed header does not match', () => {
+    const wrongHeader = Buffer.from('company,metric,value\n4,revenue_arr,10\n', 'utf8');
+    expect(() => parseKpiObservationCsv(wrongHeader)).toThrow(KpiCsvBatchError);
+    try {
+      parseKpiObservationCsv(wrongHeader);
+    } catch (error) {
+      expect((error as KpiCsvBatchError).code).toBe('TEMPLATE_HEADER_MISMATCH');
+    }
+  });
+
+  it('rejects the whole batch on an embedded newline or row overflow', () => {
+    const embedded = Buffer.from(
+      `${HEADER}\n4,qualitative_update,2026-04-01,2026-06-30,actual,"a\nb",,,,2026-07-05\n`,
+      'utf8'
+    );
+    expect(() => parseKpiObservationCsv(embedded)).toThrow(/newline/i);
+
+    const overflow = csv(...Array.from({ length: KPI_CSV_MAX_ROWS + 1 }, () => ARR_ROW));
+    expect(() => parseKpiObservationCsv(overflow)).toThrow(/exceeds the limit/);
+  });
+
+  it('rejects only the offending rows and keeps the rest of the batch', () => {
+    const parsed = parseKpiObservationCsv(
+      csv(
+        ARR_ROW,
+        '0,revenue_arr,2026-04-01,2026-06-30,actual,10,,,,2026-07-05',
+        '4,made_up_metric,2026-04-01,2026-06-30,actual,10,,,,2026-07-05',
+        '4,headcount,2026-04-01,2026-06-30,actual,twelve,,,,2026-07-05',
+        '4,revenue_arr,2026-04-01,2026-06-30,actual,10,,,,not-a-date',
+        '4,cash_balance,2026-06-30,2026-04-01,actual,10,,,,2026-07-05'
+      )
+    );
+
+    expect(parsed.accepted).toHaveLength(1);
+    expect(parsed.rejected.map((rejection) => [rejection.row, rejection.code])).toEqual([
+      [2, 'INVALID_PORTFOLIO_COMPANY_ID'],
+      [3, 'UNKNOWN_METRIC'],
+      [4, 'INVALID_VALUE'],
+      [5, 'INVALID_SUBMITTED_AT'],
+      [6, 'INVALID_ROW'],
+    ]);
+  });
+
+  it('refuses to truncate money below the six-decimal boundary', () => {
+    const parsed = parseKpiObservationCsv(
+      csv('4,revenue_arr,2026-04-01,2026-06-30,actual,10.1234567,,,,2026-07-05')
+    );
+    expect(parsed.accepted).toEqual([]);
+    expect(parsed.rejected[0]?.code).toBe('INVALID_VALUE');
+  });
+
+  it('reads a parenthesised negative as a signed company KPI', () => {
+    const parsed = parseKpiObservationCsv(
+      csv('4,company_specific,2026-04-01,2026-06-30,actual,(4.5),NRR delta,,,2026-07-05')
+    );
+    expect(parsed.accepted[0]?.request.value).toEqual({
+      valueKind: 'number',
+      number: '-4.500000',
+    });
+    expect(parsed.accepted[0]?.request.companyKpiLabel).toBe('NRR delta');
+  });
+
+  it('rejects a negative magnitude metric through the contract refinement', () => {
+    const parsed = parseKpiObservationCsv(
+      csv('4,monthly_burn,2026-04-01,2026-06-30,actual,(500000),,,,2026-07-05')
+    );
+    expect(parsed.accepted).toEqual([]);
+    expect(parsed.rejected[0]).toMatchObject({ row: 1, code: 'INVALID_ROW' });
+  });
+});

--- a/tests/unit/services/kpi/kpi-observation-service.test.ts
+++ b/tests/unit/services/kpi/kpi-observation-service.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  KPI_METRIC_VALUE_KIND,
+  type KpiObservationCreateRequest,
+} from '../../../../shared/contracts/kpi/kpi-observation-v1.contract';
+import type { KpiObservationRow } from '../../../../shared/schema/kpi-observations';
+import { IdempotentCommandError } from '../../../../server/lib/idempotent-command';
+import {
+  KpiObservationServiceError,
+  createKpiObservationWithPorts,
+  toKpiObservationContract,
+  type CreateKpiObservationInput,
+  type KpiObservationPorts,
+} from '../../../../server/services/kpi/kpi-observation-service';
+
+const REQUEST: KpiObservationCreateRequest = {
+  portfolioCompanyId: 4,
+  metric: 'revenue_arr',
+  periodStart: '2026-04-01',
+  periodEnd: '2026-06-30',
+  basis: 'actual',
+  value: { valueKind: 'money', amountUsd: '2100000.000000' },
+  submittedAt: '2026-07-05T09:00:00.000Z',
+};
+
+class FakePorts implements KpiObservationPorts {
+  companies = new Set(['1:4']);
+  rows = new Map<string, { row: KpiObservationRow; requestHash: string }>();
+  nextId = 1;
+
+  async assertCompanyOwned(fundId: number, portfolioCompanyId: number) {
+    await Promise.resolve();
+    if (!this.companies.has(`${fundId}:${portfolioCompanyId}`)) {
+      throw new KpiObservationServiceError(
+        404,
+        'PORTFOLIO_COMPANY_NOT_FOUND',
+        'Portfolio company not found in this fund.'
+      );
+    }
+  }
+
+  async createIdempotent(input: Parameters<KpiObservationPorts['createIdempotent']>[0]) {
+    await Promise.resolve();
+    const key = `${input.fundId}:${input.idempotencyKey}`;
+    const requestHash = JSON.stringify(input.preimage);
+    const existing = this.rows.get(key);
+    if (existing) {
+      if (existing.requestHash !== requestHash) {
+        throw new IdempotentCommandError(
+          409,
+          'IDEMPOTENCY_KEY_REUSE',
+          'Idempotency-Key was already used for a different request.'
+        );
+      }
+      return { row: existing.row, replayed: true };
+    }
+
+    const value = input.request.value;
+    const at = new Date('2026-07-06T00:00:00.000Z');
+    const row: KpiObservationRow = {
+      id: this.nextId++,
+      fundId: input.fundId,
+      portfolioCompanyId: input.request.portfolioCompanyId,
+      metric: input.request.metric,
+      periodStart: input.request.periodStart,
+      periodEnd: input.request.periodEnd,
+      basis: input.request.basis,
+      valueKind: KPI_METRIC_VALUE_KIND[input.request.metric],
+      valueAmount:
+        value.valueKind === 'money'
+          ? value.amountUsd
+          : value.valueKind === 'number'
+            ? value.number
+            : null,
+      valueDate: value.valueKind === 'date' ? value.date : null,
+      valueText: value.valueKind === 'text' ? value.text : null,
+      companyKpiLabel: input.request.companyKpiLabel ?? null,
+      source: input.source,
+      sourceLabel: input.request.sourceLabel ?? null,
+      comment: input.request.comment ?? null,
+      submittedAt: new Date(input.request.submittedAt),
+      reviewStatus: 'pending',
+      reviewComment: null,
+      reviewedBy: null,
+      reviewedAt: null,
+      version: 1,
+      idempotencyKey: input.idempotencyKey,
+      requestHash,
+      createdBy: input.actorId,
+      createdAt: at,
+      updatedAt: at,
+    };
+    this.rows.set(key, { row, requestHash });
+    return { row, replayed: false };
+  }
+}
+
+function input(overrides: Partial<CreateKpiObservationInput> = {}): CreateKpiObservationInput {
+  return {
+    fundId: 1,
+    request: REQUEST,
+    source: 'manual',
+    actorId: 7,
+    idempotencyKey: 'kpi-1',
+    ...overrides,
+  };
+}
+
+describe('KPI observation service', () => {
+  it('creates then replays the same strict public response', async () => {
+    const ports = new FakePorts();
+    const created = await createKpiObservationWithPorts(ports, input());
+    const replay = await createKpiObservationWithPorts(ports, input());
+
+    expect(created.replayed).toBe(false);
+    expect(replay).toEqual({ ...created, replayed: true });
+    expect(ports.rows.size).toBe(1);
+    expect(Object.keys(created.observation)).not.toContain('idempotencyKey');
+    expect(Object.keys(created.observation)).not.toContain('requestHash');
+    expect(created.observation.reviewStatus).toBe('pending');
+    expect(created.observation.version).toBe(1);
+  });
+
+  it('rejects a same-key replay that carries a different request', async () => {
+    const ports = new FakePorts();
+    await createKpiObservationWithPorts(ports, input());
+
+    await expect(
+      createKpiObservationWithPorts(
+        ports,
+        input({ request: { ...REQUEST, value: { valueKind: 'money', amountUsd: '9.000000' } } })
+      )
+    ).rejects.toBeInstanceOf(IdempotentCommandError);
+  });
+
+  it('keeps the actor out of the idempotency preimage', async () => {
+    const ports = new FakePorts();
+    const created = await createKpiObservationWithPorts(ports, input({ actorId: 7 }));
+    const replay = await createKpiObservationWithPorts(ports, input({ actorId: 99 }));
+
+    expect(replay.replayed).toBe(true);
+    expect(replay.observation).toEqual(created.observation);
+  });
+
+  it('refuses a company that belongs to another fund', async () => {
+    const ports = new FakePorts();
+    await expect(createKpiObservationWithPorts(ports, input({ fundId: 2 }))).rejects.toMatchObject({
+      statusCode: 404,
+      code: 'PORTFOLIO_COMPANY_NOT_FOUND',
+    });
+  });
+
+  it('refuses a metric/value mismatch before touching persistence', async () => {
+    const ports = new FakePorts();
+    await expect(
+      createKpiObservationWithPorts(ports, {
+        ...input(),
+        request: {
+          ...REQUEST,
+          value: { valueKind: 'text', text: 'two million' },
+        } as KpiObservationCreateRequest,
+      })
+    ).rejects.toMatchObject({ statusCode: 400, code: 'INVALID_KPI_OBSERVATION_SHAPE' });
+    expect(ports.rows.size).toBe(0);
+  });
+
+  it('pads a short stored numeric back to the six-decimal contract boundary', () => {
+    const at = new Date('2026-07-06T00:00:00.000Z');
+    const observation = toKpiObservationContract({
+      id: 1,
+      fundId: 1,
+      portfolioCompanyId: 4,
+      metric: 'runway_months',
+      periodStart: '2026-04-01',
+      periodEnd: '2026-06-30',
+      basis: 'projected',
+      valueKind: 'number',
+      valueAmount: '14.5',
+      valueDate: null,
+      valueText: null,
+      companyKpiLabel: null,
+      source: 'csv_import',
+      sourceLabel: null,
+      comment: null,
+      submittedAt: at,
+      reviewStatus: 'pending',
+      reviewComment: null,
+      reviewedBy: null,
+      reviewedAt: null,
+      version: 1,
+      idempotencyKey: 'k',
+      requestHash: 'h',
+      createdBy: null,
+      createdAt: at,
+      updatedAt: at,
+    });
+
+    expect(observation.value).toEqual({ valueKind: 'number', number: '14.500000' });
+  });
+
+  it('refuses to serve a row whose value columns contradict its value kind', () => {
+    const at = new Date('2026-07-06T00:00:00.000Z');
+    expect(() =>
+      toKpiObservationContract({
+        id: 1,
+        fundId: 1,
+        portfolioCompanyId: 4,
+        metric: 'revenue_arr',
+        periodStart: '2026-04-01',
+        periodEnd: '2026-06-30',
+        basis: 'actual',
+        valueKind: 'money',
+        valueAmount: null,
+        valueDate: null,
+        valueText: null,
+        companyKpiLabel: null,
+        source: 'manual',
+        sourceLabel: null,
+        comment: null,
+        submittedAt: at,
+        reviewStatus: 'pending',
+        reviewComment: null,
+        reviewedBy: null,
+        reviewedAt: null,
+        version: 1,
+        idempotencyKey: 'k',
+        requestHash: 'h',
+        createdBy: null,
+        createdAt: at,
+        updatedAt: at,
+      })
+    ).toThrow(/inconsistent/i);
+  });
+});

--- a/tests/unit/source/kpi-observation-boundary.test.ts
+++ b/tests/unit/source/kpi-observation-boundary.test.ts
@@ -1,0 +1,68 @@
+import { readFile } from 'node:fs/promises';
+
+import { describe, expect, it } from 'vitest';
+
+import { API_ROUTE_POLICY_REGISTRY } from '../../../server/route-policy/api-route-policy-registry';
+
+/**
+ * Ruling GR2-4a scopes v1 KPI collection to internal, CSV-first entry: no
+ * company-facing request form, no recipient, no send, no share, and no export.
+ * This test keeps that boundary from eroding one convenience endpoint at a time.
+ */
+/** Comments say what the boundary is; only executable code can breach it. */
+function withoutComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+}
+
+describe('KPI collection internal-only boundary', () => {
+  it('exposes no export, share, send, or recipient surface', async () => {
+    const [routeSource, serviceSource, csvSource] = await Promise.all([
+      readFile('server/routes/kpi-observations.ts', 'utf8'),
+      readFile('server/services/kpi/kpi-observation-service.ts', 'utf8'),
+      readFile('server/services/kpi/kpi-observation-csv.ts', 'utf8'),
+    ]);
+
+    for (const source of [routeSource, serviceSource, csvSource]) {
+      expect(withoutComments(source)).not.toMatch(
+        /\b(?:recipient|mailer|sendEmail|shareSnapshot)\b/i
+      );
+    }
+    expect(routeSource).not.toMatch(/router\.(?:get|post|put|patch|delete)\(\s*'[^']*\/export/i);
+    expect(routeSource).not.toMatch(/router\.(?:get|post|put|patch|delete)\(\s*'[^']*\/share/i);
+    expect(routeSource).not.toMatch(/router\.(?:get|post|put|patch|delete)\(\s*'[^']*\/requests/i);
+    expect(routeSource).not.toMatch(/text\/csv|attachment;/i);
+  });
+
+  it('never deletes a collected observation', async () => {
+    const [routeSource, serviceSource] = await Promise.all([
+      readFile('server/routes/kpi-observations.ts', 'utf8'),
+      readFile('server/services/kpi/kpi-observation-service.ts', 'utf8'),
+    ]);
+
+    expect(routeSource).not.toMatch(/router\.delete\(/);
+    expect(serviceSource).not.toMatch(/export\s+(?:async\s+)?function\s+delete/);
+    expect(serviceSource).not.toMatch(/\.delete\(/);
+  });
+
+  it('classifies every KPI route as internal and not exportable', () => {
+    const kpiEntries = API_ROUTE_POLICY_REGISTRY.filter((entry) =>
+      entry.path.includes('/kpi-observations')
+    );
+
+    expect(kpiEntries).toHaveLength(5);
+    for (const entry of kpiEntries) {
+      expect(entry.exportPolicy).toBe('not_exportable');
+      expect(entry.apiAuthBoundary).toBe('require_auth_and_fund_access');
+      expect(entry.fundScopeMode).toBe('route_param_fund_id');
+      expect(entry.financialSurface).toBe('portfolio_management');
+    }
+  });
+
+  it('reuses the one shared CSV tokenizer instead of adding a parser', async () => {
+    const csvSource = await readFile('server/services/kpi/kpi-observation-csv.ts', 'utf8');
+
+    expect(csvSource).toContain("from '../../lib/csv-tokenizer'");
+    expect(csvSource).not.toMatch(/require\(['"]csv-parse|from ['"]csv-parse/);
+    expect(csvSource).not.toMatch(/function\s+\w*(?:splitCsv|tokenize)\w*\s*\(/i);
+  });
+});


### PR DESCRIPTION
Closes #1300 (ruling GR2-4a).

Adds the backend-only, CSV-first KPI observation surface:

- `kpi-observation/1.0.0` contract with a closed metric-to-value-kind map. Money and non-money numerics cross the wire as fixed 6-decimal strings; `source` is server-decided.
- `kpi_observations` table with dedicated columns for metric, period, actual/projected basis, typed value, source, submission date, reviewer status, and comment. No structured KPI data is nested into JSONB.
- Additive, replay-safe migration `0049_kpi_observations.sql`, journal index 50, and production-schema manifest `26-kpi-observations.json` with order 26.
- Internal-only routes registered through the server manifest, policy registry, and `mountCommonRoutes`, with database-backed idempotent creation and If-Match optimistic locking for review.
- CSV import on the existing shared tokenizer. Batch-level structural faults reject the batch; row-level faults reject only that row.
- Real PostgreSQL persistence coverage for create, accept, reread, raw-row verification, and stale-version compare-and-set behavior.

Scope is intentionally backend-only. This PR contains zero `client/` and zero `msw/` changes. `/kpi-manager` and `/kpi-submission` remain in `ARCHIVED_PLACEHOLDER_ROUTES`; no user-reachable surface is activated.

## Contract relationship

`kpi-observation/1.0.0` adapts alongside existing KPI contracts; it supersedes nothing. `kpi-selector.contract.ts` and `kpi-raw-facts.contract.ts` remain unchanged and are not deprecated. Existing contracts represent fund-level derived KPI reads; this contract represents company-level, per-metric, per-period write-and-review observations. The new contract references neither `KPIResponseSchema` nor `KPIRawFactsResponseSchema`.

## Persistence proof

Prior route and service tests were mock-backed. `tests/integration/kpi/kpi-observation-persistence.pg.test.ts` exercises the real service and database across separate connections, then verifies both mapped contract output and the raw row. Its second case proves stale `expectedVersion` returns null without mutating the accepted row.

## Deferred / CI authority

Local Docker and `TEST_DATABASE_URL` are unavailable, so PostgreSQL/Testcontainers runtime coverage is deferred to exact-head CI. No `db:push` or `db:migrate` was run. The schema change causes the full Testcontainers workflow to run automatically before merge.
