### PR TITLE
fix(deps): bump brace-expansion override to 5.0.9 for GHSA-rgw5-rvv9-x895

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11251,9 +11251,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/package.json
+++ b/package.json
@@ -259,7 +259,7 @@
     "uuid": "^11.1.1",
     "ws": "^8.21.0",
     "@opentelemetry/core": "2.8.0",
-    "brace-expansion": "5.0.8"
+    "brace-expansion": "5.0.9"
   },
   "devDependencies": {
     "@axe-core/playwright": "4.12.1",


### PR DESCRIPTION
## Description

Restores the red `CI Unified` gate on `main`. The `Production dependency audit` step (`npm audit --omit=dev --audit-level=high`) began failing on the newest main run (commit `a0605aa`, 17:27 UTC) because the high-severity brace-expansion DoS advisory [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) (affects 4.0.0-5.0.8) was published against the repo's exact `5.0.8` override pin. The failure is advisory churn, not a regression from #1319: the 17:15 UTC run on the same dependency tree was green.

This bumps the existing `overrides["brace-expansion"]` pin from `5.0.8` to the patched `5.0.9` release and refreshes the lockfile.

## Slice Summary

### Owned Files

- `package.json` (one-line override bump)
- `package-lock.json` (lockfile refresh for the override)

### Explicit Non-Goals

- No dependency additions or removals; no other version changes
- Does not touch the open major bumps (#1330 eslint 10, #1331 openai 7)

### Schema Or Contract Impact

none

### Rollback Path

Revert the commit; the override returns to `5.0.8` (which will re-fail the audit gate until the advisory is otherwise resolved).

### Commands Actually Run

- `npm audit --omit=dev --audit-level=high` (before: 1 high; after: 0 vulnerabilities)
- `npm install` (lockfile refresh)
- `npm run doctor:quick` (PASS)

### Docs Or Guardrail Impact

none

### Archived Active Docs

none

## Required Slice Checklist

- [x] Owned files are listed explicitly
- [x] Explicit non-goals are listed
- [x] Schema or contract impact is called out
- [x] Rollback path is documented
- [x] Commands actually run are listed
- [x] Docs or guardrail artifacts changed, with reason (none)
- [x] Any active doc archived is named, with destination path (none)

## Type of Change

- [x] Security fix

## Related Issues

Unblocks the merge train for #1332, #1323, #1322, #1333, #1326 (their next CI runs would hit the same audit failure).

## Additional Notes

`brace-expansion` is a transitive dependency (via `minimatch`/`glob` under `exceljs`, `swagger-jsdoc`, etc.); the patch release only tightens the CVE-2026-14257 mitigation, so runtime risk is minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hc5pPVtQHMPJ7gYo5ScYj9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hc5pPVtQHMPJ7gYo5ScYj9)_