### PR TITLE
fix(deploy): install Vite build dependencies on Vercel

### DIFF
--- a/api/[...slug].ts
+++ b/api/[...slug].ts
@@ -9,29 +9,31 @@ import type { Express } from 'express';
 // Lazy-load the app to handle potential ESM/CJS issues
 let app: Express | undefined;
 
-async function getApp() {
-  if (!app) {
-    // Import the pre-bundled server app (api/_app.generated.mjs), produced by
-    // scripts/build-vercel-api.mjs during the Vercel build. We bundle because
-    // the raw server source uses extensionless relative imports and @shared/*
-    // aliases that fail under Node's ESM resolver when @vercel/node ships the
-    // files individually; esbuild resolves both at bundle time.
-    const appModule = await import('./_app.generated.mjs');
-    const makeApp = appModule.makeApp ?? appModule.default;
+async function getApp(): Promise<Express> {
+  if (app) return app;
 
-    if (!makeApp) {
-      throw new Error('Could not find makeApp export from _app.generated.mjs');
-    }
+  // Import the pre-bundled server app (api/_app.generated.mjs), produced by
+  // scripts/build-vercel-api.mjs during the Vercel build. We bundle because
+  // the raw server source uses extensionless relative imports and @shared/*
+  // aliases that fail under Node's ESM resolver when @vercel/node ships the
+  // files individually; esbuild resolves both at bundle time.
+  const appModule = await import('./_app.generated.mjs');
+  const makeApp = appModule.makeApp ?? appModule.default;
 
-    app = makeApp();
-
-    // Additional production optimizations for Vercel
-    if (process.env['VERCEL']) {
-      app.disable('x-powered-by');
-      app.set('trust proxy', 1);
-    }
+  if (!makeApp) {
+    throw new Error('Could not find makeApp export from _app.generated.mjs');
   }
-  return app;
+
+  const initializedApp = makeApp();
+
+  // Additional production optimizations for Vercel
+  if (process.env['VERCEL']) {
+    initializedApp.disable('x-powered-by');
+    initializedApp.set('trust proxy', 1);
+  }
+
+  app = initializedApp;
+  return initializedApp;
 }
 
 /**

--- a/api/_app.generated.d.mts
+++ b/api/_app.generated.d.mts
@@ -1,0 +1,6 @@
+import type { Express } from 'express';
+
+export declare function makeApp(): Express;
+
+declare const defaultExport: typeof makeApp;
+export default defaultExport;

--- a/audit/surface-contract-matrix/g1-review.json
+++ b/audit/surface-contract-matrix/g1-review.json
@@ -6,7 +6,7 @@
     ".dockerignore": "5ec5fd9ba5605180f60c7ebdfbafa37bcbee0e743d16504c79c51b0b088dfba4",
     ".vercelignore": "e5ecda625e91bc51d1bd68adae5403a46546709d580626b21a39be07267940da",
     "api/_types.ts": "a987351f31d859cc233189163fc1ac24eb7ebd05c8dac0b46772c55295dbd2d6",
-    "api/[...slug].ts": "2b45faee7726ceca4df08b8bed599ba2713697255411f594df7ef067db28000e",
+    "api/[...slug].ts": "7672947630aaedb829c34f3150d16aa129bc97947c38f8758ed3a8a7ad0f0098",
     "api/telemetry/wizard.ts": "055e2fb386041bc22fea7ce410e4b27f536a4cfab204da13804ca6c270cf901d",
     "audit/surface-contract-matrix/boot-proofs.json": "a1c0dc75af88e52f96aab8e082d71be2eb08e12df520738ea0824679981505aa",
     "audit/surface-contract-matrix/matrix-schema.mjs": "b7f61213bf8e1f0db8d5bd28c15c1867f8909b5a68bfacf0871d1f42c422b3ba",

--- a/audit/surface-contract-matrix/g1-review.json
+++ b/audit/surface-contract-matrix/g1-review.json
@@ -150,7 +150,7 @@
     "shared/routes/api-runtime-specific-manifest.ts": "0daa50b7d7d569e6068a8e6998e57b3a6b3c76effa5a3834d53302c60b566805",
     "shared/routes/app-route-definitions.ts": "72ac7651f290aea940432af3ffde06746f8ce7b3b7a198e6ad718d336c673a0b",
     "shared/routes/route-governance-registry.ts": "07c1e15b2f1c343320125eac20ff75e55c6c7f63fa2b1d578aba9eadd8c76928",
-    "vercel.json": "4304014b77ad44d55a09c1349c01dc389bd84f561556dc8fc96a084cc618d491",
+    "vercel.json": "3350f3fa3237c2df1d7f8d08c4dc7c59433e20543e8241fe7d410613c12d8744",
     "vite.config.ts": "44f0745da9cf4aa73c55447b22dc8c5e9dd34bbd06b760899e00908ba08b18ad",
     "workers/cohort-worker.ts": "aa05a747b0a8605eb23264cd2149b0cf737b0f0f4a8d092fa57e0e32c416e187",
     "workers/dlq.ts": "4ab16ca234a24130b20abfcc78cdf9b6a159f5104fb682cc390adccbc0acedae",

--- a/audit/surface-contract-matrix/matrix.json
+++ b/audit/surface-contract-matrix/matrix.json
@@ -99127,7 +99127,7 @@
       ".dockerignore": "5ec5fd9ba5605180f60c7ebdfbafa37bcbee0e743d16504c79c51b0b088dfba4",
       ".vercelignore": "e5ecda625e91bc51d1bd68adae5403a46546709d580626b21a39be07267940da",
       "api/_types.ts": "a987351f31d859cc233189163fc1ac24eb7ebd05c8dac0b46772c55295dbd2d6",
-      "api/[...slug].ts": "2b45faee7726ceca4df08b8bed599ba2713697255411f594df7ef067db28000e",
+      "api/[...slug].ts": "7672947630aaedb829c34f3150d16aa129bc97947c38f8758ed3a8a7ad0f0098",
       "api/telemetry/wizard.ts": "055e2fb386041bc22fea7ce410e4b27f536a4cfab204da13804ca6c270cf901d",
       "audit/surface-contract-matrix/boot-proofs.json": "a1c0dc75af88e52f96aab8e082d71be2eb08e12df520738ea0824679981505aa",
       "audit/surface-contract-matrix/matrix-schema.mjs": "b7f61213bf8e1f0db8d5bd28c15c1867f8909b5a68bfacf0871d1f42c422b3ba",

--- a/audit/surface-contract-matrix/matrix.json
+++ b/audit/surface-contract-matrix/matrix.json
@@ -99271,7 +99271,7 @@
       "shared/routes/api-runtime-specific-manifest.ts": "0daa50b7d7d569e6068a8e6998e57b3a6b3c76effa5a3834d53302c60b566805",
       "shared/routes/app-route-definitions.ts": "72ac7651f290aea940432af3ffde06746f8ce7b3b7a198e6ad718d336c673a0b",
       "shared/routes/route-governance-registry.ts": "07c1e15b2f1c343320125eac20ff75e55c6c7f63fa2b1d578aba9eadd8c76928",
-      "vercel.json": "4304014b77ad44d55a09c1349c01dc389bd84f561556dc8fc96a084cc618d491",
+        "vercel.json": "3350f3fa3237c2df1d7f8d08c4dc7c59433e20543e8241fe7d410613c12d8744",
       "vite.config.ts": "44f0745da9cf4aa73c55447b22dc8c5e9dd34bbd06b760899e00908ba08b18ad",
       "workers/cohort-worker.ts": "aa05a747b0a8605eb23264cd2149b0cf737b0f0f4a8d092fa57e0e32c416e187",
       "workers/dlq.ts": "4ab16ca234a24130b20abfcc78cdf9b6a159f5104fb682cc390adccbc0acedae",

--- a/audit/surface-contract-matrix/source-inventory.json
+++ b/audit/surface-contract-matrix/source-inventory.json
@@ -622,7 +622,7 @@
     "shared/routes/api-runtime-specific-manifest.ts": "0daa50b7d7d569e6068a8e6998e57b3a6b3c76effa5a3834d53302c60b566805",
     "shared/routes/app-route-definitions.ts": "72ac7651f290aea940432af3ffde06746f8ce7b3b7a198e6ad718d336c673a0b",
     "shared/routes/route-governance-registry.ts": "07c1e15b2f1c343320125eac20ff75e55c6c7f63fa2b1d578aba9eadd8c76928",
-    "vercel.json": "4304014b77ad44d55a09c1349c01dc389bd84f561556dc8fc96a084cc618d491",
+    "vercel.json": "3350f3fa3237c2df1d7f8d08c4dc7c59433e20543e8241fe7d410613c12d8744",
     "vite.config.ts": "44f0745da9cf4aa73c55447b22dc8c5e9dd34bbd06b760899e00908ba08b18ad",
     "workers/cohort-worker.ts": "aa05a747b0a8605eb23264cd2149b0cf737b0f0f4a8d092fa57e0e32c416e187",
     "workers/dlq.ts": "4ab16ca234a24130b20abfcc78cdf9b6a159f5104fb682cc390adccbc0acedae",

--- a/audit/surface-contract-matrix/source-inventory.json
+++ b/audit/surface-contract-matrix/source-inventory.json
@@ -478,7 +478,7 @@
     ".dockerignore": "5ec5fd9ba5605180f60c7ebdfbafa37bcbee0e743d16504c79c51b0b088dfba4",
     ".vercelignore": "e5ecda625e91bc51d1bd68adae5403a46546709d580626b21a39be07267940da",
     "api/_types.ts": "a987351f31d859cc233189163fc1ac24eb7ebd05c8dac0b46772c55295dbd2d6",
-    "api/[...slug].ts": "2b45faee7726ceca4df08b8bed599ba2713697255411f594df7ef067db28000e",
+    "api/[...slug].ts": "7672947630aaedb829c34f3150d16aa129bc97947c38f8758ed3a8a7ad0f0098",
     "api/telemetry/wizard.ts": "055e2fb386041bc22fea7ce410e4b27f536a4cfab204da13804ca6c270cf901d",
     "audit/surface-contract-matrix/boot-proofs.json": "a1c0dc75af88e52f96aab8e082d71be2eb08e12df520738ea0824679981505aa",
     "audit/surface-contract-matrix/matrix-schema.mjs": "b7f61213bf8e1f0db8d5bd28c15c1867f8909b5a68bfacf0871d1f42c422b3ba",

--- a/docs/deployment/vercel-setup.md
+++ b/docs/deployment/vercel-setup.md
@@ -39,7 +39,7 @@ NODE_OPTIONS=--max-old-space-size=4096
 
 **Location**: Settings → Build & Development Settings
 
-- **Install Command**: `npm ci` (should match vercel.json)
+- **Install Command**: `npm ci --include=dev` (should match vercel.json)
 - **Build Command**: `npm run build` (should match vercel.json)
 - **Output Directory**: Leave empty (uses Vercel Build Output API)
 - **Framework Preset**: None/Other
@@ -62,7 +62,8 @@ If you want to skip PR preview builds:
    - [ ] Set Node.js version to `20.x` (Settings → General)
    - [ ] Add `NODE_OPTIONS=--max-old-space-size=4096` environment variable
          (Settings → Environment Variables)
-   - [ ] Verify build commands match vercel.json: `npm ci` and `npm run build`
+   - [ ] Verify build commands match vercel.json: `npm ci --include=dev` and
+         `npm run build`
 
 2. **Deploy with Clear Cache:**
    - [ ] Trigger new deployment with "Clear build cache" enabled

--- a/tests/regressions/ci-fail-closed.test.ts
+++ b/tests/regressions/ci-fail-closed.test.ts
@@ -3634,8 +3634,9 @@ describe('required CI fails closed', () => {
 
     const vercelConfig = JSON.parse(
       await readFile(path.join(process.cwd(), 'vercel.json'), 'utf8')
-    ) as { github?: { autoAlias?: boolean } };
+    ) as { github?: { autoAlias?: boolean }; installCommand?: string };
     expect(vercelConfig.github?.autoAlias).toBe(false);
+    expect(vercelConfig.installCommand).toBe('npm ci --include=dev');
 
     const automationSurfaces = await collectAutomationSurfaces();
     expect(automationSurfaces.some((surface) => surface.id.startsWith('workflow:'))).toBe(true);

--- a/tests/unit/scripts/build-vercel-api.test.mjs
+++ b/tests/unit/scripts/build-vercel-api.test.mjs
@@ -52,6 +52,32 @@ describe('build-vercel-api', () => {
     expect(bundleState.hasRequire2).toBe(false);
     expect(bundleState.hasRequire).toBe(false);
     expect(bundleState.mentionsNeonHttp).toBe(true);
+
+    const typecheck = spawnSync(
+      process.execPath,
+      [
+        resolve(root, 'node_modules/typescript/bin/tsc'),
+        '--noEmit',
+        '--strict',
+        '--skipLibCheck',
+        '--target',
+        'ES2022',
+        '--module',
+        'ESNext',
+        '--moduleResolution',
+        'Bundler',
+        '--types',
+        'node',
+        resolve(root, 'api/[...slug].ts'),
+      ],
+      {
+        cwd: root,
+        encoding: 'utf8',
+        timeout: 15000,
+      }
+    );
+
+    expect(typecheck.status, typecheck.stderr || typecheck.stdout).toBe(0);
   }, 60000);
 
   it('imports the built Vercel app without blocking on async module initialization', () => {

--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,7 @@
   "version": 2,
   "buildCommand": "npm run build:web && node scripts/build-vercel-api.mjs",
   "outputDirectory": "dist/public",
-  "installCommand": "npm ci",
+  "installCommand": "npm ci --include=dev",
   "framework": "vite",
 
   "functions": {


### PR DESCRIPTION
## Root cause
Vercel preview inherited production npm behavior, so npm ci omitted devDependencies. Vite and config plugins were absent; npx fetched Vite 8.2.1 and config loading failed.

## Fix
- force npm ci --include=dev in vercel.json
- guard install command in deployment regression coverage
- sync surface-matrix source fingerprints
- update active Vercel setup guide

## Verification
- production-mode clean install resolved pinned Vite 6.4.3 and all config plugins
- production-mode SPA build passed
- Vercel API bundle generation passed
- targeted deployment and surface-matrix tests passed
- TypeScript baseline, lint/guardrails, and docs links passed

Follow-up to merged PR #1348.