### PR TITLE
fix(ci): update Hadolint and satisfy Dockerfile rules

### DIFF
--- a/.github/workflows/dockerfile-lint.yml
+++ b/.github/workflows/dockerfile-lint.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Run Hadolint
-        uses: hadolint/hadolint-action@v3.3.0
+        uses: hadolint/hadolint-action@v3.4.0
         with:
           dockerfile: Dockerfile
           format: sarif

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,10 +53,10 @@ COPY --from=build --chown=nextjs:nodejs /app/package*.json ./
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD node -e "require('http').get('http://localhost:3000/health', (res) => process.exit(res.statusCode === 200 ? 0 : 1))"
+    CMD ["node", "-e", "require('http').get('http://localhost:3000/health', (res) => process.exit(res.statusCode === 200 ? 0 : 1))"]
 
 # Security: switch to non-root user
-USER nextjs
+USER 1001:1001
 
 EXPOSE 3000
 

--- a/audit/surface-contract-matrix/g1-review.json
+++ b/audit/surface-contract-matrix/g1-review.json
@@ -30,7 +30,7 @@
     "client/src/pages/v2/portfolio.tsx": "442e18560a3ad25c8c461ef37cf748b05d494c7f2f302f170852957240b8d4c2",
     "client/src/pages/v2/scenarios.tsx": "f783378ab9ef3b1783eca2ff30087788ddeca81ea558433098c7f6ad7063c187",
     "client/src/pages/v2/today.tsx": "fb08a56d3bce71348145f524507d6ab1e9df84adefae7ac5e8feb2ecb8393116",
-    "Dockerfile": "96d57b64ade98aa931861c199020e4b5fb4e5745e53124e11636ec3cbbad378f",
+    "Dockerfile": "8f1a97cd1fa18373606e32f13352998c6c9ac00be55dcfd1c44c593ff9c20931",
     "Dockerfile.railway": "ca8800e99aabcc675fd6838619611f8dedaeec3530b3366b1a3652bd03d6e681",
     "Dockerfile.simple": "bfcbd376504c160cac0e5200b46db48579d65e857eba61a558fdc196919c34b7",
     "Dockerfile.worker": "bade9f62fae8feddf7a63b75a30f5550f510bd8bcb72ee3cb66fb070cd44a86b",
@@ -16206,7 +16206,7 @@
         "candidate_path": "Dockerfile",
         "disposition": "product-surface",
         "decision_status": "approved",
-        "fingerprint": "ca8a56775447ca16f0b7edc8e4b8dbe682ff0b265e31c7becf3f4ac9ae0db3d4",
+        "fingerprint": "f557f7dd689a505a7c989723effe860d24d1fcd39f9e7a143d135bcd057a7dc8",
         "decision_evidence": "Individually reviewed dockerfile-root at Dockerfile; discovery evidence [\"Dockerfile:56\",\"Dockerfile:65\"]; classification product-surface; extraction strategy container-entrypoint-evidence."
       },
       "dockerfile-railway": {

--- a/audit/surface-contract-matrix/listener-dispositions.json
+++ b/audit/surface-contract-matrix/listener-dispositions.json
@@ -2,7 +2,7 @@
   {
     "candidate_path": "Dockerfile",
     "listener_id": "dockerfile-root",
-    "fingerprint": "ca8a56775447ca16f0b7edc8e4b8dbe682ff0b265e31c7becf3f4ac9ae0db3d4",
+    "fingerprint": "f557f7dd689a505a7c989723effe860d24d1fcd39f9e7a143d135bcd057a7dc8",
     "evidence": [
       "Dockerfile:56",
       "Dockerfile:65"

--- a/audit/surface-contract-matrix/matrix.json
+++ b/audit/surface-contract-matrix/matrix.json
@@ -99151,7 +99151,7 @@
       "client/src/pages/v2/portfolio.tsx": "442e18560a3ad25c8c461ef37cf748b05d494c7f2f302f170852957240b8d4c2",
       "client/src/pages/v2/scenarios.tsx": "f783378ab9ef3b1783eca2ff30087788ddeca81ea558433098c7f6ad7063c187",
       "client/src/pages/v2/today.tsx": "fb08a56d3bce71348145f524507d6ab1e9df84adefae7ac5e8feb2ecb8393116",
-      "Dockerfile": "96d57b64ade98aa931861c199020e4b5fb4e5745e53124e11636ec3cbbad378f",
+      "Dockerfile": "8f1a97cd1fa18373606e32f13352998c6c9ac00be55dcfd1c44c593ff9c20931",
       "Dockerfile.railway": "ca8800e99aabcc675fd6838619611f8dedaeec3530b3366b1a3652bd03d6e681",
       "Dockerfile.simple": "bfcbd376504c160cac0e5200b46db48579d65e857eba61a558fdc196919c34b7",
       "Dockerfile.worker": "bade9f62fae8feddf7a63b75a30f5550f510bd8bcb72ee3cb66fb070cd44a86b",

--- a/audit/surface-contract-matrix/source-inventory.json
+++ b/audit/surface-contract-matrix/source-inventory.json
@@ -502,7 +502,7 @@
     "client/src/pages/v2/portfolio.tsx": "442e18560a3ad25c8c461ef37cf748b05d494c7f2f302f170852957240b8d4c2",
     "client/src/pages/v2/scenarios.tsx": "f783378ab9ef3b1783eca2ff30087788ddeca81ea558433098c7f6ad7063c187",
     "client/src/pages/v2/today.tsx": "fb08a56d3bce71348145f524507d6ab1e9df84adefae7ac5e8feb2ecb8393116",
-    "Dockerfile": "96d57b64ade98aa931861c199020e4b5fb4e5745e53124e11636ec3cbbad378f",
+    "Dockerfile": "8f1a97cd1fa18373606e32f13352998c6c9ac00be55dcfd1c44c593ff9c20931",
     "Dockerfile.railway": "ca8800e99aabcc675fd6838619611f8dedaeec3530b3366b1a3652bd03d6e681",
     "Dockerfile.simple": "bfcbd376504c160cac0e5200b46db48579d65e857eba61a558fdc196919c34b7",
     "Dockerfile.worker": "bade9f62fae8feddf7a63b75a30f5550f510bd8bcb72ee3cb66fb070cd44a86b",


### PR DESCRIPTION
## Summary

- update `hadolint/hadolint-action` from v3.3.0 to v3.4.0
- use JSON exec form for `HEALTHCHECK`
- use numeric UID:GID for final runtime user

Replaces closed PR #1336.

## Verification

- Hadolint v2.15.0 with repository config: pass, zero findings
- Hadolint v2.15.0 without config: pass, zero findings
- `docker build --target deps -q .`: pass
- workflow/source contract check: pass
- `git diff --check`: pass

No permissions or SARIF upload behavior changed.