### PR TITLE
test(integration): align fund draft creator identity

### DIFF
--- a/tests/integration/fund-draft-round-trip.test.ts
+++ b/tests/integration/fund-draft-round-trip.test.ts
@@ -5,22 +5,53 @@
  * Also validates upsert: second PUT updates instead of creating duplicate.
  */
 
-import { describe, it, expect, beforeAll } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { randomUUID } from 'node:crypto';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import express from 'express';
 import request from 'supertest';
+import { users } from '@shared/schema';
+import { db } from '../../server/db';
 import { validDraftPayload, minimalDraftPayload } from '../fixtures/fund-contract-v1-fixtures';
 import { makeJwt } from '../utils/integrationAuth';
 
 let app: express.Express;
-const partnerToken = (fundIds: number[] = []): string =>
-  makeJwt({
-    userId: '1',
+const fixture = { partnerUserId: undefined as number | undefined };
+const MODULE_RUN_ID = randomUUID();
+const PARTNER_USERNAME = `integration-fund-draft-round-trip-${MODULE_RUN_ID}`;
+const PARTNER_PASSWORD = 'test-only-password';
+const idempotencyKey = (operation: string): string => `draft-rt-${MODULE_RUN_ID}-${operation}`;
+
+const partnerToken = (fundIds: number[] = []): string => {
+  if (fixture.partnerUserId === undefined) {
+    throw new Error('Integration-test partner user is not provisioned');
+  }
+
+  return makeJwt({
+    userId: String(fixture.partnerUserId),
     email: 'draft-partner@example.com',
     role: 'partner',
     fundIds,
   });
+};
 
 beforeAll(async () => {
+  const [partnerUser] = await db
+    .insert(users)
+    .values({
+      username: PARTNER_USERNAME,
+      password: PARTNER_PASSWORD,
+      role: 'partner',
+      isActive: true,
+      isReleaseCanaryPrincipal: false,
+    })
+    .returning({ id: users.id });
+
+  if (!partnerUser || !Number.isInteger(partnerUser.id) || partnerUser.id <= 0) {
+    throw new Error('Failed to provision integration-test partner user');
+  }
+  Object.assign(fixture, { partnerUserId: partnerUser.id });
+
   app = express();
   app.use(express.json({ limit: '1mb' }));
 
@@ -36,13 +67,20 @@ beforeAll(async () => {
   registerFundConfigRoutes(app);
 });
 
+afterAll(async () => {
+  if (fixture.partnerUserId === undefined) return;
+
+  await db.delete(users).where(eq(users.id, fixture.partnerUserId));
+  Object.assign(fixture, { partnerUserId: undefined });
+});
+
 describe('PUT /api/funds/:id/draft round-trip', () => {
   it('saves and retrieves a full draft payload', async () => {
     // First create a fund to get a valid ID
     const createRes = await request(app)
       .post('/api/funds')
       .set('Authorization', `Bearer ${partnerToken()}`)
-      .set('Idempotency-Key', 'draft-rt-create-01')
+      .set('Idempotency-Key', idempotencyKey('create-01'))
       .send({ name: 'Draft RT Fund', size: 50_000_000 });
 
     expect(createRes.status).toBe(201);
@@ -72,7 +110,7 @@ describe('PUT /api/funds/:id/draft round-trip', () => {
     const createRes = await request(app)
       .post('/api/funds')
       .set('Authorization', `Bearer ${partnerToken()}`)
-      .set('Idempotency-Key', 'draft-rt-upsert-01')
+      .set('Idempotency-Key', idempotencyKey('upsert-01'))
       .send({ name: 'Upsert Fund', size: 25_000_000 });
 
     expect(createRes.status).toBe(201);
@@ -105,7 +143,7 @@ describe('PUT /api/funds/:id/draft round-trip', () => {
     const createRes = await request(app)
       .post('/api/funds')
       .set('Authorization', `Bearer ${partnerToken()}`)
-      .set('Idempotency-Key', 'draft-rt-strict-01')
+      .set('Idempotency-Key', idempotencyKey('strict-01'))
       .send({ name: 'Strict Fund', size: 10_000_000 });
 
     expect(createRes.status).toBe(201);

--- a/tests/integration/fund-draft-round-trip.test.ts
+++ b/tests/integration/fund-draft-round-trip.test.ts
@@ -14,7 +14,7 @@ import { makeJwt } from '../utils/integrationAuth';
 let app: express.Express;
 const partnerToken = (fundIds: number[] = []): string =>
   makeJwt({
-    userId: 'draft-partner',
+    userId: '1',
     email: 'draft-partner@example.com',
     role: 'partner',
     fundIds,


### PR DESCRIPTION
## Summary

- Replace stale nonnumeric draft-test actor with a database-hermetic partner fixture.
- Sign JWTs with the fixture's returned positive numeric user ID.
- Scope usernames and idempotency keys to one module run; delete only the owned actor row.
- Keep production creator identity parsing, JWT defaults, integration configuration, and workflows unchanged.

## Fresh-schema failure and repair

The initial literal numeric actor passed a warmed local database but failed an empty CI-style schema: three fund creates returned 500 because users.id=1 did not exist and user_fund_grants rejected the foreign key. The final fixture inserts its own non-canary partner and cleans it afterward.

## Validation

- Fresh focused integration: 4/4 passed twice
- Creator credential regressions: 10/10 passed
- Fresh-schema full integration with CLI isolation: 64 files, 771 tests passed
- Unit gate: 988 files, 12,140 tests passed
- Target ESLint and TypeScript: passed
- Fixture cleanup query: zero matching actor rows
- Matrix exclusion and git diff check: passed
- Fresh Sol Advisor final review: ship

CLI isolation is supporting causal proof only; checked-in integration configuration remains unchanged in this PR.

## Scope and sequencing

One tracked file changes: tests/integration/fund-draft-round-trip.test.ts. No provider mutation, production code, CI workflow, or matrix regeneration.

After this PR merges, exact merged-main full integration and CI Gate Status must pass. The separate config-only isolation repair starts only from that green main SHA. Task 2 remains blocked until both merged-main gates pass.