### PR TITLE
docs: reconcile F1.3/F1.4 fee economics plans

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -113,9 +113,18 @@ return
 **Unused Fee**: A fee charged on undrawn credit facility capacity. _Avoid_:
 Management fee
 
-**Management Fee Waiver**: A reduction or waiver of management fees used as part
-of fund economics, commonly alongside cashless GP commitment treatment. _Avoid_:
-Cashless GP commitment
+**Fee Profile**: Versionable fee terms used to calculate fee outflows. _Avoid_:
+Fee basis
+
+**LP Class**: An investor grouping to which fee terms bind. _Avoid_: Partner
+class
+
+**Fee Basis**: The capital population against which a fee rate applies. _Avoid_:
+Fee profile
+
+**Management Fee Waiver**: Reduced fee rate for a named **LP Class**; not a
+shared-fee-basis deduction or proof that waived-fee dollars equal a deemed
+contribution. _Avoid_: Fee-basis deduction
 
 **LP Commitment Percentage**: The percentage of fund commitments attributed to
 limited partners. _Avoid_: Paid-in capital
@@ -123,15 +132,28 @@ limited partners. _Avoid_: Paid-in capital
 **GP Commitment Percentage**: The percentage of fund commitments attributed to
 the general partner. _Avoid_: Carried interest
 
-**GP Cash Commitment**: The portion of the GP commitment contributed in cash.
-_Avoid_: Cashless GP commitment
+**Contractual GP Commitment**: The full ownership/profit-participating GP
+commitment; it determines sizing and ownership but is not itself a cash flow.
+_Avoid_: GP cash contribution
 
-**Cashless GP Commitment**: The portion of the GP commitment credited without a
-cash contribution, commonly associated with management fee waiver economics.
-_Avoid_: Cash balance, cashless exercise
+**GP Cash Contribution**: `Contractual GP Commitment × (1 - fundedFromFeesPct)`;
+the cash portion that enters the cash ledger and cash-only bases. _Avoid_: GP
+deemed contribution
 
-**Cashless GP Contribution Percentage**: The percentage of the GP commitment
-treated as cashless. _Avoid_: Cashless split when the split basis is unclear
+**GP Deemed Contribution**: `Contractual GP Commitment × fundedFromFeesPct`;
+non-cash and excluded from fee, cash, return-of-capital, preferred-return, IRR,
+and clawback bases while retaining ownership and profit participation. _Avoid_:
+GP cash contribution
+
+**fundedFromFeesPct**: Persisted `0..1` ratio only; never proof that waived-fee
+dollars equal a deemed contribution and never a fee-basis deduction. _Avoid_:
+Cashless contribution percentage
+
+**GP Cash Commitment**: Legacy compatibility alias for **GP Cash Contribution**.
+_Avoid_: Canonical domain language
+
+**Cashless GP Commitment**: Legacy compatibility alias for **GP Deemed
+Contribution**. _Avoid_: Canonical domain language
 
 **Fund KPI**: A computed fund-level output metric, such as TVPI, DPI, RVPI, IRR,
 NAV, or investment count. _Avoid_: Company metric
@@ -590,14 +612,18 @@ For Task 16.3 implementation scope and ratification, route to ADR-065 in
   capital is called
 - **LP Commitment Percentage** and **GP Commitment Percentage** allocate
   **Capital Commitments** by partner role
-- **GP Commitment Percentage** can be split into **GP Cash Commitment** and
-  **Cashless GP Commitment**
-- **Cashless GP Contribution Percentage** determines how much of the GP
-  commitment is cashless
-- A **Management Fee Waiver** can be associated with **Cashless GP Commitment**
-  economics
-- **Cashless GP Commitment** is not **Cash in Bank** and is not a cashless
-  security exercise
+- **GP Commitment Percentage** sizes the **Contractual GP Commitment**
+- **Contractual GP Commitment** determines GP ownership and profit participation
+  but is not itself a cash-flow amount
+- **GP Cash Contribution** equals **Contractual GP Commitment** × (1 -
+  **fundedFromFeesPct**) and enters the cash ledger and cash-only bases
+- **GP Deemed Contribution** equals **Contractual GP Commitment** ×
+  **fundedFromFeesPct**; it is non-cash and excluded from fee, cash,
+  return-of-capital, preferred-return, IRR, and clawback bases
+- A **Fee Profile** contains versionable fee terms that bind to an **LP Class**;
+  a **Fee Basis** is the capital population against which its fee rate applies
+- A **Management Fee Waiver** reduces the fee rate for a named **LP Class**; it
+  is not a shared-fee-basis deduction or proof of dollar funding equality
 - A **Fund KPI** is a fund-level output, not a **Company Metric**
 - A **Dual Forecast** compares **Construction Forecast** against **Current
   Forecast**
@@ -720,7 +746,8 @@ For Task 16.3 implementation scope and ratification, route to ADR-065 in
 - The Fund Configuration API source uses `construction` and `current` with
   overlapping descriptions. Resolved: they are the two sides of the **Dual
   Forecast**.
-- The Fund Configuration API source uses `cashless` for **Cashless GP
-  Commitment** treatment, not cash balance or security exercise.
+- The Fund Configuration API source uses `cashless` as a legacy compatibility
+  label for **GP Deemed Contribution** (formerly **Cashless GP Commitment**),
+  not cash balance or security exercise.
 - API fields such as status code, body, internal IDs, visibility flags, and raw
   arrays are implementation/source-data fields, not glossary terms.

--- a/docs/1-plans/F_1.3.0_fee-economics-convergence.plan.md
+++ b/docs/1-plans/F_1.3.0_fee-economics-convergence.plan.md
@@ -1,359 +1,251 @@
-# Fee & Economics Convergence Implementation Plan
+# Fee & Economics Convergence Design and Sequencing Plan
 
-## Overview
+## Authority, boundary, and current gate state
 
-This plan delivers the **post-activation fee/economics convergence** release —
-Phase 3 of the Current-Forecast V2 activation program (items 20–26 of the source
-plan `docs/1-plans/F_1.0.0_current-forecast-activation.plan.md`). It covers:
-FeeProfile truth-case coverage (#1337), fee-engine unification (#1338),
-versioned LP-only fee bases with `feeProfileId` binding (#1321), GP cash +
-fee-funded deemed calls in internal LP economics (#1320), cashless GP
-contribution surfacing (#1318), broadened ModelingWizard routing/persistence
-(#1339), and the narrowed clawback-threshold truth case (#1317).
+This document is design and sequencing authority for the fee and
+internal-economics convergence lane. It preserves repository decisions,
+reconciles stale GitHub issue wording offline, and defines the conditions for
+minting later child implementation plans. It dispatches no product code, schema
+change, migration, test edit, GitHub mutation, or runtime action.
 
-Sibling plans in this release series:
+The governing activation program is
+`docs/1-plans/F_1.2.0_v1.4-release-proof-activation.plan.md`. The
+post-activation construction and other deferred product lanes, including #1022
+and #1023, remain in `docs/1-plans/F_1.4.0_post-activation-epics.plan.md`; this
+plan does not amend them. Repository ADRs remain authoritative unless a reviewed
+superseding ADR lands in the repository. GitHub issue bodies, comments, labels,
+and closures are evidence only; every proposed external text below is offline
+and requires human-in-the-loop (HITL) approval and execution.
 
-- `F_1.0.0_activation-blockers-runtime.plan.md` (Phase 0: #1325, NEW-A,
-  resume/re-arm, #1299-R flag removal, NEW-B runbook, #1172-EXP)
-- `F_1.1.0_wave-h-context-rail-decisions.plan.md` (Phase 1: #1284, #1288, #1289,
-  #1290, #1293, #1283, #1287, ELIG)
-- `F_1.2.0_deployment-soak-activation.plan.md` (Phase 2 ops checklist:
-  #1294–#1299)
-- `F_1.4.0_post-activation-epics.plan.md` (Phase 4 planning only: NEW-D, #1022,
-  #1023, waterfall lane, NEW-C, disposition closes)
+The embedded gate facts below are this plan's self-contained controlling
+negative evidence as of 2026-08-10. The durable gate criteria remain in
+`docs/1-plans/F_1.2.0_v1.4-release-proof-activation.plan.md` and in the GitHub
+URLs embedded in the matrix. `.superpowers/sdd/PLAN (7)/gate-evidence.md` was an
+ephemeral, ignored authoring input only; it is absent from the committed tree
+and has no continuing authority:
 
-**Version policy:** plan versions use a 1.x line decoupled from the package.json
-version (package is 1.3.2, `v2.0.0` tag exists); the plan version is the
-proposed TRIP release version only.
+- G3 is unsatisfied: no accepted frozen SHA, zero-obligation finding, complete
+  exact-SHA verification, or authoritative reviewer verdict.
+- G5 / #1299 activation is unsatisfied.
+- #1337 is open, unassigned, and lacks owner-scope ratification.
 
-**Ordering authority:** #1337 → coordinate {#1338, #1321} → #1318 → broadened
-#1339. #1320 runs independently (or promoted pre-#1296 by ELIG, in which case
-#1337 was already promoted alongside #1321). #1317 is a separate item throughout
-— never batched with UI/fee work.
+Planning may be reviewed while G3 is open. It may merge only after durable G3
+acceptance evidence exists on `main`: accepted exact SHA, zero outstanding
+G3-or-earlier obligations, required verification for that SHA, and an
+authoritative reviewer verdict. Vercel preview `READY` is not activation
+evidence.
 
-## Problem Statement
+## Repository evidence anchors
 
-Post-activation, the fee and internal-economics layer has convergent defects
-that must land as one coherent model:
+These repository facts constrain the later child plans. They are citations, not
+a product-code work list.
 
-- The fee truth-case harness exercises `computeFeePreview` only — the FeeProfile
-  engine has no truth-case coverage, so any fee-basis or unification change
-  ships unguarded (#1337).
-- Fee logic is duplicated across engines; findings reject the subannual
-  flow-basis approach, and unification must be coordinated with versioned LP fee
-  bases so both land as a single semantic model (#1338 + #1321).
-- LP-only fee bases are unversioned and no `feeProfileId` binding exists
-  anywhere in the repo (confirmed absent repo-wide), so fee-profile-to-LP-class
-  association cannot be expressed (#1321).
-- The internal capital envelope cannot carry GP commitment as contractual vs
-  cash vs fee-funded-deemed; the gate in
-  `server/services/internal-economics/lp-economics-run-service.ts:926-935`
-  refuses such funds with `GP_COMMITMENT_UNSUPPORTED` (#1320).
-- Cashless GP contribution is not surfaced in the UI and a duplicate input
-  exists (#1318).
-- ModelingWizard is implemented but unrouted — no live `/fund-setup` routing,
-  persistence, or caller wiring (#1339).
-- The clawback-threshold truth case remains unwritten; it is P2 and must be
-  reviewed by the waterfall-specialist in isolation (#1317).
+- `shared/lib/fund-math.ts:113-180` defines `computeFeeBasisTimeline`, including
+  cumulative schedules, period-flow handling, and FeeProfile fee calculation.
+  `server/services/construction-forecast-calculator.ts:11-14,40,146` imports a
+  FeeProfile and invokes that timeline for construction forecasts.
+- `client/src/lib/fees-wizard.ts:42-117` defines the separate annual
+  `computeFeePreview` helper. The current repository inventory finds only
+  truth-test callers, not production callers; that finding is a deletion
+  default, not a permanent assumption.
+- `shared/contracts/internal-economics/capital-envelope-v1.contract.ts` fixes
+  the existing `capital-envelope/1.0.0` shape and hashes its legal content. The
+  internal economics service still fails closed at
+  `server/services/internal-economics/lp-economics-run-service.ts:926-934` with
+  `GP_COMMITMENT_UNSUPPORTED` for nonzero GP commitment.
+- `docs/adr/ADR-070-cashless-gp-commitments-and-fee-waivers.md:41-78` makes fees
+  LP-class/profile based and defines cash versus deemed contribution. Its
+  taxonomy and compatibility constraints at `:191-264` keep Contractual GP
+  Commitment, GP Cash Contribution, and GP Deemed Contribution distinct.
+- `shared/lib/economics/economics-engine.ts:396-411` already preserves both the
+  full GP commitment and a cash-only amount. The funded-split coverage in
+  `tests/unit/economics/economics-engine.test.ts:11-45,226-317` supplies the
+  direct economics-engine seam for the residual regression; it does not
+  authorize changing its current behavior.
+- `/fund-setup` is the routed production flow in
+  `client/src/app/app-routes.tsx:25,83` and
+  `client/src/pages/fund-setup.tsx:13,176`.
+  `client/src/hooks/useModelingWizard.ts:1-15` and
+  `client/src/components/modeling-wizard/ModelingWizard.tsx:1-15,266-272`
+  identify ModelingWizard as compatibility-only and opt-in. The old client
+  calculation needing retirement is evidenced at
+  `client/src/lib/capital-calculations.ts:187-210`.
+- `docs/waterfall-ledger.truth-cases.json` currently has fourteen cases. Those
+  cases remain unchanged by the #1317 residual lane.
 
-## Solution Architecture
+## Lifecycle gates and sequence
 
-- **Truth-case-first:** #1337 extends the fee truth-case harness to cover the
-  FeeProfile engine _before_ any semantic change, so #1338/#1321 land against a
-  green baseline.
-- **One fee model:** #1338 (engine unification, retitled per findings) and #1321
-  (versioned LP fee bases + `feeProfileId` binding) are coordinated so LP fee
-  bases and profile unification land as one model. V1 outputs are preserved
-  byte-for-byte; cashless GP funding never changes a fee basis.
-- **Independent economics lane:** #1320 models GP cash + fee-funded deemed calls
-  in internal LP economics against the recorded #1314 decisions (ADR-070 exists
-  on main). It does not block the fee-basis lane and runs independently unless
-  ELIG (Phase 1 plan) promotes it pre-activation.
-- **UI last:** #1318 (surface cashless GP contribution, retire duplicate input)
-  and broadened #1339 (route ModelingWizard, persistence, live caller wiring)
-  land after their data-model blockers.
-- **Clawback isolated:** #1317 ships as its own change with explicit
-  waterfall-specialist review, blocked by #1320 decisions.
+All gates are cumulative and fail closed. Satisfying a later gate never waives
+an earlier one.
 
-### External / HITL prerequisites (not TRIP-2 implementation tasks)
+1. **G3 durable planning gate.** Merge this planning authority only after the G3
+   evidence named above is durable on `main`. No text in an unmerged plan can
+   stand in for that evidence.
+2. **#1337 scope-ratification gate.** Before any #1337 implementation work,
+   obtain the approved offline supersession text below, named owner-scope
+   ratification, and merged planning authority. After those first three
+   conditions are durable, creating or rebasing the empty #1337 branch onto
+   current `origin/main` is the sole permitted action and satisfies the fourth
+   condition. No implementation task, test edit, or other code command begins
+   until all four conditions hold.
+3. **#1337 truth gate.** The ratified child truth plan may add an additive
+   production FeeProfile corpus while preserving legacy characterization. Green
+   FeeProfile truth evidence is required before any caller migration, fee
+   authority retirement, or implementation-plan minting for the dependent fee
+   lane.
+4. **Domain-decision gate.** Approve every relevant decision-lane packet below,
+   including specialist reviews, before minting its child implementation plan.
+   Design investigation may proceed, but it creates no product implementation
+   authority.
+5. **G5 / #1299 merge gate.** Default #1337 and the fee/economics child work
+   merge only after completed G5/#1299 activation. A durable ELIG decision may
+   explicitly promote #1337; that exception must also record #1338's
+   disposition. It does not waive G3, #1337 owner ratification, green truth
+   evidence, or domain approvals.
 
-These are external actions on GitHub issues or human decisions. They are
-prerequisites to specific items below, represented as checkboxes in To-dos
-marked "(HITL — external)" — never as implementation work.
+The mandatory program order is therefore: approved #1337 supersession, green
+FeeProfile truth evidence, approved domain decisions, then child implementation
+plans. #1320 research may be independent in subject matter, but it does not
+bypass this global child-plan sequence.
 
-- ELIG outcome recorded on the ELIG issue (Phase 1 plan): if ELIG promotes #1321
-  pre-activation, **#1337 is promoted alongside it** (since #1321 is blocked by
-  #1337), and whether coordinated #1338 also moves must be decided and recorded
-  on the ELIG issue. The ELIG probe itself must query the exact pinned envelope
-  via `internal_economics_policy_versions.capital_envelope_version_id`, not the
-  newest by `created_at`.
-- #1338 retitle per findings recorded on the issue (HITL — external).
-- Specialist sign-off for #1320 from `waterfall-specialist` and
-  `xirr-fees-validator` recorded before merge (HITL — external).
-- Specialist review for #1317 by `waterfall-specialist` recorded before merge
-  (HITL — external).
+## Offline supersession matrix
 
-## Implementation Details
+**Snapshot protocol.** The timestamps, `updatedAt` values, raw-body SHA-256
+digests, and GitHub URLs embedded in each row are the self-contained controlling
+snapshot record for this plan, captured at `2026-08-10T09:47:46.403Z` UTC.
+`.superpowers/sdd/PLAN (7)/github-issue-snapshots.md` was an ephemeral, ignored
+authoring input only; it is absent from the committed tree and has no continuing
+authority. This is an offline proposal matrix, not instruction to mutate GitHub.
+Immediately before any external mutation, an authorized human must re-fetch the
+issue body and metadata. If either the raw-body SHA-256 or `updatedAt` differs
+from the row, action is blocked; refresh the matrix, reconcile the new conflict,
+and obtain approval again. Do not overwrite another author's changes or infer
+approval from a stale snapshot.
 
-### 1. #1337 — Fee truth-case harness covers the FeeProfile engine
+| Issue | Snapshot, conflict, and repository authority                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | Retained, moved, removed, and deferred scope                                                                                                                                                                                                                                                                                                                                                         | Offline proposed body/comment text                                                                                                                                                                                                                                                                                                                                                                                    | Required approver and current disposition                                                                                                                        |
+| ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| #1337 | **Snapshot UTC:** `2026-08-10T09:47:46.403Z`.<br>**updatedAt:** `2026-08-04T01:06:01Z`.<br>**URL:** <https://github.com/nikhillinit/Updog_restore/issues/1337>.<br>**Raw-body SHA-256:** `bd85fc13a72116cc7d8627bf31248bfb87c0a82877d14ee1364d8ec9d2395096`.<br>**Conflict:** current wording extends a legacy `computeFeePreview` suite as if it certifies production FeeProfile behavior.<br>**Repository authority:** `shared/lib/fund-math.ts:113-180`; `server/services/construction-forecast-calculator.ts:11-14,40,146`; `client/src/lib/fees-wizard.ts:42-117`.                                                                       | **Retain:** immutable legacy characterization and its existing coverage.<br>**Move:** additive production FeeProfile corpus and adapter design to a ratified #1337 child plan after gates.<br>**Remove:** legacy-suite-extension wording as production certification.<br>**Defer:** caller migration and independent-preview retirement to #1338 after parity.                                       | **Offline proposal — not posted:** “Supersede legacy-suite-extension scope. Preserve legacy `computeFeePreview` characterization unchanged and non-normative. Add a separate production FeeProfile truth corpus exercising canonical timeline behavior. No production behavior changes in this scope. Owner ratification is required before a code branch.”                                                           | **Approver:** named #1337 owner plus repository owner.<br>**Disposition:** `BLOCKED-G3-AND-RATIFICATION`; supersession is proposed, not approved.                |
+| #1338 | **Snapshot UTC:** `2026-08-10T09:47:46.403Z`.<br>**updatedAt:** `2026-08-04T01:06:02Z`.<br>**URL:** <https://github.com/nikhillinit/Updog_restore/issues/1338>.<br>**Raw-body SHA-256:** `baef36acf34f34615e11579d9c5a1c88e135d5f2df0a32d9ac2254d0cb796896`.<br>**Conflict:** current wording describes duplicate fee arithmetic and interim guards but does not lock one canonical authority or a retirement trigger.<br>**Repository authority:** `shared/lib/fund-math.ts:113-180`; `client/src/lib/fees-wizard.ts:42-117`; current caller inventory.                                                                                      | **Retain:** period-flow disagreement and all protective behavior until parity is proven.<br>**Move:** implementation details into a child retirement plan after #1337 green truth and fee-authority approval.<br>**Remove:** treatment of independent `computeFeePreview` arithmetic as co-canonical.<br>**Defer:** any newly discovered production caller; it triggers re-inventory and replanning. | **Offline proposal — not posted:** “FeeProfile plus `computeFeeBasisTimeline` is canonical timeline authority. After new FeeProfile truth is green, inventory and migrate callers through the canonical interface, prove parity, then remove independent `computeFeePreview` arithmetic. The current no-production-caller finding locks deletion as default; a new caller blocks retirement and requires replanning.” | **Approver:** repository owner and `xirr-fees-validator`.<br>**Disposition:** `DEFERRED-AFTER-#1337-TRUTH`; no direct unification branch is authorized.          |
+| #1320 | **Snapshot UTC:** `2026-08-10T09:47:46.403Z`.<br>**updatedAt:** `2026-08-03T23:44:36Z`.<br>**URL:** <https://github.com/nikhillinit/Updog_restore/issues/1320>.<br>**Raw-body SHA-256:** `e387520603826adbcf206e3f78b2400ec2b4f5323ca997dbb1d09c951c247342`.<br>**Conflict:** issue cites stale ADR-035 and suggests removing a gate before an approved envelope successor exists.<br>**Repository authority:** `docs/adr/ADR-070-cashless-gp-commitments-and-fee-waivers.md:41-78,191-264`; `shared/contracts/internal-economics/capital-envelope-v1.contract.ts`; `server/services/internal-economics/lp-economics-run-service.ts:926-934`. | **Retain:** nonzero-GP fail-closed behavior and the need for a three-way split.<br>**Move:** version, policy, and replay design to the capital-envelope decision packet.<br>**Remove:** ADR-035 as governing citation and any implication that the V1 gate may be silently deleted.<br>**Defer:** implementation until a new envelope version and all reviews are approved.                          | **Offline proposal — not posted:** “Replace ADR-035 with ADR-070. Preserve `capital-envelope/1.0.0` and `GP_COMMITMENT_UNSUPPORTED` until an approved successor defines contractual, cash, and deemed GP values; eligibility, calls, distributions, reconciliation, XIRR, hashes, idempotency, persistence, migration, and replay. Deemed contribution is non-cash.”                                                  | **Approver:** repository owner, `waterfall-specialist`, `xirr-fees-validator`, and `phoenix-precision-guardian`.<br>**Disposition:** `DECISION-PACKET-REQUIRED`. |
+| #1321 | **Snapshot UTC:** `2026-08-10T09:47:46.403Z`.<br>**updatedAt:** `2026-08-03T23:44:38Z`.<br>**URL:** <https://github.com/nikhillinit/Updog_restore/issues/1321>.<br>**Raw-body SHA-256:** `a5c66b264f80c991ed5942fdb057621a7f6ce603e8d07901c0a365db8933c5f4`.<br>**Conflict:** issue cites stale ADR-035 while asking to change V1 whole-fund populations.<br>**Repository authority:** `docs/adr/ADR-070-cashless-gp-commitments-and-fee-waivers.md:41-61,191-264`; `shared/lib/fund-math.ts:113-180`.                                                                                                                                        | **Retain:** LP-class/profile binding, LP-attributable fee policy, and V1 reproducibility.<br>**Move:** canonical interface/adapters before persistence and version migration.<br>**Remove:** stale ADR-035 citation and any unversioned population rewrite.<br>**Defer:** migration and result-version work until fee authority and replay design approve them.                                      | **Offline proposal — not posted:** “Replace ADR-035 with ADR-070. Every supported fee-basis population receives versioned semantics; define LP-class/profile identity, binding, selection, result versioning, additive migration, and V1 replay preservation. `fundedFromFeesPct` never changes a fee basis.”                                                                                                         | **Approver:** repository owner and `xirr-fees-validator`.<br>**Disposition:** `DEFERRED-AFTER-#1337-AND-FEE-AUTHORITY`.                                          |
+| #1318 | **Snapshot UTC:** `2026-08-10T09:47:46.403Z`.<br>**updatedAt:** `2026-08-03T23:44:35Z`.<br>**URL:** <https://github.com/nikhillinit/Updog_restore/issues/1318>.<br>**Raw-body SHA-256:** `eaa8a300549e607216d3352740ae2fedb7daa5434aeca255d50a125935571bda`.<br>**Conflict:** historical UI premise links a cashless GP split to a fee-basis deduction.<br>**Repository authority:** ADR-070 at `:41-78,191-264`; duplicate calculation at `client/src/lib/capital-calculations.ts:187-210`.                                                                                                                                                  | **Retain:** display of contractual, cash, and deemed values; consumption of #1321 output.<br>**Move:** UI retirement of duplicate calculation to production-flow child plan after canonical fee authority.<br>**Remove:** cashless-percentage fee-basis deduction and parallel client calculator premise.<br>**Defer:** UI work until #1321 semantic/version decision is approved.                   | **Offline proposal — not posted:** “The UI is a consumer, not a fee calculator. Derive GP Cash Contribution and GP Deemed Contribution only from Contractual GP Commitment times `fundedFromFeesPct`; never from rates, waived-fee dollars, or fee-basis results. Retire the duplicate client basis deduction after canonical output is available.”                                                                   | **Approver:** repository owner and `xirr-fees-validator`.<br>**Disposition:** `DEFERRED-ON-#1321`.                                                               |
+| #1339 | **Snapshot UTC:** `2026-08-10T09:47:46.403Z`.<br>**updatedAt:** `2026-08-04T01:06:04Z`.<br>**URL:** <https://github.com/nikhillinit/Updog_restore/issues/1339>.<br>**Raw-body SHA-256:** `92d99ba90fba3fcac721fd386fc3bb0a00f7b875d16e0df3d7bd3f950e495ffc`.<br>**Conflict:** issue presents routing ModelingWizard as the decision, although repository routing already selects `/fund-setup` and marks ModelingWizard compatibility-only.<br>**Repository authority:** `client/src/app/app-routes.tsx:25,83`; `client/src/hooks/useModelingWizard.ts:1-15`; `client/src/components/modeling-wizard/ModelingWizard.tsx:1-15,266-272`.        | **Retain:** reachable catch-up control as product need.<br>**Move:** catch-up controls to `/fund-setup` production flow.<br>**Remove:** routing or reviving ModelingWizard as a production owner.<br>**Defer:** production-flow child planning until the fee authority and route ownership are approved.                                                                                             | **Offline proposal — not posted:** “Select `/fund-setup` as the sole production route. Move required catch-up controls there and retain ModelingWizard in compatibility quarantine; do not grant it production routing, persistence authority, or a parallel caller path.”                                                                                                                                            | **Approver:** repository owner and routed-fund-setup owner.<br>**Disposition:** `QUARANTINE-RETAINED; DEFERRED`.                                                 |
+| #1317 | **Snapshot UTC:** `2026-08-10T09:47:46.403Z`.<br>**updatedAt:** `2026-08-03T23:44:34Z`.<br>**URL:** <https://github.com/nikhillinit/Updog_restore/issues/1317>.<br>**Raw-body SHA-256:** `9c025345dab5368557358cbcac7dd9208616f0eda57cd94f71a80ef411dbb10e`.<br>**Conflict:** issue reopens cashless-waterfall policy that ADR-070 already resolves and seeks a broad waterfall change.<br>**Repository authority:** ADR-070 at `:191-264`; `shared/lib/economics/economics-engine.ts:396-411`; `tests/unit/economics/economics-engine.test.ts:11-45,226-317`; `docs/waterfall-ledger.truth-cases.json`.                                      | **Retain:** existing waterfall guards and all fourteen waterfall-ledger truth cases.<br>**Move:** one direct economics-engine regression to a narrow child plan.<br>**Remove:** broad re-decision of return-of-capital, preferred return, and clawback policy.<br>**Defer:** any engine change unless the new regression fails.                                                                      | **Offline proposal — not posted:** “Narrow #1317 to one uncovered clawback/deemed-contribution regression. Keep the fourteen waterfall-ledger cases unchanged. Test fundedFromFeesPct 0, 0.25, and 1 with clawback enabled; do not change an engine unless that regression fails.”                                                                                                                                    | **Approver:** repository owner and `waterfall-specialist`.<br>**Disposition:** `NARROWED-REGRESSION-ONLY; DEFERRED`.                                             |
 
-- **File**: fee truth-case harness and truth-case corpus (per
-  `npm run phoenix:truth` runner, `tests/truth-cases/`)
-- **Current state**: Harness currently exercises `computeFeePreview` only (title
-  confirmed).
-- **Modifications**:
-  - Add FeeProfile-engine coverage to the fee truth-case harness.
-- **Invariants**: Existing `computeFeePreview` truth cases unchanged; new cases
-  follow the existing truth-case corpus format; no engine behavior changes in
-  this item.
-- **Verification**: `npm run phoenix:truth && npm run calc-gate:orphans`
+## Decision lane A — #1320 capital-envelope successor
 
-### 2. #1338 — Unify fee engines (RETITLE/KEEP per findings)
+`capital-envelope/1.0.0` remains immutable and `GP_COMMITMENT_UNSUPPORTED`
+remains in force until a successor version is approved. The future decision
+packet must define all of the following before an implementation plan can exist:
 
-- **File**: fee engine modules (duplicated engines identified by findings; exact
-  seams per issue)
-- **Current state**: Fee logic duplicated across engines; findings reject the
-  subannual flow-basis approach.
-- **Modifications**:
-  - Retitle the issue per findings (HITL — external; see prerequisites).
-  - Unify the duplicated fee engines; coordinate semantics with #1321 so LP fee
-    bases and profile unification land as one model.
-- **Invariants**: Fee truth-case harness (#1337) stays green throughout; no
-  change to LP fee-basis semantics except as coordinated with #1321.
-- **Verification**: `npm run calc-gate && npm test`
+- **Terms and eligibility:** Contractual GP Commitment is the full legal amount
+  and controls ownership and profit participation. GP Cash Contribution and GP
+  Deemed Contribution are separately eligible only where their named semantic
+  permits it.
+- **Calls, distributions, and reconciliation:** cash calls and cash
+  distributions use GP Cash Contribution. GP Deemed Contribution is non-cash; it
+  never enters the fee basis, cash ledger, return-of-capital base,
+  preferred-return base, or clawback base. It cannot repair a reconciliation
+  difference.
+- **Returns and profit:** LP, GP, and gross XIRR use actual cash flows only.
+  Full Contractual GP Commitment still controls ownership and residual/profit
+  participation. The packet must distinguish investment distributions, carry,
+  escrow, and clawback rather than substituting one GP quantity for another.
+- **Durability:** contract/version selection, content and result hashes,
+  idempotency, persistence, additive migration, versioned methodology, and
+  replay behavior must be explicit. V1 replay either reproduces its prior result
+  or fails closed under its recorded version rule.
 
-### 3. #1321 — Version LP-only fee bases; bind fee profiles to LP classes
+Required approvals are `waterfall-specialist`, `xirr-fees-validator`, and
+`phoenix-precision-guardian`, followed by repository-owner approval. The
+authority is ADR-070, not a default inferred from current implementation.
 
-- **Priority**: P1 (or P0 if promoted by ELIG)
-- **Blocked by**: #1337; coordinate #1338
-- **File**: fee-basis schema/migration and internal-economics fee-basis
-  consumers (exact paths per issue; `feeProfileId` binding confirmed absent
-  repo-wide today)
-- **Current state**: LP fee bases unversioned; no `feeProfileId` binding exists
-  anywhere in the repo.
-- **Modifications**:
-  - Introduce `feeProfileId` binding.
-  - Introduce versioned fee-basis semantics.
-  - Preserve V1 outputs byte-for-byte.
-  - Cashless GP funding never changes a fee basis (per issue).
-- **Invariants**: V1 output bytes identical before/after; additive + replay-safe
-  migration discipline per repo rules (no `unique()`→`uniqueIndex` FK-target
-  mistake — drizzle 42830 gotcha; migration pin asserts its own journal entry,
-  never `entries.at(-1)`).
-- **Verification**: `npm run calc-gate:full && npm run test:testcontainers`
+## Decision lane B — #1338 and #1321 fee authority
 
-### 4. #1320 — Model GP cash + fee-funded deemed calls in internal LP economics
+First inventory every fee implementation, importer, and result consumer. Freeze
+FeeProfile plus `computeFeeBasisTimeline` as canonical deep behavior, based on
+the repository evidence above. The inventory must state whether the current
+no-production-caller finding for `computeFeePreview` still holds; a newly
+discovered production caller stops retirement and requires a revised decision
+packet.
 
-- **Priority**: P1 (or P0 pre-#1296 if promoted by ELIG)
-- **Blocked by**: #1314 decisions (recorded — ADR-070 exists on main)
-- **File**: `server/services/internal-economics/lp-economics-run-service.ts`
-  (gate at `:926-935`) and the internal capital envelope model; tests under
-  `tests/unit/services/internal-economics/`
-- **Current state**: Envelope cannot carry GP commitment split by funding
-  source; the gate refuses with `GP_COMMITMENT_UNSUPPORTED`.
-- **Modifications**:
-  - Envelope carries contractual / cash / fee-funded-deemed GP separately before
-    the gate is removed.
-  - Deemed contribution stays out of cash reconciliation and IRR flows.
-  - Obtain specialist sign-off (waterfall-specialist, xirr-fees-validator) —
-    recorded on the issue (HITL — external).
-- **Invariants**: Deemed contribution never enters cash reconciliation or IRR
-  flows; existing envelope rows for non-GP-commitment funds behave identically;
-  gate removal only after the three-way split is in place.
-- **Verification**:
-  `TZ=UTC npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/services/internal-economics/ && npm run calc-gate`
+The packet then defines LP-class identity, FeeProfile identity, binding, version
+selection, result-version identity, additive migration, and V1 replay
+preservation for every fee-basis population. It separates two future child
+plans:
 
-### 5. #1318 — Surface cashless GP contribution; retire duplicate input
+1. canonical interface and adapters, with parity evidence against canonical
+   timeline behavior; then
+2. persistence and version migration, with explicit replay and result-version
+   rules.
 
-- **Blocked by**: #1321
-- **File**: UI surface carrying the duplicate cashless GP input (per issue;
-  coordinated with the #1321 fee-basis model)
-- **Current state**: Cashless GP contribution not surfaced; duplicate input
-  exists.
-- **Modifications**:
-  - Surface cashless GP contribution in the UI.
-  - Retire the duplicate input.
-- **Invariants**: Surfaced values read from the versioned fee-basis model landed
-  by #1321 — no parallel data path; retiring the duplicate input does not change
-  any computed fee basis.
-- **Verification**: `npm run calc-gate && npm test`
+Only after #1337 green truth and approved parity evidence may the #1338
+retirement slice migrate callers and delete independent `computeFeePreview`
+arithmetic. It does not reinterpret fee waivers: FeeProfile determines fee
+outflows, while `fundedFromFeesPct` never changes a fee basis.
 
-### 6. #1339 — BROADEN: route ModelingWizard; persistence; live caller wiring
+## Decision lane C — #1318 and #1339 production flow
 
-- **File**: ModelingWizard component, `/fund-setup` route surface, persistence
-  layer (issue title confirms ModelingWizard unrouted today)
-- **Current state**: ModelingWizard implemented but unrouted; no persistence or
-  live caller wiring.
-- **Modifications**:
-  - Add live `/fund-setup` UI routing.
-  - Add persistence.
-  - Add live caller wiring.
-- **Invariants**: Routing follows existing app route registration conventions;
-  flags via `flag-definitions.ts` if any; client tests live in `tests/unit/**`
-  (co-located tests never run).
-- **Verification**:
-  `npm run test:integration && TZ=UTC npx vitest run --config vitest.config.mjs --configLoader native --project=client tests/unit/`
+The production flow has one calculation boundary and one route owner:
 
-### 7. #1317 — NARROW: clawback-threshold truth case + review evidence
+- FeeProfile controls fee outflows only.
+- GP Cash Contribution equals Contractual GP Commitment multiplied by
+  `(1 - fundedFromFeesPct)`; GP Deemed Contribution equals Contractual GP
+  Commitment multiplied by `fundedFromFeesPct`.
+- Neither contribution may be derived from FeeProfile rates, waived-fee dollars,
+  or fee-basis results. The legacy fee-basis deduction in the duplicate client
+  calculation is retired only through a later approved child plan.
+- `/fund-setup` remains the production route. Required catch-up controls belong
+  there. ModelingWizard remains in compatibility quarantine and does not become
+  a second persistence, routing, or calculation owner.
 
-- **Priority**: P2
-- **Blocked by**: #1320 decisions
-- **File**: waterfall truth-case corpus (per `npm run phoenix:truth` runner)
-- **Current state**: Clawback-threshold truth case unwritten.
-- **Modifications**:
-  - Add the narrowed clawback-threshold truth case.
-  - Record waterfall-specialist review evidence on the issue (HITL — external).
-- **Invariants**: This item ships alone — never batched with UI or fee work;
-  truth case added without changing waterfall engine behavior.
-- **Verification**: `npm run phoenix:truth`
+This lane can be planned only after fee-authority decisions explain the output
+it consumes. It cannot create a parallel model to bypass those decisions.
 
-## Technical Considerations
+## Decision lane D — #1317 residual regression
 
-- **Activation precedence**: the activation release
-  (`F_1.2.0_deployment-soak-activation.plan.md`) precedes this release, unless
-  ELIG promotes #1320/#1321/#1337 pre-activation (pre-#1296), in which case
-  those items move to the earlier release per the ELIG decision recorded on the
-  issue.
-- **Promotion coordination**: if ELIG promotes #1321, #1337 must be promoted
-  alongside it (#1321 is blocked by #1337); whether coordinated #1338 also moves
-  must be decided and recorded on the ELIG issue (HITL — external).
-- **ELIG probe correctness**: the promotion decision rests on the ELIG probe,
-  which must query the exact pinned envelope via
-  `internal_economics_policy_versions.capital_envelope_version_id`, not the
-  newest by `created_at` (owned by the Phase 1 plan; restated here because it
-  drives this plan's scope).
-- **Byte-for-byte V1 preservation**: #1321's versioned fee bases must not alter
-  any V1 output; the #1337 truth-case harness is the guard and must land first.
-- **Deemed-contribution isolation**: #1320's fee-funded deemed calls must stay
-  out of cash reconciliation and IRR flows; this invariant is what #1317's
-  clawback truth case later depends on, hence #1317 blocked by #1320 decisions.
-- **#1317 isolation**: clawback work requires waterfall-specialist review and is
-  never batched with unrelated UI/fee work; batching it would mix review domains
-  and invalidate sign-off.
-- **Phoenix discipline**: Phoenix truth cases must pass before merging
-  calculation changes; run `npm run phoenix:truth` for the current count rather
-  than trusting hardcoded numbers. `TZ=UTC` is required for all test runs. No
-  emoji in code, docs, or logs.
+Keep all fourteen `docs/waterfall-ledger.truth-cases.json` cases byte-for-byte
+unchanged. A later narrow child plan may add one direct economics-engine
+regression with clawback enabled and `fundedFromFeesPct` values `0`, `0.25`, and
+`1`.
 
-## Files to Modify/Create
+Its oracle is:
 
-1. `tests/truth-cases/` fee truth-case corpus + harness (modify) — FeeProfile
-   engine coverage (#1337)
-2. Fee engine modules (modify) — unify duplicated engines (#1338; exact seams
-   per issue findings)
-3. Fee-basis schema + migration (new migration; exact `migrations/NNNN_*.sql`
-   number pinned at mint time against the live journal) — versioned LP fee
-   bases + `feeProfileId` binding (#1321)
-4. Internal-economics fee-basis consumers (modify) — consume versioned bases
-   (#1321)
-5. `server/services/internal-economics/lp-economics-run-service.ts` (modify) —
-   three-way GP envelope split; remove `GP_COMMITMENT_UNSUPPORTED` gate after
-   split (#1320)
-6. Internal capital envelope model (modify) — contractual / cash /
-   fee-funded-deemed GP carried separately (#1320)
-7. Cashless GP UI surface (modify) — surface contribution, retire duplicate
-   input (#1318)
-8. ModelingWizard component (modify) — live caller wiring (#1339)
-9. `/fund-setup` route surface (modify) — route ModelingWizard (#1339)
-10. ModelingWizard persistence layer (new/modify per issue) — persist wizard
-    state (#1339)
-11. Waterfall truth-case corpus (modify) — narrowed clawback-threshold case
-    (#1317)
-12. Various test files (modify) — per verification blocks above
+```text
+eligibleProfit = max(0, LP distributions + GP investment distributions + GP carry - LP cash calls - GP cash calls)
+targetCarry = eligibleProfit × carryPct
+finalClawbackDue = max(0, GP carry - targetCarry)
+```
 
-## Test Impact
+The regression must prove that GP Deemed Contribution never enters paid-in
+capital or any clawback calculation. It is an evidence-only residual slice: no
+engine change is authorized unless the regression fails. `waterfall-specialist`
+review and repository owner approval are required before that child plan is
+minted.
 
-- New FeeProfile truth cases added under the `npm run phoenix:truth` runner
-  (#1337); existing `computeFeePreview` cases must not churn.
-- `tests/unit/services/internal-economics/` gains coverage for the three-way GP
-  envelope split, the deemed-contribution exclusion from cash
-  reconciliation/IRR, and gate removal (#1320).
-- #1321 requires testcontainers-backed migration/binding coverage
-  (`npm run test:testcontainers`) plus a byte-for-byte V1 output preservation
-  check.
-- Client-side: #1339 routing/persistence covered by `npm run test:integration`
-  and the client unit project; #1318 UI changes covered by `npm test`.
-- #1317 adds exactly one narrowed clawback-threshold truth case; no
-  integration/E2E scope.
+## Child-plan minting checklist
 
-## Documentation Impact
+A child implementation plan may be minted only when its relevant boxes are true:
 
-- `CHANGELOG.md` — add release entry for the fee/economics convergence release.
-- `DECISIONS.md` — record an ADR entry if #1338 unification or #1321 fee-basis
-  versioning introduces a new architectural decision beyond ADR-070.
-- `docs/ARCHI.md` — update if fee-engine unification changes module boundaries
-  described there.
-- `docs/_generated/router-index.json` — regenerate
-  (`npm run docs:routing:generate`) if any routed doc above changes.
-- `README.md`, `AGENTS.md`, `docs/runbooks/`, `cheatsheets/INDEX.md` — none
-  expected; no runbook or convention changes in this release.
+- [ ] Durable G3 acceptance is recorded on `main` for an accepted exact SHA.
+- [ ] The corresponding offline matrix row has been re-fetched with unchanged
+      raw-body digest and `updatedAt`, or has been refreshed and reapproved.
+- [ ] #1337 owner scope is ratified, its truth evidence is green, and dependent
+      fee lanes have their approved decision packet.
+- [ ] Required specialist reviews and repository-owner approval are recorded for
+      the applicable decision lane.
+- [ ] G5 / #1299 is complete, unless a durable ELIG promotion explicitly names
+      #1337 and records #1338 disposition.
+- [ ] The child plan contains its own implementation scope, safety properties,
+      and verification evidence; none is delegated by this parent plan.
 
-## To-dos
+## Explicit deferrals
 
-Phase A — prerequisites (external/HITL):
-
-- [ ] Confirm ELIG outcome on the ELIG issue: promotions of #1320/#1321 (with
-      #1337 alongside #1321), and the #1338 move/no-move decision recorded (HITL
-      — external)
-- [ ] Confirm activation release `F_1.2.0` completed, unless ELIG promoted items
-      out of this plan's scope (HITL — external)
-- [ ] Record #1338 retitle per findings on issue #1338 (HITL — external)
-
-Phase B — truth-case foundation:
-
-- [ ] #1337: add FeeProfile-engine coverage to the fee truth-case harness
-- [ ] #1337: verify `npm run phoenix:truth && npm run calc-gate:orphans` green
-
-Phase C — fee model (coordinated #1338 + #1321):
-
-- [ ] #1338: unify duplicated fee engines, semantics coordinated with #1321
-- [ ] #1321: mint additive replay-safe migration for versioned LP fee bases
-      (journal entry pinned at mint time)
-- [ ] #1321: introduce `feeProfileId` binding
-- [ ] #1321: preserve V1 outputs byte-for-byte (truth-case guarded)
-- [ ] #1321: assert cashless GP funding never changes a fee basis
-- [ ] #1338/#1321: verify `npm run calc-gate && npm test` and
-      `npm run calc-gate:full && npm run test:testcontainers` green
-
-Phase D — GP economics (independent lane; may run parallel to Phase C):
-
-- [ ] #1320: envelope carries contractual / cash / fee-funded-deemed GP
-      separately
-- [ ] #1320: keep deemed contribution out of cash reconciliation and IRR flows
-- [ ] #1320: remove `GP_COMMITMENT_UNSUPPORTED` gate only after the three-way
-      split lands
-- [ ] #1320: specialist sign-off recorded (waterfall-specialist,
-      xirr-fees-validator) (HITL — external)
-- [ ] #1320: verify
-      `TZ=UTC npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/services/internal-economics/ && npm run calc-gate`
-      green
-
-Phase E — UI surface (after #1321):
-
-- [ ] #1318: surface cashless GP contribution in the UI
-- [ ] #1318: retire the duplicate input
-- [ ] #1318: verify `npm run calc-gate && npm test` green
-
-Phase F — ModelingWizard broadening (#1339):
-
-- [ ] #1339: add live `/fund-setup` UI routing
-- [ ] #1339: add persistence
-- [ ] #1339: add live caller wiring
-- [ ] #1339: verify
-      `npm run test:integration && TZ=UTC npx vitest run --config vitest.config.mjs --configLoader native --project=client tests/unit/`
-      green
-
-Phase G — clawback truth case (separate item; never batched):
-
-- [ ] #1317: add narrowed clawback-threshold truth case (blocked by #1320
-      decisions)
-- [ ] #1317: waterfall-specialist review evidence recorded on the issue (HITL —
-      external)
-- [ ] #1317: verify `npm run phoenix:truth` green
-
-Phase H — documentation:
-
-- [ ] Add CHANGELOG.md release entry
-- [ ] Record ADR in DECISIONS.md if #1338/#1321 introduces a new architectural
-      decision
-- [ ] Regenerate `docs/_generated/router-index.json` if routed docs changed
+- #1022 and #1023 remain governed by F1.4. This plan neither rewrites their
+  issue bodies nor dispatches their work.
+- No change is authorized to
+  `docs/adr/ADR-070-cashless-gp-commitments-and-fee-waivers.md`, product
+  runtime, schema, migration, test corpus, generated documentation, or external
+  system.
+- All GitHub actions remain offline proposals until an authorized human passes
+  the snapshot-drift check and supplies the named approval.

--- a/docs/1-plans/F_1.4.0_post-activation-epics.plan.md
+++ b/docs/1-plans/F_1.4.0_post-activation-epics.plan.md
@@ -1,349 +1,251 @@
-# Post-Activation Epics Implementation Plan
+# F1.4 Post-Activation Governance Charter
 
-**Version policy:** plan versions use a 1.x line decoupled from the package.json
-version (package is 1.3.2, and a `v2.0.0` tag exists); the plan version is the
-proposed TRIP release version only.
+## Charter and Authority
 
-## Overview
+F1.4 is a planning and governance record for post-activation work. It does not
+authorize product design, source changes, runtime changes, schema changes,
+tests, generated artifacts, GitHub mutations, or implementation dispatch.
 
-This plan covers **Phase 4 — Post-Activation Epics** of the Current-Forecast V2
-activation program: **sequencing and planning only, no design here**. It records
-the authoritative backlog dispositions, the product ordering, the dependency
-fences, and the human-in-the-loop (HITL) actions required to mint, narrow,
-rewrite, and close issues. Each epic that results in code will receive its own
-follow-up TRIP plan before implementation begins; this plan never dispatches
-`TRIP-2-implement` work by itself.
+Concrete planning baseline: main at 26afc694105f0f08023db2b5ea82dfa0a69ed683.
+Re-fence repository state before a future child plan; this SHA is a planning
+reference, not an accepted G3 SHA.
 
-Product order (fixed): construction engine + narrowed `#1022` → Scenario-V2
-`#1023` → broader scenario UX.
+This plan follows:
 
-Sibling plans in the split:
+- F_1.0.0_activation-blockers-runtime.plan.md for Phase 0.
+- F_1.1.0_wave-h-context-rail-decisions.plan.md for Phase 1.
+- F_1.2.0_v1.4-release-proof-activation.plan.md for G1 through G5 release and
+  activation governance.
+- F_1.3.0_fee-economics-convergence.plan.md for fee and economics convergence.
 
-- `F_1.0.0_activation-blockers-runtime.plan.md` — Phase 0: `#1325`, NEW-A,
-  resume/re-arm, `#1299-R` flag removal, NEW-B runbook, `#1172-EXP`
-- `F_1.1.0_wave-h-context-rail-decisions.plan.md` — Phase 1: `#1284`, `#1288`,
-  `#1289`, `#1290`, `#1293`, `#1283`, `#1287`, ELIG
-- `F_1.2.0_deployment-soak-activation.plan.md` — Phase 2 ops checklist:
-  `#1294`–`#1299`
-- `F_1.3.0_fee-economics-convergence.plan.md` — Phase 3: `#1337`, `#1338`,
-  `#1321`, `#1320`, `#1318`, `#1339`, `#1317`
-- `F_1.4.0_post-activation-epics.plan.md` — this plan (Phase 4 planning only)
+The fixed product order remains construction reconciliation plus the approved
+#1022 scope, then the approved #1023 Scenario-V2 scope, then broader scenario
+UX. The order is a governance constraint, not authorization to change any live
+issue body.
 
-The plan is keyed to `origin/main` @ `a3d0a6b6`; re-fence before each dispatch.
+### Lifecycle gates
 
-## Problem Statement
+1. Planning may be authored, committed, and reviewed before G3, but may not
+   merge until G3 is durably accepted. A planning merge or child-plan
+   preparation is not G3 acceptance.
+2. G3 must have durable main-branch evidence for one accepted frozen SHA, zero
+   G3-or-earlier obligations, its required exact-SHA verification battery, and
+   an authoritative reviewer verdict. The 2026-08-10 gate snapshot records all
+   four as UNSATISFIED for the baseline above.
+3. G4 is the governed release and staged/promotion proof after G3. No
+   post-activation implementation dispatch skips it.
+4. G5 is the four-window shadow-soak and HITL one-way activation decision in
+   #1299. The snapshot records G5 as UNSATISFIED: #1299 remains open and
+   blocked. No Phase 4 implementation dispatch, equivalence claim, or
+   post-activation merge gate is considered open until the durable G5 record
+   exists.
+5. After G5, every code-bearing item still needs its own approved TRIP-1 plan,
+   current repository preflight, and its named domain reviews. F1.4 never
+   dispatches TRIP-2 work.
 
-After activation completes (Phase 2, `#1299`) and fee/economics convergence
-lands (Phase 3), several large product epics remain. They were previously
-bundled into a single plan with activation work, which created a
-release-sequencing deadlock (one branch cannot contain deploy-gated code, four
-seven-day soak windows, activation, and post-activation epics). Phase 4 items
-must be sequenced explicitly because:
+External mutation ban: no agent may create, edit, replace, relabel, link,
+comment on, close, reopen, or change dependencies of a GitHub issue under this
+charter. Every such action is HITL and requires the fresh-evidence procedure
+below. This plan also does not edit ADR-066 or ADR-068.
 
-- The Tactyc Construction Engine (NEW-D) has no issue yet; its scope spans six
-  slices and must not block activation.
-- `#1022` and `#1023` carry stale, over-broad bodies that need
-  narrowing/rewriting before any implementation plan can be written against
-  them.
-- The waterfall lane (`#1305`–`#1309`) has a strict internal order and a
-  cross-plan coordination point with `#1321` (Phase 3).
-- The internal KPI manager backend shipped without UI (`#1326` delivered backend
-  only); `/kpi-manager` and `/kpi-submission` currently redirect to
-  `/dashboard`, and the UI activation needs a minted issue (NEW-C) before work
-  begins.
-- Two backlog issues (`#1314`, `#1054`) have verified close conditions that were
-  never executed.
+### Durable evidence and re-fence procedure
 
-## Solution Architecture
+Issue evidence below was captured through a read-only GitHub connector at
+2026-08-10T09:47:46.403Z. Each body digest is SHA-256 of the raw UTF-8 connector
+body. Before any proposed external mutation, an authorized human must re-fetch
+the issue and compare state, updated-at, URL, and body digest. Any drift blocks
+the action until this charter's matrix is refreshed. The historical body,
+comments, and edit history remain evidence even if a future owner approves a
+supersession comment.
 
-- **Planning-only release.** This plan produces issue mutations (HITL —
-  external) and a sequencing record. No source code changes are dispatched from
-  this plan.
-- **HITL-first.** Every GitHub issue edit (mint NEW-D, mint NEW-C, narrow
-  `#1022`, rewrite `#1023`, close `#1314` and `#1054`) is an explicit
-  prerequisite checkbox marked "(HITL — external)". None of these are TRIP-2
-  implementation tasks.
-- **Epic decomposition.** NEW-D is minted as an epic with six slices; each slice
-  gets its own follow-up TRIP plan. The narrowed `#1022` owns the first
-  construction slice.
-- **Sequencing fences.** The Wave W merge fence from Phase 2 applies to any
-  ticket attempting a pre-soak merge. The waterfall lane has a fixed internal
-  order. `#1307` coordinates with `#1321` (single class/profile model) in
-  Phase 3.
-- **No Tactyc-equivalence claims** may be made until the NEW-D construction
-  engine slices land; NEW-D does not block activation itself.
+## Construction / NEW-D — Reuse, Replace, Quarantine Inventory
 
-## Implementation Details
+This inventory is the first preflight for any future NEW-D text. It corrects the
+obsolete assertion that no construction engine exists.
 
-### 1. NEW-D — Tactyc Construction Engine epic (mint; HITL — external)
+| Asset                                                      | Current evidence                                                                                                                                                                                                                                                         | Governance disposition                                                                                                                                                                                  |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ConstructionForecastCalculator                             | Existing Decimal/J-curve calculator imports FeeProfile and computeFeeBasisTimeline at server/services/construction-forecast-calculator.ts:10-17; declares its construction configuration at :23-47; and generates forecast, fee audit, and lifecycle output at :109-237. | REUSE as the observed baseline. Do not replace it under this charter. A child plan may propose a bounded adapter or replacement only after reconciliation truth cases identify a concrete semantic gap. |
+| Metrics aggregator consumer                                | server/services/metrics-aggregator.ts:54-60 imports the calculator and :929-942 builds the construction forecast that feeds dual-forecast assembly.                                                                                                                      | REUSE and characterize. A future slice must preserve or explicitly version this consumer contract.                                                                                                      |
+| Projected metrics consumer                                 | server/services/projected-metrics-calculator.ts:20-31 imports the calculator and :400-435 converts its construction forecast into projected arrays.                                                                                                                      | REUSE and characterize. Do not introduce a parallel ungoverned construction path.                                                                                                                       |
+| FeeProfile timeline integration                            | ConstructionForecastCalculator accepts FeeProfile and calls computeFeeBasisTimeline, exposing fee audit evidence in server/services/construction-forecast-calculator.ts:10-17, :39-40, and :137-164.                                                                     | REUSE canonical timeline integration. No NEW-D slice may duplicate fee arithmetic or reinterpret retroactive catch-up without an approved fee-domain plan.                                              |
+| Existing tests                                             | tests/unit/services/construction-forecast-fee-audit.test.ts exercises fee-audit and catch-up behavior; tests/unit/services/projected-metrics-calculator.test.ts and projected-metrics-calculator.legacy-characterization.test.ts characterize the projected consumer.    | REUSE as regression anchors. Extend only in a future approved child plan.                                                                                                                               |
+| Tactyc-equivalence statement and any unratified new engine | No reconciliation proof has established semantic equivalence between the existing calculator and a Tactyc construction model.                                                                                                                                            | QUARANTINE. No product, roadmap, test, or external claim may say Tactyc-equivalent until the sixth slice's reconciliation truth cases pass.                                                             |
 
-- **File**: new GitHub epic issue (external; no repo file at mint time)
-- **Current state**: No issue exists. No construction-engine code exists in the
-  repo; Current-Forecast V2 serves the reference forecast only.
-- **Modifications** (issue body content at mint time):
-  - Epic with six slices, each to become its own follow-up TRIP plan:
-    1. Allocation / capital-constrained cohort formation
-    2. Pacing + graduation transitions
-    3. Follow-on / pro-rata / dilution
-    4. Exit/failure probabilities + valuations
-    5. Fractional-count disclosure
-    6. Construction-vs-current-forecast truth cases
-  - Record on the epic: NEW-D does **not** block activation; it blocks
-    Tactyc-equivalence claims only.
-  - Design is explicitly out of scope for this plan; each slice's TRIP-1 plan
-    owns its own design.
-- **Invariants**: No slice plan may claim Tactyc equivalence before slice 6
-  (truth cases) passes; slice plans must not reopen activation semantics
-  (one-way latch documented in `#1299`).
-- **Verification**: `gh issue view <NEW-D> --json body` shows all six slices and
-  the non-blocking/equivalence-claim scoping statement.
+REPLACE inventory: none. Replacement remains prohibited until a future approved
+child plan identifies a semantic gap with reconciliation evidence, specifies
+consumer migration and regression coverage, and clears its domain gates.
 
-### 2. #1022 — NARROW to engine authority / activation hardening (HITL — external, then first construction slice)
+### NEW-D future epic text
 
-- **File**: issue `#1022` body (external edit)
-- **Current state**: Issue body is over-broad relative to the
-  construction-engine epic.
-- **Modifications**:
-  - (HITL — external) Narrow `#1022` to engine authority / activation hardening
-    plus ownership of the **first construction slice** (allocation /
-    capital-constrained cohort formation, slice 1 of NEW-D).
-  - Remove scope now owned by NEW-D slices 2–6 and record the pointers on the
-    issue.
-- **Invariants**: After narrowing, `#1022` scope must be a strict subset of
-  NEW-D slice 1 plus hardening; no overlap with `#1023` (Scenario-V2 adapter)
-  scope.
-- **Verification**: `gh issue view 1022 --json body` reflects the narrowed
-  scope; follow-up TRIP plan for `#1022` is minted only after the body edit
-  lands.
+NEW-D may be proposed only as a post-G5 HITL issue. Its durable text must state
+that it is non-blocking for activation and contains these six sequential future
+convergence slices:
 
-### 3. #1023 — REWRITE solely as Scenario-V2 adapter (HITL — external)
+1. Allocation and capital-constrained cohort formation.
+2. Pacing and graduation.
+3. Follow-on, pro-rata, and dilution.
+4. Exit, failure, and valuation.
+5. Fractional-count disclosure.
+6. Construction-versus-current-forecast reconciliation truth cases.
 
-- **File**: issue `#1023` body (external edit)
-- **Current state**: Issue body predates the Current-Forecast V2 activation and
-  references pre-activation surfaces.
-- **Modifications**:
-  - (HITL — external) Rewrite `#1023` so its entire scope is the Scenario-V2
-    adapter keyed on `financialFactsSnapshotId` + `currentPlanVersionId`.
-  - Broader scenario UX is explicitly out of scope for `#1023`; it follows as
-    later work after the adapter lands (product order: construction engine +
-    narrowed `#1022` → Scenario-V2 `#1023` → broader scenario UX).
-- **Invariants**: Adapter consumes only activated V2 surfaces; no dependency on
-  the retired `enable_current_forecast_v2` flag (removed in Phase 0, `#1299-R`).
-- **Verification**: `gh issue view 1023 --json body` reflects the adapter-only
-  scope with both key fields named.
+Each slice needs a separate approved TRIP-1 plan after its dependency gates
+open. Slice 6 must compare named inputs, timing, monetary boundaries,
+assumptions, and disclosed differences against the current construction
+baseline. Passing reconciliation truth cases is the sole gate in this charter
+for a Tactyc-equivalence claim; landing any earlier slice is insufficient.
 
-### 4. Waterfall lane sequencing (#1305 → #1291 → #1306 → #1307 → #1308; #1309 optional)
+## #1022 and #1023 — Durable Supersession Control
 
-- **File**: issues `#1305`, `#1291`, `#1306`, `#1307`, `#1308`, `#1309`
-  (external records; no repo file at planning time)
-- **Current state**: Lane issues exist without a recorded execution order.
-- **Modifications** (sequencing record only):
-  - Fixed order: `#1305` → `#1291` → `#1306` → `#1307` → `#1308`; `#1309` is
-    optional and may be dropped or deferred without affecting the lane.
-  - `#1307` LP-tier expense treatment coordinates with `#1321` (single
-    class/profile model, owned by `F_1.3.0_fee-economics-convergence.plan.md`);
-    `#1307` must not start before `#1321` semantics are settled.
-  - The Wave W merge fence from Phase 2 applies to any lane ticket attempting a
-    pre-soak merge.
-  - Lane tickets are waterfall-domain work: each gets its own TRIP plan and
-    waterfall-specialist review; never batch lane tickets with unrelated UI/fee
-    work (same rule that keeps `#1317` separate in Phase 3).
-- **Invariants**: Order is not reorderable without a recorded DECISIONS.md
-  entry; `#1309` optional status must be recorded on the issue.
-- **Verification**: Blocked-by relationships visible via
-  `gh issue view <n> --json body` for each lane ticket.
+The live PRDs, all issue comments, and GitHub edit history are preserved. A
+future owner may approve an additive supersession comment, but this charter
+prohibits body replacement as the default. A body rewrite requires a separate,
+explicit HITL decision after a fresh snapshot and must preserve the original PRD
+by GitHub history rather than treating it as deleted.
 
-### 5. NEW-C — Internal KPI manager activation (mint; HITL — external)
+| Issue | Durable snapshot metadata                                                                                                                                              | Retained scope and record                                                                                               | Proposed move or supersession scope; not approved                                                                                                                                                                                                                                    | Removed scope                                                                                                                                                 | Required approval and child-plan gate                                                                                                                            |
+| ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| #1022 | open; updated 2026-08-03T23:45:03Z; https://github.com/nikhillinit/Updog_restore/issues/1022; SHA-256 4cba19c963068f70cd6e9b919f7a0cae402c17f27cc0659c6d151fdaffd659ed | Retain the live allocation-first Round/FMV actuals PRD, its facts-contract constraints, comments, and edit history.     | Candidate only: define whether a narrowly approved allocation/cohort construction slice belongs in NEW-D or remains in #1022. Any moved scope must name source and destination acceptance criteria, preserve facts-contract constraints, and avoid a second construction calculator. | None from the live issue or history. Any scope excluded from a future child plan is retained in the live PRD until an owner approves an explicit destination. | Repository owner approves exact additive comment after re-fence. A child plan may be minted only from that approved comment text and only after lifecycle gates. |
+| #1023 | open; updated 2026-08-03T23:45:04Z; https://github.com/nikhillinit/Updog_restore/issues/1023; SHA-256 85595a8439ab534b8309a19e01ec05421f29417b6fd18a6972792372fe3ece7a | Retain the live Scenario Builder and Monte Carlo PRD, actuals-facts provenance constraints, comments, and edit history. | Candidate only: a post-construction Scenario-V2 adapter limited to financialFactsSnapshotId plus currentPlanVersionId. Broader Scenario Builder and Monte Carlo UX stays separately deferred unless the owner approves exact destination text.                                       | None from the live issue or history. The proposed adapter must not silently erase the retained probabilistic PRD.                                             | Repository owner approves exact additive comment after re-fence. A child plan may be minted only from that approved comment text and only after lifecycle gates. |
 
-- **File**: new GitHub issue (external at mint time); anticipated future code
-  paths listed under Files to Modify/Create
-- **Current state**: `#1326` delivered the `kpi-observation/1.0.0` backend only
-  (list/read/create/CSV import/optimistic-lock review). `/kpi-manager` and
-  `/kpi-submission` redirect to `/dashboard` today.
-- **Modifications** (issue body content at mint time; implementation owned by a
-  follow-up TRIP plan):
-  - Wire an authenticated internal KPI manager UI to the `kpi-observation/1.0.0`
-    backend: list, CSV import, manual entry, review, filtering.
-  - Update route governance + README.
-  - `/kpi-submission` stays archived (redirect remains).
-- **Invariants**: Authenticated surface only; no regression to existing
-  `/dashboard` redirect behavior for `/kpi-submission`.
-- **Verification**: `gh issue view <NEW-C> --json body` shows the five UI
-  capabilities and the archived-redirect invariant. The follow-up implementation
-  plan must verify with `npm run test:integration && npm run policy:verify`.
+Default additive-comment template, for owner review only:
 
-### 6. Disposition closes (HITL — external)
+> Proposed supersession map; it does not replace this issue body, comments, or
+> edit history. Retained scope: (exact text). Moved or deferred scope: (exact
+> text and destination). Removed-from-proposed-child-scope: (exact text; no
+> historical deletion). Approved implementation scope: (exact text). No child
+> plan, dependency edit, or dispatch is authorized until this comment is
+> approved and current issue metadata matches the recorded snapshot.
 
-- **File**: issues `#1314`, `#1054` (external)
-- **Current state**: Both close conditions are verified but unexecuted.
-- **Modifications**:
-  - (HITL — external) `gh issue close 1314` — ADR-070
-    `docs/adr/ADR-070-cashless-gp-commitments-and-fee-waivers.md` verified
-    present on main; `fundedFromFeesPct` landed via `#1333`.
-  - (HITL — external) `gh issue close 1054` — facts used for per-company
-    candidate rankings; per prior verdict, not re-litigated.
-- **Invariants**: Close comments must cite the evidence (ADR-070 path, `#1333`
-  for `#1314`; prior verdict for `#1054`).
-- **Verification**: `gh issue view 1314 --json state` and
-  `gh issue view 1054 --json state` return `CLOSED`.
+The approved comment must repeat the current body digest or provide the
+refreshed digest, identify all retained, moved, and removed-from-proposed-child
+scope, and state whether NEW-D exists. A proposed comment is not an instruction
+to mutate the issue.
 
-## Technical Considerations
+## Waterfall Lane — BLOCKED-GOVERNANCE
 
-- **Sequencing-only plan**: no `TRIP-2-implement` dispatch originates here.
-  Every code-bearing item (NEW-D slices, narrowed `#1022`, rewritten `#1023`,
-  waterfall lane, NEW-C) requires its own follow-up TRIP-1 plan after the HITL
-  issue mutations land.
-- **Re-fence before dispatch**: the plan is keyed to `origin/main` @ `a3d0a6b6`;
-  two merges landed on snapshot day (`#1333`, `#1326`), so re-verify issue
-  bodies and file paths before each follow-up plan is written.
-- **Activation semantics are settled upstream**: the one-way activation latch,
-  resume/re-arm command, and soak runbook are owned by Phases 0–2. Phase 4 items
-  must not reopen them; `#1023` in particular must not depend on the retired
-  `enable_current_forecast_v2` flag.
-- **Cross-plan dependency**: `#1307` ↔ `#1321` coordination crosses plan
-  boundaries (Phase 3 owns `#1321`); record the coordination decision on both
-  issues when `#1321` lands or is promoted by ELIG (ELIG is owned by
-  `F_1.1.0_wave-h-context-rail-decisions.plan.md`).
-- **Equivalence-claim gate**: no external or internal Tactyc-equivalence claim
-  is permitted until NEW-D slice 6 (construction-vs-current-forecast truth
-  cases) passes under `npm run phoenix:truth`.
+Status for the entire lane: BLOCKED-GOVERNANCE. Repository authority is the
+accepted ADR record, not a later issue-comment instruction that conflicts with
+it.
 
-## Files to Modify/Create
+### Repository DAG and parked work
 
-This plan itself changes no repo files. The following are anticipated by the
-follow-up implementation plans; exact paths are set by those plans:
+The repository DAG to preserve unless jointly ratified otherwise is:
 
-1. `client/src/pages/` (new, anticipated) — KPI manager page for NEW-C
-2. `client/src/hooks/` (new, anticipated) — KPI data hooks for NEW-C
-3. `shared/routes/api-route-manifest.ts` (modify, anticipated) — route
-   registration if NEW-C adds endpoints
-4. `docs/_generated/router-index.json` (regenerate, anticipated) — after NEW-C
-   route/docs changes
-5. `README.md` (modify, anticipated) — NEW-C route governance documentation
-6. Various test files (new/modify, anticipated) — per follow-up plan
-   verification blocks (NEW-C integration tests, NEW-D slice 6 truth cases,
-   waterfall lane calc-gate tests)
+    #1305 → (#1306, #1307)
+                     ↑
+                   #1321
 
-## Test Impact
+    #1291: PARKED
+    #1308: PARKED
+    #1309: DEFERRED
 
-- No existing tests are affected by this plan directly; it dispatches no code
-  changes.
-- NEW-D slice 6 introduces new construction-vs-current-forecast truth cases that
-  must run under `npm run phoenix:truth`; slice plans 1–5 each carry their own
-  unit coverage.
-- NEW-C's follow-up plan must add integration coverage for the KPI manager UI
-  and pass `npm run test:integration && npm run policy:verify`.
-- Waterfall lane items (`#1305`–`#1308`) each require calc-gate coverage
-  (`npm run calc-gate`) in their own plans, with waterfall-specialist review.
-- E2E applicability: none in this plan; NEW-C and scenario-UX follow-ups should
-  evaluate E2E coverage at planning time.
+#1321 also gates #1307 because LP-class/profile semantics must remain one model.
+#1291 and #1308 remain parked under ADR-066 and ADR-068; #1309 is deferred. This
+is deliberately not the linear #1305 → #1291 → #1306 → #1307 → #1308 chain.
 
-## Documentation Impact
+| Record                    | Snapshot or repository evidence                                                                                                                                                                                                                                                                                            | Consequence                                                                                      |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| ADR-066                   | DECISIONS.md:9586-9627 requires deal_by_deal-only activation evidence and parks #1291, with #1285 controlling #1291 and #1308.                                                                                                                                                                                             | #1291 and #1308 cannot be scheduled as an unconditional linear lane.                             |
+| ADR-068                   | DECISIONS.md:9673-9790 restores vocabulary while deferring live selection, preserves #1285's parked role, and records the side trail; DECISIONS.md:9847-9948 records consumer blast radius and certification limits.                                                                                                       | #1305 may not be treated as permission to widen selection, persistence, or certified results.    |
+| #1285 later owner comment | Comment 5172912679, author nikhillinit; timestamps not exposed by connector; https://github.com/nikhillinit/Updog_restore/issues/1285#issuecomment-5172912679; SHA-256 fe26542dce48c9abb73bf0c57d3d0625e6000843cc00374285ce8cefc7baa12f. Its stated linear chain is #1305 → #1291 → #1306 → #1307 → #1308, #1309 optional. | Authority conflict. Record it as evidence, not as a dependency change or dispatch authorization. |
 
-- `README.md` — must be updated by NEW-C's follow-up plan for the activated
-  `/kpi-manager` route (currently redirecting to `/dashboard`).
-- `DECISIONS.md` — must record any waterfall-lane reordering and the
-  `#1307`/`#1321` coordination outcome when decided.
-- `CHANGELOG.md` — entries required when NEW-C, narrowed `#1022`, rewritten
-  `#1023`, and waterfall lane follow-up plans land.
-- `docs/_generated/router-index.json` — regenerate if NEW-C or scenario work
-  adds routes or docs pages.
-- `AGENTS.md` — update only if NEW-D slice plans introduce new engine
-  directories or conventions.
-- `cheatsheets/INDEX.md` — update only if a follow-up plan adds a runbook or
-  cheatsheet (none planned here).
+Related durable issue snapshots:
 
-## Backlog Disposition (authoritative verdict record — fully reflected, no silent drops)
+| Issue | State | Updated at           | SHA-256 raw body                                                 |
+| ----- | ----- | -------------------- | ---------------------------------------------------------------- |
+| #1305 | open  | 2026-08-03T23:44:57Z | cb4254bd3e1ed31d4d5333a247cd1faf0dae8d7021c976f3c41a0f513514a806 |
+| #1306 | open  | 2026-08-03T23:44:58Z | 647b8b37e63a48e3bc527bd6a5b84c901d260476972699b3635c8a5d52d12154 |
+| #1307 | open  | 2026-08-03T23:45:00Z | dcf1bd556573127ff6bf7b92ebe1b8bfa0e88a464f3e9620b854d66a59d7d8e9 |
+| #1291 | open  | 2026-08-03T23:44:56Z | 4ba4677e241e27ea76c47dfc9e0757bc35b2755f63a080d33fec678f028479ad |
+| #1308 | open  | 2026-08-03T23:45:01Z | bc18a110e49f5bd7d11a7def70ba8ffeb7f49cb1b48a433cc6c164562cbf16c9 |
+| #1309 | open  | 2026-08-03T23:45:02Z | f40c22f766280abac8ca0c0ec7dd6e2dc98b80256231887dfb452ca544a5e69c |
+| #1321 | open  | 2026-08-03T23:44:38Z | a5c66b264f80c991ed5942fdb057621a7f6ce603e8d07901c0a365db8933c5f4 |
 
-| Issue | Verdict                           | Where in plan                                                                                                                                                                                              |
-| ----- | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| #1314 | CLOSE                             | This plan, section 6 (ADR-070 verified present on main; `fundedFromFeesPct` via #1333)                                                                                                                     |
-| #1317 | NARROW                            | `F_1.3.0_fee-economics-convergence.plan.md` (separate item; waterfall-specialist review)                                                                                                                   |
-| #1337 | KEEP                              | `F_1.3.0_fee-economics-convergence.plan.md` (Phase 3 head)                                                                                                                                                 |
-| #1338 | RETITLE/KEEP                      | `F_1.3.0_fee-economics-convergence.plan.md` (coordinated with #1321)                                                                                                                                       |
-| #1339 | BROADEN                           | `F_1.3.0_fee-economics-convergence.plan.md` (after #1318)                                                                                                                                                  |
-| #1320 | KEEP (conditional pre-activation) | ELIG decision in `F_1.1.0_wave-h-context-rail-decisions.plan.md`; conditional promotion gates #1296 in `F_1.2.0_deployment-soak-activation.plan.md`; otherwise `F_1.3.0_fee-economics-convergence.plan.md` |
-| #1321 | KEEP                              | `F_1.3.0_fee-economics-convergence.plan.md` (promotable via ELIG in `F_1.1.0_wave-h-context-rail-decisions.plan.md`; coordinates with this plan's #1307)                                                   |
-| #1318 | KEEP after #1321                  | `F_1.3.0_fee-economics-convergence.plan.md`                                                                                                                                                                |
-| #1022 | NARROW                            | This plan, section 2                                                                                                                                                                                       |
-| #1023 | REWRITE                           | This plan, section 3                                                                                                                                                                                       |
-| #1054 | CLOSE                             | This plan, section 6                                                                                                                                                                                       |
+No child plan, issue dependency edit, issue comment, issue body change, or
+implementation dispatch may occur for any waterfall item until both the
+repository owner and waterfall-specialist jointly ratify one of:
 
-## To-dos
+1. The existing ADR-066 and ADR-068 DAG above; or
+2. A new superseding ADR that states semantic effects, a complete replacement
+   DAG, and new test and merge gates.
 
-### Phase A — Prerequisites (HITL — external)
+The joint ratification must be durable, cite the fresh snapshots and comment
+5172912679, and state how #1321 gates #1307. F1.4 does not amend either ADR.
 
-- [ ] Confirm Phase 2 activation complete (`#1299` flip executed, one-way latch
-      documented) per `F_1.2.0_deployment-soak-activation.plan.md` before
-      dispatching any Phase 4 follow-up plan (HITL — external)
-- [ ] Confirm Phase 3 `#1321` status (landed, in progress, or ELIG-promoted) to
-      settle the `#1307` coordination point (HITL — external)
+## NEW-C — KPI Manager Governance
 
-### Phase B — Issue mutations (HITL — external)
+### Preflight inventory
 
-- [ ] Mint NEW-D Tactyc Construction Engine epic with all six slices and the
-      non-blocking/equivalence-claim scoping statement (HITL — external)
-- [ ] Narrow `#1022` body to engine authority/activation hardening + first
-      construction slice; record removed scope pointers to NEW-D slices 2–6
-      (HITL — external)
-- [ ] Rewrite `#1023` body to Scenario-V2 adapter only
-      (`financialFactsSnapshotId` + `currentPlanVersionId`); move broader
-      scenario UX out of scope (HITL — external)
-- [ ] Mint NEW-C internal KPI manager activation issue (list, CSV import, manual
-      entry, review, filtering; route governance + README; `/kpi-submission`
-      stays archived) (HITL — external)
-- [ ] Record waterfall lane order (`#1305` → `#1291` → `#1306` → `#1307` →
-      `#1308`; `#1309` optional) as blocked-by relationships on the lane issues
-      (HITL — external)
-- [ ] Record the Wave W merge fence (no pre-soak merge) on each waterfall lane
-      issue (HITL — external)
-- [ ] Record the `#1307` ↔ `#1321` coordination requirement on both issues (HITL
-      — external)
+KPI manager is currently a placeholder, not a live management page. The
+authoritative archived-placeholder registry keeps /kpi-manager and
+/kpi-submission redirected to /dashboard at
+shared/routes/app-route-definitions.ts:41-63. This registry, not an old page
+name, governs current routing.
 
-### Phase C — Disposition closes (HITL — external)
+The existing backend is reusable. Future preflight must name and inspect:
 
-- [ ] `gh issue close 1314` with comment citing
-      `docs/adr/ADR-070-cashless-gp-commitments-and-fee-waivers.md` on main and
-      `fundedFromFeesPct` via `#1333` (HITL — external)
-- [ ] `gh issue close 1054` with comment citing the per-company
-      candidate-ranking verdict (HITL — external)
+- Contract: shared/contracts/kpi/kpi-observation-v1.contract.ts.
+- Route: server/routes/kpi-observations.ts.
+- Services: server/services/kpi/kpi-observation-service.ts and
+  server/services/kpi/kpi-observation-csv.ts.
+- Existing evidence:
+  tests/unit/contract/kpi/kpi-observation-v1.contract.test.ts,
+  tests/unit/routes/kpi-observations.contract.test.ts,
+  tests/unit/routes/kpi-observations-dual-runtime.contract.test.ts, and
+  tests/integration/kpi/kpi-observation-persistence.pg.test.ts.
 
-### Phase D — Sequencing: NEW-D construction engine (product order step 1)
+No initial endpoint is authorized. NEW-C reuses these observation contracts,
+routes, and services; it does not create a parallel KPI API.
 
-- [ ] Write follow-up TRIP-1 plan for narrowed `#1022` (engine
-      authority/activation hardening + construction slice 1:
-      allocation/capital-constrained cohort formation)
-- [ ] Write follow-up TRIP-1 plan for NEW-D slice 2 (pacing + graduation
-      transitions)
-- [ ] Write follow-up TRIP-1 plan for NEW-D slice 3
-      (follow-on/pro-rata/dilution)
-- [ ] Write follow-up TRIP-1 plan for NEW-D slice 4 (exit/failure
-      probabilities + valuations)
-- [ ] Write follow-up TRIP-1 plan for NEW-D slice 5 (fractional-count
-      disclosure)
-- [ ] Write follow-up TRIP-1 plan for NEW-D slice 6
-      (construction-vs-current-forecast truth cases; gate for Tactyc-equivalence
-      claims)
+### Future child-plan boundary
 
-### Phase E — Sequencing: Scenario-V2 (product order step 2)
+After G5 and an approved NEW-C issue text, a child plan may move /kpi-manager
+from archived placeholder routing into protected application routing and
+register a lazy KPI manager component. It must preserve /kpi-submission →
+/dashboard as an archived redirect.
 
-- [ ] Write follow-up TRIP-1 plan for rewritten `#1023` (Scenario-V2 adapter)
-      after narrowed `#1022` slice 1 lands
-- [ ] Record broader scenario UX as a separate later item, gated on `#1023`
-      adapter completion
+If the proposed page needs a backend capability absent from the named contract,
+route, or services, stop and create a contract-gap decision packet instead of
+adding an endpoint. The packet must include the required user operation, current
+contract evidence, missing request/response or concurrency semantics,
+authorization and idempotency/optimistic-lock implications, alternatives, owner,
+and an approval decision. A later approved child plan, not this charter, may act
+on the decision.
 
-### Phase F — Sequencing: waterfall lane
+Exact future Playwright acceptance:
 
-- [ ] Write follow-up TRIP-1 plan for `#1305`
-- [ ] Write follow-up TRIP-1 plan for `#1291` (after `#1305`)
-- [ ] Write follow-up TRIP-1 plan for `#1306` (after `#1291`)
-- [ ] Write follow-up TRIP-1 plan for `#1307` (after `#1306` and after `#1321`
-      semantics settled)
-- [ ] Write follow-up TRIP-1 plan for `#1308` (after `#1307`)
-- [ ] Decide keep/drop for optional `#1309` and record the decision on the issue
-      (HITL — external)
+1. Anonymous access to /kpi-manager redirects to login.
+2. Authenticated authorized access to /kpi-manager renders KPI manager.
+3. Access to archived /kpi-submission retains redirect to /dashboard.
 
-### Phase G — Sequencing: NEW-C KPI manager
+## Backlog Dispositions
 
-- [ ] Write follow-up TRIP-1 plan for NEW-C (KPI manager UI wiring; verification
-      `npm run test:integration && npm run policy:verify`)
+| Issue | Durable snapshot metadata                                                                                                                                              | Governance disposition                                                                                                                                                                                         | External action rule                    |
+| ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| #1314 | open; updated 2026-08-03T23:44:33Z; https://github.com/nikhillinit/Updog_restore/issues/1314; SHA-256 60a4dfc4c3fd6927b069cac9b70971b5746eb970c324ad839ef3d268e02b4963 | Close-ready only after HITL approval and an evidence-citing close comment. The approval must identify the governing decision and the verified implementation evidence; stale snapshot metadata blocks closure. | No automatic comment or closure.        |
+| #1054 | open; updated 2026-08-03T23:45:05Z; https://github.com/nikhillinit/Updog_restore/issues/1054; SHA-256 de6aea416ca17882c237490f4ba4372cbaed1fdf8176ba0e126128925b56302f | Reproducible low-priority debt. Keep open and do not relabel it as activation or post-activation completion.                                                                                                   | No automatic edit, comment, or closure. |
+
+## Future-Dispatch Checklist
+
+Before any future child plan is written or implementation work begins, require
+all of the following:
+
+- Durable G3, G4, and G5 satisfaction evidence; no reliance on preview status or
+  an unmerged acceptance assertion.
+- Fresh repository preflight against current main, including cited consumer and
+  test seams.
+- Fresh issue/comment snapshots whose metadata and SHA-256 digests match, or an
+  explicitly refreshed matrix.
+- Exact HITL-approved additive supersession text for #1022, #1023, or NEW-C.
+- Waterfall joint ratification if any waterfall issue is in scope.
+- A bounded TRIP-1 plan with named acceptance, test, merge, and specialist
+  gates. No plan may broaden an external issue beyond approved text.
+
+## Verification and Change Scope
+
+This charter changes documentation only. It makes no runtime, schema, test,
+generated-artifact, ADR, or external-system change. Verify this planning change
+with targeted remark --frail, git diff --check, stale-baseline and stale-F1.2
+filename scans, matrix metadata/digest comparison against the corrected
+snapshot, and one-tracked-file scope before commit.

--- a/docs/_generated/router-fast.json
+++ b/docs/_generated/router-fast.json
@@ -2,7 +2,7 @@
   "config": {
     "max_docs_per_keyword": 25
   },
-  "generatedAt": "2026-08-09T00:00:00.000Z",
+  "generatedAt": "2026-08-10T00:00:00.000Z",
   "keyword_to_docs": {
     "add feature": [
       "CLAUDE.md"

--- a/docs/_generated/router-index.json
+++ b/docs/_generated/router-index.json
@@ -261,7 +261,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".agents-feedback.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -276,7 +276,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".agents-metrics.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -304,7 +304,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Team",
       "path": ".claude/AGENT-DIRECTORY.md",
-      "staleDays": 223,
+      "staleDays": 224,
       "status": "ACTIVE"
     },
     {
@@ -333,7 +333,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Platform Team",
       "path": ".claude/AGENT-METRICS.md",
-      "staleDays": 81,
+      "staleDays": 82,
       "status": "ACTIVE"
     },
     {
@@ -348,7 +348,7 @@
       "lastUpdated": "2026-03-27",
       "owner": null,
       "path": ".claude/ANTI-DRIFT-CHECKLIST.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -363,7 +363,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/DELIVERY-SUMMARY.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "HISTORICAL"
     },
     {
@@ -392,7 +392,7 @@
       "lastUpdated": "2026-04-18",
       "owner": "Platform Team",
       "path": ".claude/DISCOVERY-MAP.md",
-      "staleDays": 113,
+      "staleDays": 114,
       "status": "ACTIVE"
     },
     {
@@ -407,7 +407,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/PHOENIX-AGENTS-REGISTRY.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -422,7 +422,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/PHOENIX-TOOL-ROUTING.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -437,7 +437,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/PROJECT-UNDERSTANDING.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -452,7 +452,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": ".claude/WORKFLOW.md",
-      "staleDays": 113,
+      "staleDays": 114,
       "status": "ACTIVE"
     },
     {
@@ -472,7 +472,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/baseline-regression-explainer.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -489,7 +489,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/chaos-engineer.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -507,7 +507,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/code-explorer.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -525,7 +525,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/code-reviewer.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -542,7 +542,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/code-simplifier.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -560,7 +560,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/comment-analyzer.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -577,7 +577,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/context-orchestrator.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -594,7 +594,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/database-expert.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -612,7 +612,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/db-migration.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -629,7 +629,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/debug-expert.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -646,7 +646,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/devops-troubleshooter.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -663,7 +663,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/docs-architect.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -680,7 +680,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/dx-optimizer.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -697,7 +697,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/incident-responder.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -714,7 +714,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/legacy-modernizer.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -734,7 +734,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/parity-auditor.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -752,7 +752,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/perf-guard.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -772,7 +772,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/perf-regression-triager.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -794,7 +794,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-brand-reporting-stylist.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -816,7 +816,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-capital-allocation-analyst.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -838,7 +838,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-docs-scribe.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -860,7 +860,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-precision-guardian.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -882,7 +882,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-probabilistic-engineer.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -904,7 +904,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-reserves-optimizer.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -926,7 +926,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-truth-case-runner.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -946,7 +946,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/playwright-test-author.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -964,7 +964,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/pr-test-analyzer.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -984,7 +984,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/schema-drift-checker.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -1002,7 +1002,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/silent-failure-hunter.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -1019,7 +1019,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/test-automator.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -1037,7 +1037,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/test-repair.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -1055,7 +1055,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/test-scaffolder.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -1073,7 +1073,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/type-design-analyzer.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -1094,7 +1094,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/waterfall-specialist.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -1111,7 +1111,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/workflow-orchestrator.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -1133,7 +1133,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/xirr-fees-validator.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -1151,7 +1151,7 @@
       "lastUpdated": "2026-06-23",
       "owner": "Platform / GP Modeling",
       "path": ".claude/artifacts/debate-rubric-v33.md",
-      "staleDays": 47,
+      "staleDays": 48,
       "status": "REFERENCE"
     },
     {
@@ -1169,7 +1169,7 @@
       "lastUpdated": "2026-06-23",
       "owner": "Platform / GP Modeling",
       "path": ".claude/artifacts/debate-synthesis-v33.md",
-      "staleDays": 47,
+      "staleDays": 48,
       "status": "REFERENCE"
     },
     {
@@ -1196,7 +1196,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/advise.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -1212,7 +1212,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/catalog-tooling.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -1228,7 +1228,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/db-validate.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -1243,7 +1243,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/deploy-check.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -1260,7 +1260,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/enable-agent-memory.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -1276,7 +1276,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/evaluate-tools.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -1291,7 +1291,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/fix-auto.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -1308,7 +1308,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/log-change.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -1325,7 +1325,7 @@
       "lastUpdated": "2026-04-06",
       "owner": null,
       "path": ".claude/commands/log-decision.md",
-      "staleDays": 125,
+      "staleDays": 126,
       "status": "UNKNOWN"
     },
     {
@@ -1343,7 +1343,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/phoenix-phase2.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -1360,7 +1360,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/phoenix-prob-report.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -1377,7 +1377,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/phoenix-truth.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -1393,7 +1393,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/pr-ready.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -1408,7 +1408,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/pre-commit-check.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -1423,7 +1423,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/retrospective.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -1438,7 +1438,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/session-learnings.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "HISTORICAL"
     },
     {
@@ -1454,7 +1454,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/session-start.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -1469,7 +1469,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/test-smart.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -1484,7 +1484,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/workflows.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -1499,7 +1499,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/wshobson/deps-audit.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -1514,7 +1514,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/wshobson/tech-debt.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -1542,7 +1542,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Team",
       "path": ".claude/docs/TEST-STRATEGY.md",
-      "staleDays": 223,
+      "staleDays": 224,
       "status": "ACTIVE"
     },
     {
@@ -1558,7 +1558,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": ".claude/hermes/SOUL.md",
-      "staleDays": 81,
+      "staleDays": 82,
       "status": "UNKNOWN"
     },
     {
@@ -1621,7 +1621,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-execution-summary.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "HISTORICAL"
     },
     {
@@ -1636,7 +1636,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-final-report.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "HISTORICAL"
     },
     {
@@ -1651,7 +1651,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-plan-comparison.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -1666,7 +1666,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-reenable-plan-v2.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -1681,7 +1681,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-reenable-plan.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -1734,7 +1734,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Developer",
       "path": ".claude/plan.md",
-      "staleDays": 223,
+      "staleDays": 224,
       "status": "ACTIVE"
     },
     {
@@ -1748,7 +1748,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/ci-workflow-cleanup.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -1762,7 +1762,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4-final-plan.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -1776,7 +1776,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4-review-findings.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -1790,7 +1790,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4.5-findings.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -1804,7 +1804,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4.5-plan.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -1818,7 +1818,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p5-findings.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -1832,7 +1832,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p5-plan.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -1847,7 +1847,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/integration-test-continuation-prompt.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -1862,7 +1862,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/portfolio-intelligence-timeout-fix.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -1877,7 +1877,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-next-session-kickoff.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "HISTORICAL"
     },
     {
@@ -1892,7 +1892,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase2-quickstart.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -1907,7 +1907,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v10.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -1922,7 +1922,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v2.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -1937,7 +1937,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v3.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -1952,7 +1952,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v4.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -1967,7 +1967,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v5.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -1986,7 +1986,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v6.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "ready"
     },
     {
@@ -2005,7 +2005,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v8.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "ready"
     },
     {
@@ -2024,7 +2024,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v9.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "ready"
     },
     {
@@ -2039,7 +2039,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2054,7 +2054,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase4-next-steps.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2093,7 +2093,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/security-fixes-lp-reporting.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "HISTORICAL"
     },
     {
@@ -2108,7 +2108,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/session-summary-portfolio-intelligence-implementation.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "HISTORICAL"
     },
     {
@@ -2123,7 +2123,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/sessions/PHASE4-CONTINUATION-KICKOFF.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2149,7 +2149,7 @@
       "lastUpdated": "2026-05-21",
       "owner": null,
       "path": ".claude/skills/INDEX.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -2164,7 +2164,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/README.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2191,7 +2191,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/api-design-principles.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2206,7 +2206,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/architecture-patterns.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2221,7 +2221,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/async-error-resilience.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2236,7 +2236,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/baseline-governance/SKILL.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2252,7 +2252,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": ".claude/skills/bias-audit/SKILL.md",
-      "staleDays": 90,
+      "staleDays": 91,
       "status": "UNKNOWN"
     },
     {
@@ -2268,7 +2268,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/bundle-size/SKILL.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -2283,7 +2283,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/bundle-size/references/capability-tiers.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2298,7 +2298,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/bundle-size/references/troubleshooting.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2313,7 +2313,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/claude-infra-integrity/SKILL.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2328,7 +2328,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/continuous-improvement.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2344,7 +2344,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": ".claude/skills/control-plane/SKILL.md",
-      "staleDays": 90,
+      "staleDays": 91,
       "status": "UNKNOWN"
     },
     {
@@ -2359,7 +2359,7 @@
       "lastUpdated": "2026-07-29",
       "owner": null,
       "path": ".claude/skills/database-schema-evolution.md",
-      "staleDays": 11,
+      "staleDays": 12,
       "status": "ACTIVE"
     },
     {
@@ -2374,7 +2374,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/extended-thinking-framework.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2389,7 +2389,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/financial-calc-correctness/SKILL.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2405,7 +2405,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/frontend-ui-ux/SKILL.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -2420,7 +2420,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/inversion-thinking.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2435,7 +2435,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/iterative-improvement.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2450,7 +2450,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/memory-management.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2464,7 +2464,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/owasp-security/SKILL.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -2479,7 +2479,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/pattern-recognition.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2495,7 +2495,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-advanced-forecasting/SKILL.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -2511,7 +2511,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-brand-reporting/SKILL.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -2527,7 +2527,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-capital-exit-investigator/SKILL.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -2543,7 +2543,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-docs-sync/SKILL.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -2559,7 +2559,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-precision-guard/SKILL.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -2575,7 +2575,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-reserves-optimizer/SKILL.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -2591,7 +2591,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-truth-case-orchestrator/SKILL.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -2607,7 +2607,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-waterfall-ledger-semantics/SKILL.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -2622,7 +2622,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/phoenix-workflow-orchestrator/SKILL.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2638,7 +2638,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-xirr-fees-validator/SKILL.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -2653,7 +2653,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/prompt-caching-usage.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2668,7 +2668,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/react-hook-form-stability/SKILL.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2683,7 +2683,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/react-performance-optimization.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2699,7 +2699,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/refactor-code/SKILL.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -2715,7 +2715,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/regression-checker/SKILL.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -2730,7 +2730,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/root-cause-tracing.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2748,7 +2748,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/session-learnings/SKILL.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -2763,7 +2763,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/statistical-testing/SKILL.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2778,7 +2778,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/task-decomposition.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2793,7 +2793,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/test-fixture-generator/SKILL.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2808,7 +2808,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/test-pyramid/SKILL.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2824,7 +2824,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/ui-design-system/SKILL.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -2839,7 +2839,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/xlsx.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2854,7 +2854,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/platform-test-checklist.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2869,7 +2869,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/testing/platform-testing-rubric-index.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "ACTIVE"
     },
     {
@@ -2884,7 +2884,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-api-integration.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2899,7 +2899,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-calculation-engines.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2914,7 +2914,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-cross-cutting.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2929,7 +2929,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-fund-setup.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2944,7 +2944,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/scenario-comparison-manual-test-rubric.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2959,7 +2959,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/seed-script-remaining-fixes.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -2974,7 +2974,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": "AGENTS.md",
-      "staleDays": 81,
+      "staleDays": 82,
       "status": "ACTIVE"
     },
     {
@@ -2989,7 +2989,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "AI-WORKFLOW-COMPLETE-GUIDE.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3004,7 +3004,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "ANTI_PATTERNS.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3040,7 +3040,7 @@
       "lastUpdated": "2026-03-27",
       "owner": "Core Team",
       "path": "CAPABILITIES.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3053,11 +3053,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": false,
+      "isStale": true,
       "lastUpdated": "2026-08-03",
       "owner": "Core Team",
       "path": "CHANGELOG.md",
-      "staleDays": 6,
+      "staleDays": 7,
       "status": "ACTIVE"
     },
     {
@@ -3072,7 +3072,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": "CLAUDE.md",
-      "staleDays": 81,
+      "staleDays": 82,
       "status": "ACTIVE"
     },
     {
@@ -3087,7 +3087,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "CLAUDE_COOKBOOK_INTEGRATION.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3102,7 +3102,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "COMPREHENSIVE-WORKFLOW-GUIDE.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3131,7 +3131,7 @@
       "lastUpdated": "2026-08-07",
       "owner": "Core Team",
       "path": "DECISIONS.md",
-      "staleDays": 2,
+      "staleDays": 3,
       "status": "ACTIVE"
     },
     {
@@ -3162,7 +3162,7 @@
       "lastUpdated": "2026-08-08",
       "owner": "Product + Frontend",
       "path": "DESIGN.md",
-      "staleDays": 1,
+      "staleDays": 2,
       "status": "ACTIVE"
     },
     {
@@ -3177,7 +3177,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "DEV_BOOTSTRAP_README.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3192,7 +3192,7 @@
       "lastUpdated": "2026-07-28",
       "owner": null,
       "path": "DEV_BRAIN.md",
-      "staleDays": 12,
+      "staleDays": 13,
       "status": "ACTIVE"
     },
     {
@@ -3219,7 +3219,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "ITERATION-A-QUICKSTART.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3234,7 +3234,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "MIGRATION-NATIVE-MEMORY.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3249,7 +3249,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "NATIVE-MEMORY-INTEGRATION.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3264,7 +3264,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "PRE_MERGE_CHECKLIST.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3279,7 +3279,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "PRODUCTION_RUNBOOK.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3294,7 +3294,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "PROMPT_PATTERNS.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3309,7 +3309,7 @@
       "lastUpdated": "2026-07-11",
       "owner": null,
       "path": "README.md",
-      "staleDays": 29,
+      "staleDays": 30,
       "status": "ACTIVE"
     },
     {
@@ -3324,7 +3324,7 @@
       "lastUpdated": "2026-07-12",
       "owner": null,
       "path": "SECURITY.md",
-      "staleDays": 28,
+      "staleDays": 29,
       "status": "ACTIVE"
     },
     {
@@ -3339,7 +3339,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "STEP_2_AND_4_IMPROVEMENTS.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3366,7 +3366,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "UNIFIED_METRICS_IMPLEMENTATION.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3383,7 +3383,7 @@
       "lastUpdated": "2026-03-27",
       "owner": "Core Team",
       "path": "cheatsheets/INDEX.md",
-      "staleDays": 135,
+      "staleDays": 136,
       "status": "ACTIVE"
     },
     {
@@ -3398,7 +3398,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/agent-architecture.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3413,7 +3413,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/agent-memory-integration.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "ACTIVE"
     },
     {
@@ -3428,7 +3428,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/agent-memory/database-expert-schema-tdd.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3443,7 +3443,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/ai-code-review.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3458,7 +3458,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/anti-pattern-prevention.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3473,7 +3473,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/api.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3488,7 +3488,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "cheatsheets/baseline-governance.md",
-      "staleDays": 90,
+      "staleDays": 91,
       "status": "ACTIVE"
     },
     {
@@ -3503,7 +3503,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/capability-checklist.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3518,7 +3518,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/ci-validator-guide.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3533,7 +3533,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/claude-code-best-practices.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "ACTIVE"
     },
     {
@@ -3548,7 +3548,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/claude-commands.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3563,7 +3563,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/claude-md-guidelines.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3578,7 +3578,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/codex-collaboration-protocol.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3593,7 +3593,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/coding-pairs-playbook.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3608,7 +3608,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/command-summary.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "HISTORICAL"
     },
     {
@@ -3623,7 +3623,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/correct-workflow-example.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3638,7 +3638,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/daily-workflow.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "ACTIVE"
     },
     {
@@ -3653,7 +3653,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/document-review-workflow.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3668,7 +3668,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/documentation-validation.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3683,7 +3683,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/emoji-free-documentation.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3698,7 +3698,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/evaluator-optimizer-workflow.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "ACTIVE"
     },
     {
@@ -3713,7 +3713,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/exact-optional-property-types.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3728,7 +3728,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/extended-thinking.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3743,7 +3743,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/init-vs-update.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3758,7 +3758,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/lp-deployment-quick-reference.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3774,7 +3774,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/lp-reporting-quick-reference.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "active"
     },
     {
@@ -3789,7 +3789,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/memory-commands.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3804,7 +3804,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/memory-commit-strategy.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3819,7 +3819,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/memory-patterns.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3834,7 +3834,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/multi-agent-orchestration.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3849,7 +3849,7 @@
       "lastUpdated": "2026-04-06",
       "owner": null,
       "path": "cheatsheets/pr-merge-verification.md",
-      "staleDays": 125,
+      "staleDays": 126,
       "status": "ACTIVE"
     },
     {
@@ -3864,7 +3864,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/pr-review-workflow.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3879,7 +3879,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "cheatsheets/prompt-improver-hook.md",
-      "staleDays": 90,
+      "staleDays": 91,
       "status": "ACTIVE"
     },
     {
@@ -3894,7 +3894,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/react-performance-patterns.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3909,7 +3909,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/rls-cheatsheet.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "ACTIVE"
     },
     {
@@ -3924,7 +3924,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/schema-alignment.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3939,7 +3939,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/service-testing-patterns.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3954,7 +3954,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/test-fix-patterns.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3969,7 +3969,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/test-pyramid.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3984,7 +3984,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/testcontainers-guide.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -3999,7 +3999,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/testing.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -4014,7 +4014,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/.templates/DEPRECATION-HEADER.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -4029,7 +4029,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/.templates/DOC-FRONTMATTER-SCHEMA.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -4232,6 +4232,30 @@
       "isStale": true,
       "lastUpdated": null,
       "owner": null,
+      "path": "docs/3-code-review/README.md",
+      "staleDays": 999,
+      "status": "UNKNOWN"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {},
+      "hasExecutionClaims": false,
+      "isStale": true,
+      "lastUpdated": null,
+      "owner": null,
+      "path": "docs/3-code-review/canary-exclusion-worklist.md",
+      "staleDays": 999,
+      "status": "UNKNOWN"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {},
+      "hasExecutionClaims": false,
+      "isStale": true,
+      "lastUpdated": null,
+      "owner": null,
       "path": "docs/4-unit-tests/COVERAGE-DEBT.md",
       "staleDays": 999,
       "status": "UNKNOWN"
@@ -4260,7 +4284,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ADR-00X-resilience-circuit-breaker.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -4275,7 +4299,7 @@
       "lastUpdated": "2026-06-03",
       "owner": null,
       "path": "docs/ANALYTICS_IMPLEMENTATION.md",
-      "staleDays": 67,
+      "staleDays": 68,
       "status": "ACTIVE"
     },
     {
@@ -4302,7 +4326,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/ARCHITECTURAL-DEBT.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "ACTIVE"
     },
     {
@@ -4317,7 +4341,7 @@
       "lastUpdated": "2026-07-30",
       "owner": null,
       "path": "docs/BUILD_READINESS.md",
-      "staleDays": 10,
+      "staleDays": 11,
       "status": "ACTIVE"
     },
     {
@@ -4332,7 +4356,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CA-IMPLEMENTATION-PLAN.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -4359,7 +4383,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CA-SEMANTIC-LOCK.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -4374,7 +4398,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CI_GATING_TEST.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -4389,7 +4413,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CLAUDE-INFRA-V4-INTEGRATION-PLAN.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -4416,7 +4440,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CRITICAL_OPTIMIZATIONS.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -4431,7 +4455,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DECISIONS.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -4446,7 +4470,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DELIVERY_PLAYBOOK.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -4461,7 +4485,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DEPLOYMENT.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -4500,7 +4524,7 @@
       "lastUpdated": "2026-04-18",
       "owner": "Core Team",
       "path": "docs/DEVELOPMENT-TOOLING-CATALOG.md",
-      "staleDays": 113,
+      "staleDays": 114,
       "status": "ACTIVE"
     },
     {
@@ -4515,7 +4539,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DEVELOPMENT_STRATEGY.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -4530,7 +4554,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/IDEMPOTENCY_GUIDE.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -4545,7 +4569,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/INCIDENT_RESPONSE.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -4581,7 +4605,7 @@
       "lastUpdated": "2026-08-08",
       "owner": "Core Team",
       "path": "docs/INDEX.md",
-      "staleDays": 1,
+      "staleDays": 2,
       "status": "ACTIVE"
     },
     {
@@ -4596,7 +4620,7 @@
       "lastUpdated": "2026-07-01",
       "owner": null,
       "path": "docs/INFRASTRUCTURE_REMEDIATION.md",
-      "staleDays": 39,
+      "staleDays": 40,
       "status": "HISTORICAL"
     },
     {
@@ -4611,7 +4635,7 @@
       "lastUpdated": "2026-04-20",
       "owner": null,
       "path": "docs/INTEGRATION_PR_CHECKLIST.md",
-      "staleDays": 111,
+      "staleDays": 112,
       "status": "HISTORICAL"
     },
     {
@@ -4626,7 +4650,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/METRICS_OPERATOR_RUNBOOK.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -4641,7 +4665,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/MIGRATION_GUIDE_DB_CIRCUIT.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -4656,7 +4680,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/MILESTONE-XIRR-PHASE0-COMPLETE.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -4671,7 +4695,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/MULTI-AI-DEVELOPMENT-WORKFLOW.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "ACTIVE"
     },
     {
@@ -4686,7 +4710,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/NAV_TREATMENT.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -4701,7 +4725,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/OPERATOR_RUNBOOK.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -4716,7 +4740,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/OPTIMIZED_ROADMAP.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -4731,7 +4755,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHASE1B-ASSEMBLY-INSTRUCTIONS.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -4746,7 +4770,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHASE1B-FEES-IN-PROGRESS.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -4761,7 +4785,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHASE1B-TRUTH-CASES-REFERENCE.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -4802,7 +4826,7 @@
       "lastUpdated": "2026-04-03",
       "owner": "Phoenix Team",
       "path": "docs/PHOENIX-SOT/README.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "ACTIVE"
     },
     {
@@ -4817,7 +4841,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/brand-bridge.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -4832,7 +4856,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/deferred-vesting-plan.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -4847,7 +4871,7 @@
       "lastUpdated": "2026-04-05",
       "owner": null,
       "path": "docs/PHOENIX-SOT/evidence-ledger.md",
-      "staleDays": 126,
+      "staleDays": 127,
       "status": "STALE-VALIDATION"
     },
     {
@@ -4862,7 +4886,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/execution-plan-v2.34.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -4877,7 +4901,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/execution-plan-v3.0-phase3-addendum.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -4892,7 +4916,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/mcp-tools-guide.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -4907,7 +4931,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/prompt-templates.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -4921,7 +4945,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/PHOENIX-SOT/scope-boundary-map.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -4936,7 +4960,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/skills-overview.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -4951,7 +4975,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PORTFOLIO_TABS_ARCHITECTURE.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -4966,7 +4990,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PRODUCTION_CHECKLIST.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -4981,7 +5005,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PR_NOTES/CODACY_JCURVE_NOTE.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -4996,7 +5020,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/RATE_LIMITING_SUMMARY.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "HISTORICAL"
     },
     {
@@ -5011,7 +5035,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/RLS-DEVELOPMENT-GUIDE.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5026,7 +5050,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ROLLBACK_TRIGGERS.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5041,7 +5065,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ROLLOUT_STRATEGY.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5056,7 +5080,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SCENARIO_ANALYSIS_IMPLEMENTATION_STATUS.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5071,7 +5095,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SCENARIO_ANALYSIS_STABILITY_REVIEW.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5086,7 +5110,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SCENARIO_DEPLOY_GUIDE.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5101,7 +5125,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SETUP_NOTES.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5116,7 +5140,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SLO.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5145,7 +5169,7 @@
       "lastUpdated": "2026-05-11",
       "owner": "Core Team",
       "path": "docs/STABILIZATION-ROADMAP.md",
-      "staleDays": 90,
+      "staleDays": 91,
       "status": "ACTIVE"
     },
     {
@@ -5160,7 +5184,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/TYPESCRIPT_BASELINE.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5175,7 +5199,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/VALIDATION-FRAMEWORK-IMPLEMENTATION.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5190,7 +5214,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/VERIFICATION_CHECKLIST.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5205,7 +5229,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/WINDOWS_NODE_CORRUPTION_PREVENTION.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5220,7 +5244,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/WIZARD_RESERVE_BRIDGE_IMPLEMENTATION.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5235,7 +5259,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/WSL2_BUILD_TEST.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5250,7 +5274,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/action-plans/CODEX-FIXES-EXECUTION-SUMMARY.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "HISTORICAL"
     },
     {
@@ -5265,7 +5289,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/action-plans/CODEX-ISSUES-RESOLUTION-PLAN.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5280,7 +5304,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/0001-evaluator-metrics.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5295,7 +5319,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/0002-token-budgeting.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5310,7 +5334,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/0003-streaming-architecture.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5325,7 +5349,7 @@
       "lastUpdated": "2026-08-03",
       "owner": null,
       "path": "docs/adr/ADR-004-waterfall-names.md",
-      "staleDays": 6,
+      "staleDays": 7,
       "status": "ACTIVE"
     },
     {
@@ -5340,7 +5364,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/adr/ADR-005-xirr-excel-parity.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "ACTIVE"
     },
     {
@@ -5355,7 +5379,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-006-fee-calculation-standards.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5370,7 +5394,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-007-exit-recycling-policy.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5385,7 +5409,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-008-capital-allocation-policy.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5400,7 +5424,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-009-RESERVED.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5415,7 +5439,7 @@
       "lastUpdated": "2026-05-08",
       "owner": null,
       "path": "docs/adr/ADR-010-xirr-day-count-and-bounds.md",
-      "staleDays": 93,
+      "staleDays": 94,
       "status": "ACTIVE"
     },
     {
@@ -5430,7 +5454,7 @@
       "lastUpdated": "2026-05-08",
       "owner": null,
       "path": "docs/adr/ADR-011-decimal-string-api-convention.md",
-      "staleDays": 93,
+      "staleDays": 94,
       "status": "ACTIVE"
     },
     {
@@ -5445,7 +5469,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/adr/ADR-013-scenario-comparison-activation.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "ACTIVE"
     },
     {
@@ -5460,7 +5484,7 @@
       "lastUpdated": "2026-05-22",
       "owner": null,
       "path": "docs/adr/ADR-014-snapshot-governance.md",
-      "staleDays": 79,
+      "staleDays": 80,
       "status": "ACTIVE"
     },
     {
@@ -5475,7 +5499,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-015-XIRR-BOUNDED-RATES.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5490,7 +5514,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-017-monte-carlo-validation-strategy.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5505,7 +5529,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-018-stage-normalization-v2.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5520,7 +5544,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-019-mem0-integration.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5546,7 +5570,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/adr/ADR-021-runtime-authority.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -5561,7 +5585,7 @@
       "lastUpdated": "2026-05-29",
       "owner": null,
       "path": "docs/adr/ADR-022-fund-scenario-architecture.md",
-      "staleDays": 72,
+      "staleDays": 73,
       "status": "Implemented"
     },
     {
@@ -5576,7 +5600,7 @@
       "lastUpdated": "2026-06-21",
       "owner": null,
       "path": "docs/adr/ADR-023-investment-event-persistence.md",
-      "staleDays": 49,
+      "staleDays": 50,
       "status": "ACCEPTED (amended 2026-06-21)"
     },
     {
@@ -5615,7 +5639,7 @@
       "lastUpdated": "2026-08-03",
       "owner": null,
       "path": "docs/adr/ADR-070-cashless-gp-commitments-and-fee-waivers.md",
-      "staleDays": 6,
+      "staleDays": 7,
       "status": "ACTIVE"
     },
     {
@@ -5630,7 +5654,7 @@
       "lastUpdated": "2026-08-04",
       "owner": null,
       "path": "docs/adr/README.md",
-      "staleDays": 5,
+      "staleDays": 6,
       "status": "ACTIVE"
     },
     {
@@ -5645,7 +5669,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/agent-2-mobile-executive-dashboard.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5696,7 +5720,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ai-enhanced-components-guide.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5711,7 +5735,7 @@
       "lastUpdated": "2026-03-17",
       "owner": null,
       "path": "docs/ai-optimization/AI_AGENT_BACKTEST_FRAMEWORK.md",
-      "staleDays": 145,
+      "staleDays": 146,
       "status": "ARCHIVED"
     },
     {
@@ -5726,7 +5750,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ai-optimization/AI_COLLABORATION_GUIDE.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5741,7 +5765,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ai-optimization/AI_ORCHESTRATOR_IMPLEMENTATION.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5756,7 +5780,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/ai-optimization/BACKTEST_QUICKSTART.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "ACTIVE"
     },
     {
@@ -5771,7 +5795,7 @@
       "lastUpdated": "2026-05-27",
       "owner": null,
       "path": "docs/ai-optimization/CODEX-REVIEW-AGENT-SETUP.md",
-      "staleDays": 74,
+      "staleDays": 75,
       "status": "HISTORICAL"
     },
     {
@@ -5786,7 +5810,7 @@
       "lastUpdated": "2026-05-27",
       "owner": null,
       "path": "docs/ai-optimization/CODEX_AGENT_MIGRATION.md",
-      "staleDays": 74,
+      "staleDays": 75,
       "status": "HISTORICAL"
     },
     {
@@ -5801,7 +5825,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/analysis/perf-watch-memoization-root-cause.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5816,7 +5840,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/analysis/wizard-steps-pattern-analysis.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5831,7 +5855,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/architecture/portfolio-route-api.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5846,7 +5870,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/contracts/portfolio-route-v1.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5861,7 +5885,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/fund-allocations-phase1b.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5876,7 +5900,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/patterns/existing-route-patterns.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5891,7 +5915,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/testing/portfolio-route-test-strategy.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5906,7 +5930,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/array-safety-adoption-guide.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5933,7 +5957,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/auth/RS256-SETUP.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5948,7 +5972,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/behavioral-specs/time-travel-analytics-service-specs.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5963,7 +5987,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-and-retention.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5978,7 +6002,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/QUICK-REFERENCE.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -5993,7 +6017,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/README.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -6008,7 +6032,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/RLS-CHAOS-TESTING-PLAN.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -6023,7 +6047,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/RLS-GAME-DAY-RUNBOOK.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -6038,7 +6062,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/RLS-MONITORING-SPECS.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -6053,7 +6077,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/catalog.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -6068,7 +6092,7 @@
       "lastUpdated": "2026-03-30",
       "owner": null,
       "path": "docs/chart-migration-decision.md",
-      "staleDays": 132,
+      "staleDays": 133,
       "status": "ACTIVE"
     },
     {
@@ -6083,7 +6107,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ci/triage.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -6098,7 +6122,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/circuit-notion-checklist.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -6112,7 +6136,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/claude/mcp-setup.md",
-      "staleDays": 90,
+      "staleDays": 91,
       "status": "UNKNOWN"
     },
     {
@@ -6126,7 +6150,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/claude/operating-loop.md",
-      "staleDays": 90,
+      "staleDays": 91,
       "status": "UNKNOWN"
     },
     {
@@ -6141,7 +6165,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/code-review/CODEX-BOT-FINDINGS-SUMMARY.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "HISTORICAL"
     },
     {
@@ -6156,7 +6180,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/commands-and-plugins-inventory.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -6171,7 +6195,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/NumericInput.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -6186,7 +6210,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reallocation-tab-implementation.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -6201,7 +6225,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reserve-engine-architecture.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -6216,7 +6240,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reserve-engine-delivery.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -6231,7 +6255,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reserve-engine-spec.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -6246,7 +6270,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/worker-implementation.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -6261,7 +6285,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/contracts/parallel-foundation.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -6276,7 +6300,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/contracts/selector-contract-readme.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -6291,7 +6315,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/database/MULTI-TENANT-RLS-INFRASTRUCTURE.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -6306,7 +6330,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/debugging/profiling-playbook.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -6321,7 +6345,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/debugging/triage-guide.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -6336,7 +6360,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/CODEX-FIXES-DEPLOYMENT-STATUS.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -6351,7 +6375,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/ROLLBACK_PLAN.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -6366,7 +6390,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/STAGING_CHECKLIST.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -6381,7 +6405,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/STAGING_DEPLOYMENT_SUMMARY.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "HISTORICAL"
     },
     {
@@ -6396,7 +6420,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/STAGING_METRICS.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -6411,7 +6435,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/vercel-setup.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -6453,7 +6477,7 @@
       "lastUpdated": "2026-08-08",
       "owner": "Product + Frontend",
       "path": "docs/design/README.md",
-      "staleDays": 1,
+      "staleDays": 2,
       "status": "ACTIVE"
     },
     {
@@ -6501,7 +6525,7 @@
       "lastUpdated": "2026-06-02",
       "owner": "Product + Frontend",
       "path": "docs/design/analytics-visualization-principles.md",
-      "staleDays": 68,
+      "staleDays": 69,
       "status": "ACTIVE"
     },
     {
@@ -6546,7 +6570,7 @@
       "lastUpdated": "2026-06-03",
       "owner": "Product + Frontend",
       "path": "docs/design/analytics-visualization-rollout.md",
-      "staleDays": 67,
+      "staleDays": 68,
       "status": "ACTIVE"
     },
     {
@@ -6579,7 +6603,7 @@
       "lastUpdated": "2026-06-22",
       "owner": "Platform Team",
       "path": "docs/design/audits/2026-06-22-entity-access-boundary.md",
-      "staleDays": 48,
+      "staleDays": 49,
       "status": "ACTIVE"
     },
     {
@@ -6612,7 +6636,7 @@
       "lastUpdated": "2026-06-23",
       "owner": "Platform Team",
       "path": "docs/design/audits/2026-06-23-entity-access-boundary.md",
-      "staleDays": 47,
+      "staleDays": 48,
       "status": "ACTIVE"
     },
     {
@@ -6645,7 +6669,7 @@
       "lastUpdated": "2026-06-23",
       "owner": "Platform Team",
       "path": "docs/design/audits/2026-06-23-trust-audit.md",
-      "staleDays": 47,
+      "staleDays": 48,
       "status": "ACTIVE"
     },
     {
@@ -6683,7 +6707,7 @@
       "lastUpdated": "2026-08-08",
       "owner": "Product + Frontend",
       "path": "docs/design/audits/2026-08-08-preferred-uiux-data-contract-map.md",
-      "staleDays": 1,
+      "staleDays": 2,
       "status": "ACTIVE"
     },
     {
@@ -6714,7 +6738,7 @@
       "lastUpdated": "2026-06-23",
       "owner": "Platform Team",
       "path": "docs/design/audits/client-derived-math-inventory.md",
-      "staleDays": 47,
+      "staleDays": 48,
       "status": "ACTIVE"
     },
     {
@@ -6745,7 +6769,7 @@
       "lastUpdated": "2026-06-15",
       "owner": "Platform Team",
       "path": "docs/design/audits/server-object-readiness.md",
-      "staleDays": 55,
+      "staleDays": 56,
       "status": "ACTIVE"
     },
     {
@@ -6787,7 +6811,7 @@
       "lastUpdated": "2026-08-08",
       "owner": "Product + Frontend",
       "path": "docs/design/references/2026-08-08-preferred-uiux/README.md",
-      "staleDays": 1,
+      "staleDays": 2,
       "status": "REFERENCE"
     },
     {
@@ -6814,7 +6838,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": "docs/dev-environment-reset.md",
-      "staleDays": 113,
+      "staleDays": 114,
       "status": "ACTIVE"
     },
     {
@@ -6830,7 +6854,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/dev/async-iteration.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -6845,7 +6869,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/foreach-fix-improved.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -6860,7 +6884,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/foreach-fix.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -6875,7 +6899,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/windows-setup.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -6890,7 +6914,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/wsl2-quickstart.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -6904,7 +6928,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/evidence/endpoint-ownership.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -6919,7 +6943,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/extended-thinking-integration.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -6934,7 +6958,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/fail-open-close-matrix.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -6949,7 +6973,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/failure-triage.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -6964,7 +6988,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/feature-flags.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -6978,7 +7002,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/financial-precision.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -6993,7 +7017,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/fixes/PR-112-MANAGEMENT-FEE-HORIZON-FIX.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7008,7 +7032,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/fixes/vite-build-vercel-fix.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "ACTIVE"
     },
     {
@@ -7023,7 +7047,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/forecasting/CALIBRATION_GUIDE.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7038,7 +7062,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/forecasting/power-law-implementation.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7053,7 +7077,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/forecasting/streaming-monte-carlo-migration.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7068,7 +7092,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE0.5-TEST-DATA-INFRASTRUCTURE.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7083,7 +7107,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE2-ROADMAP-IMPROVEMENTS.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7098,7 +7122,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE2-ROADMAP.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7113,7 +7137,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE3-KICKOFF.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7128,7 +7152,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE4-KICKOFF.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7143,7 +7167,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE4-SESSION1-SUMMARY.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "HISTORICAL"
     },
     {
@@ -7158,7 +7182,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/fund-allocation-phase1b.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7191,7 +7215,7 @@
       "lastUpdated": "2026-05-28",
       "owner": "Core Team",
       "path": "docs/governance/2026-05-19-refactor-roadmap.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "ACTIVE"
     },
     {
@@ -7206,7 +7230,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/abort-matrix.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7239,7 +7263,7 @@
       "lastUpdated": "2026-05-28",
       "owner": "Core Team",
       "path": "docs/governance/cleanup-manifest.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "ACTIVE"
     },
     {
@@ -7254,7 +7278,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/decision-log.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7269,7 +7293,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/risk-matrix.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7284,7 +7308,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/sync-point-failure-plans.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7299,7 +7323,7 @@
       "lastUpdated": "2026-04-20",
       "owner": null,
       "path": "docs/ia-consolidation-strategy.md",
-      "staleDays": 111,
+      "staleDays": 112,
       "status": "HISTORICAL"
     },
     {
@@ -7314,7 +7338,7 @@
       "lastUpdated": "2026-05-17",
       "owner": null,
       "path": "docs/integration/SCHEMA-MIGRATION-PLAN.md",
-      "staleDays": 84,
+      "staleDays": 85,
       "status": "ACTIVE"
     },
     {
@@ -7329,7 +7353,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/integration/upstash-setup.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7344,7 +7368,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/architecture/state-flow.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7359,7 +7383,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/checklists/definition-of-done.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7374,7 +7398,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/checklists/self-review.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7389,7 +7413,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/database/01-overview.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7404,7 +7428,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/database/02-patterns.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7419,7 +7443,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/database/03-optimization.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7434,7 +7458,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/index.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7449,7 +7473,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/01-overview.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7464,7 +7488,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/02-zod-patterns.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7479,7 +7503,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/03-type-system.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7494,7 +7518,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/04-integration.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7509,7 +7533,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/investigation/ci-failure-analysis-2026-01-10.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "HISTORICAL"
     },
     {
@@ -7524,7 +7548,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/ALIGNMENT-STATUS.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7539,7 +7563,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/IMPLEMENTATION-STATUS.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7554,7 +7578,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/PR2-PROGRESS.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7569,7 +7593,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/PRE-TEST-HARDENING.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7584,7 +7608,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/REVIEW-ACTION-PLAN.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7599,7 +7623,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/STRATEGY-SUMMARY.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "HISTORICAL"
     },
     {
@@ -7614,7 +7638,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/iteration-a-implementation-guide.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7629,7 +7653,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/lp-deployment-checklist.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7644,7 +7668,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/lp-observability-implementation.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7665,7 +7689,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/lp-reporting-database-optimization.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "active"
     },
     {
@@ -7679,7 +7703,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/lp-reporting/PHASE-1B-PLAN.md",
-      "staleDays": 90,
+      "staleDays": 91,
       "status": "UNKNOWN"
     },
     {
@@ -7694,7 +7718,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/lp-slo-definitions.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7709,7 +7733,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/metrics-meanings.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7724,7 +7748,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/PHASE2-COMPLETE.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7739,7 +7763,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/capital-allocation.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7754,7 +7778,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/cohorts/01-overview.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7769,7 +7793,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/cohorts/02-metrics.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7784,7 +7808,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/cohorts/03-analysis.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7799,7 +7823,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/exit-recycling.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7814,7 +7838,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/fees.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7829,7 +7853,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/01-overview.md",
-      "staleDays": 90,
+      "staleDays": 91,
       "status": "ACTIVE"
     },
     {
@@ -7844,7 +7868,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/02-simulation.md",
-      "staleDays": 90,
+      "staleDays": 91,
       "status": "ACTIVE"
     },
     {
@@ -7859,7 +7883,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/03-statistics.md",
-      "staleDays": 90,
+      "staleDays": 91,
       "status": "ACTIVE"
     },
     {
@@ -7874,7 +7898,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/04-validation.md",
-      "staleDays": 90,
+      "staleDays": 91,
       "status": "ACTIVE"
     },
     {
@@ -7889,7 +7913,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/01-overview.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7904,7 +7928,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/02-strategies.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7919,7 +7943,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/03-integration.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7934,7 +7958,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/VALIDATION-NOTES.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7949,7 +7973,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/01-overview.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7964,7 +7988,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/02-algorithms.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7979,7 +8003,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/03-examples.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -7994,7 +8018,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/04-integration.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8009,7 +8033,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/waterfall.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8024,7 +8048,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/xirr.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8039,7 +8063,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/npm-bin-resolution-investigation.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8054,7 +8078,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8069,7 +8093,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/EDITORIAL-V2-CHANGELOG.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8084,7 +8108,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/README.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8099,7 +8123,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/ai-metrics.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8114,7 +8138,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/auth-comment.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8129,7 +8153,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/business-kpis.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8144,7 +8168,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/fundcalc-comment.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8159,7 +8183,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/rum.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8174,7 +8198,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/split-plan-comment.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8208,7 +8232,7 @@
       "lastUpdated": "2026-06-16",
       "owner": "Platform Team",
       "path": "docs/parity/convention-matrix.md",
-      "staleDays": 54,
+      "staleDays": 55,
       "status": "ACTIVE"
     },
     {
@@ -8223,7 +8247,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/perf-baseline.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8238,7 +8262,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/performance-logging-automation.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8254,7 +8278,7 @@
       "lastUpdated": "2026-04-05",
       "owner": null,
       "path": "docs/phase0-validation-report.md",
-      "staleDays": 126,
+      "staleDays": 127,
       "status": "HISTORICAL-SNAPSHOT"
     },
     {
@@ -8269,7 +8293,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase0-xirr-analysis-eda20590.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8284,7 +8308,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1-1-1-analysis.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8299,7 +8323,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1-xirr-baseline-heatmap.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8314,7 +8338,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1-xirr-waterfall-roadmap.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8329,7 +8353,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1b-waterfall-evaluator-hardening.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8356,7 +8380,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phoenix-v2.32-command-enhancements.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8371,7 +8395,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/planning/build-stabilization/00-ITERATION-LOG.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8386,7 +8410,7 @@
       "lastUpdated": "2026-06-22",
       "owner": null,
       "path": "docs/plans/2026-03-27-secondary-surface-decisions.md",
-      "staleDays": 48,
+      "staleDays": 49,
       "status": "ACTIVE"
     },
     {
@@ -8403,7 +8427,7 @@
       "lastUpdated": "2026-04-07",
       "owner": "Phoenix Probabilistic",
       "path": "docs/plans/2026-04-07-backtesting-scenario-comparison-correctness.md",
-      "staleDays": 124,
+      "staleDays": 125,
       "status": "TRACKED (not scheduled)"
     },
     {
@@ -8418,7 +8442,7 @@
       "lastUpdated": "2026-05-17",
       "owner": null,
       "path": "docs/plans/2026-04-07-phase-1c3-variance-automation-followons-backlog.md",
-      "staleDays": 84,
+      "staleDays": 85,
       "status": "BACKLOG"
     },
     {
@@ -8432,7 +8456,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/plans/2026-05-08-gp-economics-extension-design.md",
-      "staleDays": 90,
+      "staleDays": 91,
       "status": "UNKNOWN"
     },
     {
@@ -8449,7 +8473,7 @@
       "lastUpdated": "2026-05-31",
       "owner": "Core Team",
       "path": "docs/plans/2026-05-14-t4-t5-follow-up-tranches.md",
-      "staleDays": 70,
+      "staleDays": 71,
       "status": "ACTIVE"
     },
     {
@@ -8469,7 +8493,7 @@
       "lastUpdated": "2026-06-02",
       "owner": "Core Team",
       "path": "docs/plans/2026-06-02-scenario-comparison-evidence-workstream-plan.md",
-      "staleDays": 68,
+      "staleDays": 69,
       "status": "ACTIVE"
     },
     {
@@ -8498,7 +8522,7 @@
       "lastUpdated": "2026-06-13",
       "owner": "Core Team",
       "path": "docs/plans/2026-06-13-gp-trust-readiness-register.md",
-      "staleDays": 57,
+      "staleDays": 58,
       "status": "ACTIVE"
     },
     {
@@ -8532,7 +8556,7 @@
       "lastUpdated": "2026-06-22",
       "owner": "Platform Team",
       "path": "docs/plans/2026-06-22-current-state-steelman-roadmap.md",
-      "staleDays": 48,
+      "staleDays": 49,
       "status": "DRAFT"
     },
     {
@@ -8569,7 +8593,7 @@
       "lastUpdated": "2026-04-03",
       "owner": "Core Team",
       "path": "docs/plans/PHOENIX-FOUNDATION-HARDENING-CROSSWALK.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "ACTIVE"
     },
     {
@@ -8584,7 +8608,7 @@
       "lastUpdated": "2026-05-29",
       "owner": null,
       "path": "docs/plans/scenario-release-lane.md",
-      "staleDays": 72,
+      "staleDays": 73,
       "status": "ACTIVE"
     },
     {
@@ -8599,7 +8623,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/policies/feasibility-constraints.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8614,7 +8638,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/portfolio-construction-modeling.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "ACTIVE"
     },
     {
@@ -8629,7 +8653,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/portfolio-intelligence-systems-technical-memo.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8644,7 +8668,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/power-law-integration.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8659,7 +8683,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/prd.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8674,7 +8698,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/AUTOMATION_GUIDE.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8689,7 +8713,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/COMMIT_LOG.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8704,7 +8728,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/CONTRIBUTING.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8719,7 +8743,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/DEPLOYMENT_COMPLETE.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8734,7 +8758,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/DEPLOYMENT_TODO.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8749,7 +8773,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/FINAL_VALIDATION.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8764,7 +8788,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/GITHUB_COMMIT_GUIDE.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8779,7 +8803,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/GITHUB_SETUP.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8794,7 +8818,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PEER_REVIEW.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8809,7 +8833,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PIPELINE_SCHEMA_COMPLETE.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8824,7 +8848,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PIPELINE_TODO.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8839,7 +8863,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PRE_PUSH_CHECKLIST.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8854,7 +8878,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/TEAM_SETUP.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8869,7 +8893,7 @@
       "lastUpdated": "2026-05-21",
       "owner": null,
       "path": "docs/processes/clone-guide.md",
-      "staleDays": 80,
+      "staleDays": 81,
       "status": "ACTIVE"
     },
     {
@@ -8884,7 +8908,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/code-review-checklist.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8898,7 +8922,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/qa-response-2026-01-23.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -8925,7 +8949,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/reallocation-api-quickstart.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8940,7 +8964,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/references/capital-allocation-follow-on.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "ACTIVE"
     },
     {
@@ -8955,7 +8979,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-engines.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8970,7 +8994,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-integration.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -8985,7 +9009,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-schema.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -9000,7 +9024,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-testing.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -9015,7 +9039,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/replit.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -9030,7 +9054,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/seed-cases-ca-007-020.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -9045,7 +9069,7 @@
       "lastUpdated": "2026-06-12",
       "owner": null,
       "path": "docs/release/internal-release-notes.md",
-      "staleDays": 58,
+      "staleDays": 59,
       "status": "PROVEN"
     },
     {
@@ -9060,7 +9084,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/SlackBatchAPI-v1.0.0.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -9075,7 +9099,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/compat-matrix.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -9090,7 +9114,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-phase4.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -9105,7 +9129,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-phase5.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -9120,7 +9144,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-v3.4-option-b.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -9135,7 +9159,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-v3.4-review.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -9150,7 +9174,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-normalization-v3.4.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -9165,7 +9189,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/replit.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -9195,7 +9219,7 @@
       "lastUpdated": "2026-08-08",
       "owner": "Product + Frontend",
       "path": "docs/reviews/2026-08-08-issue-1284-prototype-review.md",
-      "staleDays": 1,
+      "staleDays": 2,
       "status": "ACTIVE"
     },
     {
@@ -9210,7 +9234,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/reviews/CA-IMPLEMENTATION-EVALUATION-FINAL.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -9225,7 +9249,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/reviews/CA-IMPLEMENTATION-EVALUATION-REFINED.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -9260,7 +9284,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/ca-period-truth-remediation-2026-05-19.md",
-      "staleDays": 81,
+      "staleDays": 82,
       "status": "COMPLETED"
     },
     {
@@ -9291,7 +9315,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/README.md",
-      "staleDays": 81,
+      "staleDays": 82,
       "status": "REFERENCE"
     },
     {
@@ -9322,7 +9346,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/architectural-audit.md",
-      "staleDays": 81,
+      "staleDays": 82,
       "status": "REFERENCE"
     },
     {
@@ -9353,7 +9377,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/code-quality-audit.md",
-      "staleDays": 81,
+      "staleDays": 82,
       "status": "REFERENCE"
     },
     {
@@ -9386,7 +9410,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/devops-dx-audit.md",
-      "staleDays": 81,
+      "staleDays": 82,
       "status": "REFERENCE"
     },
     {
@@ -9417,7 +9441,7 @@
       "lastUpdated": "2026-05-22",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/repository-structure-audit.md",
-      "staleDays": 79,
+      "staleDays": 80,
       "status": "REFERENCE"
     },
     {
@@ -9449,7 +9473,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/testing-infrastructure-audit.md",
-      "staleDays": 81,
+      "staleDays": 82,
       "status": "REFERENCE"
     },
     {
@@ -9464,7 +9488,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/rollback-playbook.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "ACTIVE"
     },
     {
@@ -9479,7 +9503,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbook.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -9494,7 +9518,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/blue-green.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -9509,7 +9533,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/canary.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -9548,7 +9572,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/dr.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -9563,7 +9587,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/incident.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -9591,7 +9615,7 @@
       "lastUpdated": "2026-03-30",
       "owner": "Core Team",
       "path": "docs/runbooks/integration-ready-file-handshake.md",
-      "staleDays": 132,
+      "staleDays": 133,
       "status": "ACTIVE"
     },
     {
@@ -9628,7 +9652,7 @@
       "lastUpdated": "2026-06-28",
       "owner": "gp-team",
       "path": "docs/runbooks/investment-rounds-enablement.md",
-      "staleDays": 42,
+      "staleDays": 43,
       "status": "ACTIVE"
     },
     {
@@ -9655,7 +9679,7 @@
       "lastUpdated": "2026-07-30",
       "owner": null,
       "path": "docs/runbooks/rollback.md",
-      "staleDays": 10,
+      "staleDays": 11,
       "status": "ACTIVE"
     },
     {
@@ -9670,7 +9694,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/stage-normalization-migration.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -9685,7 +9709,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/stage-normalization-rollout.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -9700,7 +9724,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/stage-validation.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -9715,7 +9739,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/synthetic-monitoring.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -9730,7 +9754,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/schema.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -9745,7 +9769,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/schemas/README.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -9760,7 +9784,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/schemas/schema-helpers-integration.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -9775,7 +9799,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/CODACY_REMEDIATION_2025.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -9790,7 +9814,7 @@
       "lastUpdated": "2026-07-05",
       "owner": null,
       "path": "docs/security/cve-exceptions.md",
-      "staleDays": 35,
+      "staleDays": 36,
       "status": "ACTIVE"
     },
     {
@@ -9805,7 +9829,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/00-ITERATION-LOG.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -9820,7 +9844,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/01-dependency-audit.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -9835,7 +9859,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/02-risk-assessment.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -9850,7 +9874,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/03-remediation-plan.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -9865,7 +9889,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/04-verification-log.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -9880,7 +9904,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/05-lockfile-changes.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -9894,7 +9918,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-01-20-hook-fix.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -9908,7 +9932,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-02-14-p1-financial-accuracy.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -9922,7 +9946,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-02-18.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -9936,7 +9960,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-03-17.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "UNKNOWN"
     },
     {
@@ -9950,7 +9974,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/session-learning-reports/2026-04-06.md",
-      "staleDays": 90,
+      "staleDays": 91,
       "status": "UNKNOWN"
     },
     {
@@ -9964,7 +9988,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/session-learning-reports/2026-04-07.md",
-      "staleDays": 90,
+      "staleDays": 91,
       "status": "UNKNOWN"
     },
     {
@@ -9979,7 +10003,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/skills-application-log.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -9994,7 +10018,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/skills-application-synthesis.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -10009,7 +10033,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/skills/README.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -10050,7 +10074,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-001-dynamic-imports-prevent-test-side-effects.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "VERIFIED"
     },
     {
@@ -10398,7 +10422,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-011-recharts-formatter-type-signatures.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "DRAFT"
     },
     {
@@ -10596,7 +10620,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-016-vitest-include-patterns-miss-new-test-directories.md",
-      "staleDays": 90,
+      "staleDays": 91,
       "status": "DRAFT"
     },
     {
@@ -10678,7 +10702,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-018-reserve-engine-null-safety.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "VERIFIED"
     },
     {
@@ -10751,7 +10775,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-020-large-iteration-tests-need-explicit-timeouts.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "DRAFT"
     },
     {
@@ -10795,7 +10819,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-021-exact-optional-property-types-spread-pattern.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "DRAFT"
     },
     {
@@ -10925,7 +10949,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-024-integration-test-environment-leakage.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "DRAFT"
     },
     {
@@ -10972,7 +10996,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-025-ci-compilation-boundary-mismatch.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "DRAFT"
     },
     {
@@ -11014,7 +11038,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-026-drizzle-mock-chain-overwrite.md",
-      "staleDays": 128,
+      "staleDays": 129,
       "status": "DRAFT"
     },
     {
@@ -11163,7 +11187,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-030-mock-id-type-change-blast-radius.md",
-      "staleDays": 90,
+      "staleDays": 91,
       "status": "DRAFT"
     },
     {
@@ -11189,7 +11213,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-031-as-const-literal-type-arithmetic.md",
-      "staleDays": 90,
+      "staleDays": 91,
       "status": "DRAFT"
     },
     {
@@ -11220,7 +11244,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-032-ts4111-index-signature-vs-eslint-dot-notation.md",
-      "staleDays": 90,
+      "staleDays": 91,
       "status": "DRAFT"
     },
     {
@@ -11249,7 +11273,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-033-defensive-grep-before-destructive-action.md",
-      "staleDays": 90,
+      "staleDays": 91,
       "status": "DRAFT"
     },
     {
@@ -11278,7 +11302,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-034-subagent-fabrication-tool-uses-zero.md",
-      "staleDays": 90,
+      "staleDays": 91,
       "status": "DRAFT"
     },
     {
@@ -11308,7 +11332,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-035-defensive-grep-for-recovered-process-drafts.md",
-      "staleDays": 90,
+      "staleDays": 91,
       "status": "DRAFT"
     },
     {
@@ -11338,7 +11362,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-036-silent-test-discovery-loss-from-tests-dirs.md",
-      "staleDays": 90,
+      "staleDays": 91,
       "status": "DRAFT"
     },
     {
@@ -11368,7 +11392,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-037-dynamic-import-seam-for-route-handler-mocking.md",
-      "staleDays": 90,
+      "staleDays": 91,
       "status": "DRAFT"
     },
     {
@@ -11401,7 +11425,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": "docs/skills/REFL-038-windows-agent-shell-env-missing.md",
-      "staleDays": 113,
+      "staleDays": 114,
       "status": "DRAFT"
     },
     {
@@ -11640,7 +11664,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/stage-normalization-scripts.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -11655,7 +11679,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/stage-normalization-v3.4.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -11670,7 +11694,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/standards.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -11697,7 +11721,7 @@
       "lastUpdated": "2026-05-29",
       "owner": null,
       "path": "docs/superpowers/plans/2026-05-29-allocation-sector-override-expansion.md",
-      "staleDays": 72,
+      "staleDays": 73,
       "status": "ACTIVE"
     },
     {
@@ -11725,7 +11749,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-cohort-release-readiness.md",
-      "staleDays": 72,
+      "staleDays": 73,
       "status": "ACTIVE"
     },
     {
@@ -11754,7 +11778,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-forecast-modes-actuals.md",
-      "staleDays": 72,
+      "staleDays": 73,
       "status": "ACTIVE"
     },
     {
@@ -11782,7 +11806,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-methodology-guardrails.md",
-      "staleDays": 72,
+      "staleDays": 73,
       "status": "ACTIVE"
     },
     {
@@ -11810,7 +11834,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-reserve-optimization-workflow.md",
-      "staleDays": 72,
+      "staleDays": 73,
       "status": "ACTIVE"
     },
     {
@@ -11837,7 +11861,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-ux-workspace.md",
-      "staleDays": 72,
+      "staleDays": 73,
       "status": "COMPLETE"
     },
     {
@@ -11878,7 +11902,7 @@
       "lastUpdated": "2026-06-07",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-06-07-m6-reserve-moic-follow-on-ranking.md",
-      "staleDays": 63,
+      "staleDays": 64,
       "status": "ACTIVE"
     },
     {
@@ -11895,7 +11919,7 @@
       "lastUpdated": "2026-06-13",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-06-08-c1-methodology-scenario-creation.md",
-      "staleDays": 57,
+      "staleDays": 58,
       "status": "COMPLETE"
     },
     {
@@ -11924,7 +11948,7 @@
       "lastUpdated": "2026-06-08",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-06-08-c2-economics-comparison-generalization.md",
-      "staleDays": 62,
+      "staleDays": 63,
       "status": "ACTIVE"
     },
     {
@@ -11953,7 +11977,7 @@
       "lastUpdated": "2026-06-09",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-06-09-c3-scenario-async-worker-wiring.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "ACTIVE"
     },
     {
@@ -12021,7 +12045,7 @@
       "lastUpdated": "2026-06-21",
       "owner": "Core Team",
       "path": "docs/superpowers/plans/2026-06-21-investment-round-persistence-l3b.md",
-      "staleDays": 49,
+      "staleDays": 50,
       "status": "DRAFT"
     },
     {
@@ -12075,7 +12099,7 @@
       "lastUpdated": "2026-06-23",
       "owner": "Platform / GP Modeling",
       "path": "docs/superpowers/plans/2026-06-23-trust-first-milestones-v3.3.md",
-      "staleDays": 47,
+      "staleDays": 48,
       "status": "HISTORICAL"
     },
     {
@@ -12093,7 +12117,7 @@
       "lastUpdated": "2026-06-23",
       "owner": "Platform / GP Modeling",
       "path": "docs/superpowers/plans/2026-06-23-trust-first-milestones-v3.4.md",
-      "staleDays": 47,
+      "staleDays": 48,
       "status": "DRAFT"
     },
     {
@@ -12162,7 +12186,7 @@
       "lastUpdated": "2026-06-28",
       "owner": "gp-team",
       "path": "docs/superpowers/plans/2026-06-28-investment-rounds-soak.md",
-      "staleDays": 42,
+      "staleDays": 43,
       "status": "ACTIVE"
     },
     {
@@ -12301,6 +12325,18 @@
       "docType": "doc",
       "exists": true,
       "frontmatter": {},
+      "hasExecutionClaims": false,
+      "isStale": true,
+      "lastUpdated": null,
+      "owner": null,
+      "path": "docs/superpowers/plans/2026-08-10-f1337-feeprofile-truth.md",
+      "staleDays": 999,
+      "status": "UNKNOWN"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {},
       "hasExecutionClaims": true,
       "isStale": true,
       "lastUpdated": null,
@@ -12323,7 +12359,7 @@
       "lastUpdated": "2026-06-13",
       "owner": "Platform Team",
       "path": "docs/superpowers/specs/2026-06-08-c1-methodology-scenario-creation-design.md",
-      "staleDays": 57,
+      "staleDays": 58,
       "status": "COMPLETE"
     },
     {
@@ -12352,7 +12388,7 @@
       "lastUpdated": "2026-06-08",
       "owner": "Platform Team",
       "path": "docs/superpowers/specs/2026-06-08-c2-economics-comparison-generalization-design.md",
-      "staleDays": 62,
+      "staleDays": 63,
       "status": "ACTIVE"
     },
     {
@@ -12381,7 +12417,7 @@
       "lastUpdated": "2026-06-09",
       "owner": "Platform Team",
       "path": "docs/superpowers/specs/2026-06-09-c3-scenario-async-worker-wiring-design.md",
-      "staleDays": 61,
+      "staleDays": 62,
       "status": "ACTIVE"
     },
     {
@@ -12428,7 +12464,7 @@
       "lastUpdated": "2026-06-13",
       "owner": "Core Team",
       "path": "docs/superpowers/specs/2026-06-13-gp-trust-readiness-audit-design.md",
-      "staleDays": 57,
+      "staleDays": 58,
       "status": "ACTIVE"
     },
     {
@@ -12445,7 +12481,7 @@
       "lastUpdated": "2026-06-21",
       "owner": null,
       "path": "docs/superpowers/specs/2026-06-21-investment-round-persistence-l3b-design.md",
-      "staleDays": 49,
+      "staleDays": 50,
       "status": "DRAFT (red-team hardened 2026-06-21)"
     },
     {
@@ -12549,7 +12585,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/tech-debt/type-safety-remediation-summary.md",
-      "staleDays": 81,
+      "staleDays": 82,
       "status": "ACTIVE"
     },
     {
@@ -12564,7 +12600,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/templates/README.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -12579,7 +12615,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/templates/design-system-template.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -12594,7 +12630,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/templates/feature-flow-template.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -12609,7 +12645,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/test-improvement-status.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -12636,7 +12672,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/type-safety-action-plan.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -12651,7 +12687,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/type-safety-migration.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -12666,7 +12702,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/validation/DeterministicReserveEngine.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -12681,7 +12717,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/validation/stage-validation-patched.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -12696,7 +12732,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/validation/stage-validation-v3.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -12711,7 +12747,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard-calculations-integration.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -12726,7 +12762,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/COMPLETION_SUMMARY.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "HISTORICAL"
     },
     {
@@ -12741,7 +12777,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/MIGRATION_GUIDE.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -12756,7 +12792,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/RESERVES_CARD_IMPROVEMENTS.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -12771,7 +12807,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/WIZARD_INTEGRATION.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -12786,7 +12822,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/modeling-wizard-design.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -12801,7 +12837,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/CONSOLIDATION_PLAN_V2.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -12816,7 +12852,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/CONSOLIDATION_PLAN_V3_FINAL.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -12831,7 +12867,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/PAIRED-AGENT-VALIDATION.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -12846,7 +12882,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/PRODUCTION_SCRIPTS.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -12861,7 +12897,7 @@
       "lastUpdated": "2026-05-28",
       "owner": null,
       "path": "docs/workflows/README.md",
-      "staleDays": 73,
+      "staleDays": 74,
       "status": "ACTIVE"
     },
     {
@@ -12907,7 +12943,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Developer",
       "path": "docs/xirr-consolidation-roadmap.md",
-      "staleDays": 223,
+      "staleDays": 224,
       "status": "ACTIVE"
     },
     {
@@ -12922,7 +12958,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/xirr-excel-validation.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     },
     {
@@ -12937,11 +12973,11 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/xirr-golden-set-migration-plan.md",
-      "staleDays": 202,
+      "staleDays": 203,
       "status": "ACTIVE"
     }
   ],
-  "generatedAt": "2026-08-09T00:00:00.000Z",
+  "generatedAt": "2026-08-10T00:00:00.000Z",
   "patterns": [
     {
       "category": "Security",
@@ -14123,14 +14159,14 @@
       "REFERENCE": 9,
       "STALE-VALIDATION": 1,
       "TRACKED (not scheduled)": 1,
-      "UNKNOWN": 168,
+      "UNKNOWN": 171,
       "VERIFIED": 13,
       "active": 2,
       "ready": 3
     },
-    "missing_frontmatter": 74,
-    "stale_docs": 496,
-    "total_docs": 723
+    "missing_frontmatter": 77,
+    "stale_docs": 500,
+    "total_docs": 726
   },
   "version": "2.0"
 }

--- a/docs/_generated/staleness-report.md
+++ b/docs/_generated/staleness-report.md
@@ -1,26 +1,26 @@
 ---
-last_updated: 2026-08-09
+last_updated: 2026-08-10
 ---
 
 # Staleness Report
 
-*Generated: 2026-08-09T00:00:00.000Z*
+*Generated: 2026-08-10T00:00:00.000Z*
 *Source: docs/DISCOVERY-MAP.source.yaml*
 
 ## Summary
 
 | Metric | Value |
 |--------|-------|
-| Total Documents | 723 |
-| Stale Documents | 496 |
-| Missing Frontmatter | 74 |
+| Total Documents | 726 |
+| Stale Documents | 500 |
+| Missing Frontmatter | 77 |
 
 ### By Status
 
 | Status | Count |
 |--------|-------|
 | ACTIVE | 453 |
-| UNKNOWN | 168 |
+| UNKNOWN | 171 |
 | DRAFT | 34 |
 | HISTORICAL | 22 |
 | VERIFIED | 13 |
@@ -69,6 +69,8 @@ Documents that need review (older than their cadence threshold):
 | `docs/3-code-review/CR_w1_v1.4.0.md` | Never | 999 | No | Unassigned |
 | `docs/3-code-review/CR_w1_v1.4.1.md` | Never | 999 | No | Unassigned |
 | `docs/3-code-review/CR_w1_v1.5.0.md` | Never | 999 | No | Unassigned |
+| `docs/3-code-review/README.md` | Never | 999 | No | Unassigned |
+| `docs/3-code-review/canary-exclusion-worklist.md` | Never | 999 | No | Unassigned |
 | `docs/4-unit-tests/COVERAGE-DEBT.md` | Never | 999 | No | Unassigned |
 | `docs/4-unit-tests/TESTING.md` | Never | 999 | No | Unassigned |
 | `docs/ARCHI.md` | Never | 999 | No | Unassigned |
@@ -94,107 +96,106 @@ Documents that need review (older than their cadence threshold):
 | `docs/skills/REFL-005-stale-test-files-with-api-mismatch.md` | Never | 999 | No | Unassigned |
 | `docs/skills/REFL-006-xirr-newton-raphson-divergence-on-extreme-returns.md` | Never | 999 | No | Unassigned |
 | `docs/skills/REFL-007-global-vi-mock-pollutes-all-tests.md` | Never | 999 | No | Unassigned |
-| `docs/skills/REFL-008-typescript-type-inference-from-database-schemas.md` | Never | 999 | No | Unassigned |
-| `docs/skills/REFL-009-crlf-line-endings-break-frontmatter-parsing.md` | Never | 999 | No | Unassigned |
 
-*...and 446 more stale documents.*
+*...and 450 more stale documents.*
 
 ## Documents with Execution Claims (Need Verification)
 
 These documents contain phrases like "tests pass", "PR merged", etc. and should be verified:
 
-- [ ] **.claude/commands/retrospective.md** (202 days old)
-- [ ] **.claude/commands/session-learnings.md** (202 days old)
-- [ ] **.claude/commands/wshobson/deps-audit.md** (202 days old)
-- [ ] **.claude/integration-test-execution-summary.md** (202 days old)
-- [ ] **.claude/integration-test-final-report.md** (202 days old)
-- [ ] **.claude/integration-test-reenable-plan-v2.md** (202 days old)
-- [ ] **.claude/plan.md** (223 days old)
-- [ ] **.claude/prompts/integration-test-continuation-prompt.md** (202 days old)
-- [ ] **.claude/prompts/portfolio-intelligence-timeout-fix.md** (202 days old)
-- [ ] **.claude/prompts/week2.5-next-session-kickoff.md** (202 days old)
-- [ ] **.claude/prompts/week2.5-phase3-continuation-v10.md** (202 days old)
-- [ ] **.claude/prompts/week2.5-phase3-continuation-v2.md** (202 days old)
-- [ ] **.claude/prompts/week2.5-phase3-continuation-v3.md** (202 days old)
-- [ ] **.claude/prompts/week2.5-phase3-continuation.md** (202 days old)
-- [ ] **.claude/prompts/week2.5-phase4-next-steps.md** (202 days old)
-- [ ] **.claude/session-summary-portfolio-intelligence-implementation.md** (202 days old)
-- [ ] **.claude/sessions/PHASE4-CONTINUATION-KICKOFF.md** (202 days old)
-- [ ] **.claude/skills/README.md** (202 days old)
-- [ ] **.claude/skills/iterative-improvement.md** (202 days old)
-- [ ] **.claude/skills/task-decomposition.md** (202 days old)
-- [ ] **.claude/testing/rubric-calculation-engines.md** (202 days old)
-- [ ] **.claude/testing/scenario-comparison-manual-test-rubric.md** (202 days old)
-- [ ] **.claude/testing/seed-script-remaining-fixes.md** (202 days old)
-- [ ] **ANTI_PATTERNS.md** (202 days old)
-- [ ] **COMPREHENSIVE-WORKFLOW-GUIDE.md** (202 days old)
-- [ ] **ITERATION-A-QUICKSTART.md** (202 days old)
-- [ ] **MIGRATION-NATIVE-MEMORY.md** (202 days old)
-- [ ] **PRODUCTION_RUNBOOK.md** (202 days old)
-- [ ] **PROMPT_PATTERNS.md** (202 days old)
-- [ ] **cheatsheets/baseline-governance.md** (90 days old)
-- [ ] **cheatsheets/daily-workflow.md** (128 days old)
-- [ ] **cheatsheets/emoji-free-documentation.md** (202 days old)
-- [ ] **cheatsheets/pr-merge-verification.md** (125 days old)
-- [ ] **cheatsheets/schema-alignment.md** (202 days old)
-- [ ] **docs/CA-IMPLEMENTATION-PLAN.md** (202 days old)
-- [ ] **docs/CA-SEMANTIC-LOCK.md** (202 days old)
-- [ ] **docs/DECISIONS.md** (202 days old)
-- [ ] **docs/DEPLOYMENT.md** (202 days old)
-- [ ] **docs/DEVELOPMENT_STRATEGY.md** (202 days old)
-- [ ] **docs/MILESTONE-XIRR-PHASE0-COMPLETE.md** (202 days old)
-- [ ] **docs/PRODUCTION_CHECKLIST.md** (202 days old)
-- [ ] **docs/RATE_LIMITING_SUMMARY.md** (202 days old)
-- [ ] **docs/SCENARIO_DEPLOY_GUIDE.md** (202 days old)
-- [ ] **docs/VERIFICATION_CHECKLIST.md** (202 days old)
-- [ ] **docs/action-plans/CODEX-FIXES-EXECUTION-SUMMARY.md** (202 days old)
-- [ ] **docs/action-plans/CODEX-ISSUES-RESOLUTION-PLAN.md** (202 days old)
-- [ ] **docs/adr/ADR-008-capital-allocation-policy.md** (202 days old)
-- [ ] **docs/agent-2-mobile-executive-dashboard.md** (202 days old)
-- [ ] **docs/api/architecture/portfolio-route-api.md** (202 days old)
-- [ ] **docs/api/testing/portfolio-route-test-strategy.md** (202 days old)
-- [ ] **docs/behavioral-specs/time-travel-analytics-service-specs.md** (202 days old)
-- [ ] **docs/chaos-engineering/README.md** (202 days old)
-- [ ] **docs/chaos-engineering/RLS-CHAOS-TESTING-PLAN.md** (202 days old)
-- [ ] **docs/deployment/CODEX-FIXES-DEPLOYMENT-STATUS.md** (202 days old)
-- [ ] **docs/deployment/ROLLBACK_PLAN.md** (202 days old)
-- [ ] **docs/deployment/STAGING_CHECKLIST.md** (202 days old)
-- [ ] **docs/deployment/STAGING_DEPLOYMENT_SUMMARY.md** (202 days old)
-- [ ] **docs/deployment/STAGING_METRICS.md** (202 days old)
-- [ ] **docs/failure-triage.md** (202 days old)
-- [ ] **docs/forecasting/power-law-implementation.md** (202 days old)
-- [ ] **docs/foundation/PHASE2-ROADMAP-IMPROVEMENTS.md** (202 days old)
-- [ ] **docs/foundation/PHASE2-ROADMAP.md** (202 days old)
-- [ ] **docs/foundation/PHASE3-KICKOFF.md** (202 days old)
-- [ ] **docs/foundation/PHASE4-KICKOFF.md** (202 days old)
-- [ ] **docs/integration/upstash-setup.md** (202 days old)
-- [ ] **docs/notebooklm-sources/reserves/01-overview.md** (202 days old)
-- [ ] **docs/notebooklm-sources/waterfall.md** (202 days old)
-- [ ] **docs/notebooklm-sources/xirr.md** (202 days old)
-- [ ] **docs/npm-bin-resolution-investigation.md** (202 days old)
-- [ ] **docs/observability/EDITORIAL-V2-CHANGELOG.md** (202 days old)
-- [ ] **docs/observability/README.md** (202 days old)
-- [ ] **docs/phase0-xirr-analysis-eda20590.md** (202 days old)
-- [ ] **docs/phase1-1-1-analysis.md** (202 days old)
-- [ ] **docs/phase1-xirr-baseline-heatmap.md** (202 days old)
-- [ ] **docs/phase1b-waterfall-evaluator-hardening.md** (202 days old)
-- [ ] **docs/processes/CONTRIBUTING.md** (202 days old)
-- [ ] **docs/processes/code-review-checklist.md** (202 days old)
-- [ ] **docs/references/claude-agent-testing.md** (202 days old)
-- [ ] **docs/references/replit.md** (202 days old)
-- [ ] **docs/releases/stage-norm-phase5.md** (202 days old)
-- [ ] **docs/releases/stage-normalization-v3.4.md** (202 days old)
-- [ ] **docs/replit.md** (202 days old)
-- [ ] **docs/reviews/CA-IMPLEMENTATION-EVALUATION-FINAL.md** (202 days old)
-- [ ] **docs/skills-application-log.md** (202 days old)
+- [ ] **.claude/commands/retrospective.md** (203 days old)
+- [ ] **.claude/commands/session-learnings.md** (203 days old)
+- [ ] **.claude/commands/wshobson/deps-audit.md** (203 days old)
+- [ ] **.claude/integration-test-execution-summary.md** (203 days old)
+- [ ] **.claude/integration-test-final-report.md** (203 days old)
+- [ ] **.claude/integration-test-reenable-plan-v2.md** (203 days old)
+- [ ] **.claude/plan.md** (224 days old)
+- [ ] **.claude/prompts/integration-test-continuation-prompt.md** (203 days old)
+- [ ] **.claude/prompts/portfolio-intelligence-timeout-fix.md** (203 days old)
+- [ ] **.claude/prompts/week2.5-next-session-kickoff.md** (203 days old)
+- [ ] **.claude/prompts/week2.5-phase3-continuation-v10.md** (203 days old)
+- [ ] **.claude/prompts/week2.5-phase3-continuation-v2.md** (203 days old)
+- [ ] **.claude/prompts/week2.5-phase3-continuation-v3.md** (203 days old)
+- [ ] **.claude/prompts/week2.5-phase3-continuation.md** (203 days old)
+- [ ] **.claude/prompts/week2.5-phase4-next-steps.md** (203 days old)
+- [ ] **.claude/session-summary-portfolio-intelligence-implementation.md** (203 days old)
+- [ ] **.claude/sessions/PHASE4-CONTINUATION-KICKOFF.md** (203 days old)
+- [ ] **.claude/skills/README.md** (203 days old)
+- [ ] **.claude/skills/iterative-improvement.md** (203 days old)
+- [ ] **.claude/skills/task-decomposition.md** (203 days old)
+- [ ] **.claude/testing/rubric-calculation-engines.md** (203 days old)
+- [ ] **.claude/testing/scenario-comparison-manual-test-rubric.md** (203 days old)
+- [ ] **.claude/testing/seed-script-remaining-fixes.md** (203 days old)
+- [ ] **ANTI_PATTERNS.md** (203 days old)
+- [ ] **CHANGELOG.md** (7 days old)
+- [ ] **COMPREHENSIVE-WORKFLOW-GUIDE.md** (203 days old)
+- [ ] **ITERATION-A-QUICKSTART.md** (203 days old)
+- [ ] **MIGRATION-NATIVE-MEMORY.md** (203 days old)
+- [ ] **PRODUCTION_RUNBOOK.md** (203 days old)
+- [ ] **PROMPT_PATTERNS.md** (203 days old)
+- [ ] **cheatsheets/baseline-governance.md** (91 days old)
+- [ ] **cheatsheets/daily-workflow.md** (129 days old)
+- [ ] **cheatsheets/emoji-free-documentation.md** (203 days old)
+- [ ] **cheatsheets/pr-merge-verification.md** (126 days old)
+- [ ] **cheatsheets/schema-alignment.md** (203 days old)
+- [ ] **docs/CA-IMPLEMENTATION-PLAN.md** (203 days old)
+- [ ] **docs/CA-SEMANTIC-LOCK.md** (203 days old)
+- [ ] **docs/DECISIONS.md** (203 days old)
+- [ ] **docs/DEPLOYMENT.md** (203 days old)
+- [ ] **docs/DEVELOPMENT_STRATEGY.md** (203 days old)
+- [ ] **docs/MILESTONE-XIRR-PHASE0-COMPLETE.md** (203 days old)
+- [ ] **docs/PRODUCTION_CHECKLIST.md** (203 days old)
+- [ ] **docs/RATE_LIMITING_SUMMARY.md** (203 days old)
+- [ ] **docs/SCENARIO_DEPLOY_GUIDE.md** (203 days old)
+- [ ] **docs/VERIFICATION_CHECKLIST.md** (203 days old)
+- [ ] **docs/action-plans/CODEX-FIXES-EXECUTION-SUMMARY.md** (203 days old)
+- [ ] **docs/action-plans/CODEX-ISSUES-RESOLUTION-PLAN.md** (203 days old)
+- [ ] **docs/adr/ADR-008-capital-allocation-policy.md** (203 days old)
+- [ ] **docs/agent-2-mobile-executive-dashboard.md** (203 days old)
+- [ ] **docs/api/architecture/portfolio-route-api.md** (203 days old)
+- [ ] **docs/api/testing/portfolio-route-test-strategy.md** (203 days old)
+- [ ] **docs/behavioral-specs/time-travel-analytics-service-specs.md** (203 days old)
+- [ ] **docs/chaos-engineering/README.md** (203 days old)
+- [ ] **docs/chaos-engineering/RLS-CHAOS-TESTING-PLAN.md** (203 days old)
+- [ ] **docs/deployment/CODEX-FIXES-DEPLOYMENT-STATUS.md** (203 days old)
+- [ ] **docs/deployment/ROLLBACK_PLAN.md** (203 days old)
+- [ ] **docs/deployment/STAGING_CHECKLIST.md** (203 days old)
+- [ ] **docs/deployment/STAGING_DEPLOYMENT_SUMMARY.md** (203 days old)
+- [ ] **docs/deployment/STAGING_METRICS.md** (203 days old)
+- [ ] **docs/failure-triage.md** (203 days old)
+- [ ] **docs/forecasting/power-law-implementation.md** (203 days old)
+- [ ] **docs/foundation/PHASE2-ROADMAP-IMPROVEMENTS.md** (203 days old)
+- [ ] **docs/foundation/PHASE2-ROADMAP.md** (203 days old)
+- [ ] **docs/foundation/PHASE3-KICKOFF.md** (203 days old)
+- [ ] **docs/foundation/PHASE4-KICKOFF.md** (203 days old)
+- [ ] **docs/integration/upstash-setup.md** (203 days old)
+- [ ] **docs/notebooklm-sources/reserves/01-overview.md** (203 days old)
+- [ ] **docs/notebooklm-sources/waterfall.md** (203 days old)
+- [ ] **docs/notebooklm-sources/xirr.md** (203 days old)
+- [ ] **docs/npm-bin-resolution-investigation.md** (203 days old)
+- [ ] **docs/observability/EDITORIAL-V2-CHANGELOG.md** (203 days old)
+- [ ] **docs/observability/README.md** (203 days old)
+- [ ] **docs/phase0-xirr-analysis-eda20590.md** (203 days old)
+- [ ] **docs/phase1-1-1-analysis.md** (203 days old)
+- [ ] **docs/phase1-xirr-baseline-heatmap.md** (203 days old)
+- [ ] **docs/phase1b-waterfall-evaluator-hardening.md** (203 days old)
+- [ ] **docs/processes/CONTRIBUTING.md** (203 days old)
+- [ ] **docs/processes/code-review-checklist.md** (203 days old)
+- [ ] **docs/references/claude-agent-testing.md** (203 days old)
+- [ ] **docs/references/replit.md** (203 days old)
+- [ ] **docs/releases/stage-norm-phase5.md** (203 days old)
+- [ ] **docs/releases/stage-normalization-v3.4.md** (203 days old)
+- [ ] **docs/replit.md** (203 days old)
+- [ ] **docs/reviews/CA-IMPLEMENTATION-EVALUATION-FINAL.md** (203 days old)
+- [ ] **docs/skills-application-log.md** (203 days old)
 - [ ] **docs/skills/REFL-003-cross-platform-file-enumeration-fragility.md** (999 days old)
 - [ ] **docs/skills/REFL-014-test-key-reuse-across-test-cases.md** (999 days old)
 - [ ] **docs/skills/REFL-015-postgresql-service-missing-test-database.md** (999 days old)
 - [ ] **docs/superpowers/plans/2026-06-07-forecast-drift-ux-completion.md** (999 days old)
 - [ ] **docs/superpowers/plans/2026-07-29-task160-internal-waterfall-governance.md** (999 days old)
 - [ ] **docs/superpowers/specs/2026-05-16-refactor-stability-strategy-design.md** (999 days old)
-- [ ] **docs/xirr-consolidation-roadmap.md** (223 days old)
-- [ ] **docs/xirr-excel-validation.md** (202 days old)
+- [ ] **docs/xirr-consolidation-roadmap.md** (224 days old)
+- [ ] **docs/xirr-excel-validation.md** (203 days old)
 
 ## Missing Frontmatter
 
@@ -223,6 +224,8 @@ Documents without proper YAML frontmatter:
 - [ ] `docs/3-code-review/CR_w1_v1.4.0.md`
 - [ ] `docs/3-code-review/CR_w1_v1.4.1.md`
 - [ ] `docs/3-code-review/CR_w1_v1.5.0.md`
+- [ ] `docs/3-code-review/README.md`
+- [ ] `docs/3-code-review/canary-exclusion-worklist.md`
 - [ ] `docs/4-unit-tests/COVERAGE-DEBT.md`
 - [ ] `docs/4-unit-tests/TESTING.md`
 - [ ] `docs/ARCHI.md`
@@ -267,6 +270,7 @@ Documents without proper YAML frontmatter:
 - [ ] `docs/superpowers/plans/2026-07-28-tiered-model-routing.md`
 - [ ] `docs/superpowers/plans/2026-07-29-task160-internal-waterfall-governance.md`
 - [ ] `docs/superpowers/plans/2026-07-30-task163-wp-l2b-cash-assembly-and-nonzero-fees-plan.md`
+- [ ] `docs/superpowers/plans/2026-08-10-f1337-feeprofile-truth.md`
 - [ ] `docs/superpowers/specs/2026-05-16-refactor-stability-strategy-design.md`
 - [ ] `docs/superpowers/specs/2026-06-11-worker-prod-ops-design.md`
 - [ ] `docs/superpowers/specs/2026-06-21-investment-rounds-ui-v2-design.md`

--- a/docs/superpowers/plans/2026-08-10-f1337-feeprofile-truth.md
+++ b/docs/superpowers/plans/2026-08-10-f1337-feeprofile-truth.md
@@ -1,0 +1,825 @@
+# F1337 FeeProfile Production Truth Implementation Plan
+
+<!-- prettier-ignore -->
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` task-by-task. Track execution with checkbox items.
+
+**Goal:** Add eleven production-backed FeeProfile truth cases without changing
+fee production code or frozen legacy fee characterization.
+
+**Architecture:** Keep `computeFeePreview` coverage as frozen legacy
+characterization. Add a test-local serialized corpus and adapter that parse full
+FeeProfiles, convert money to Decimal, call `computeFeeBasisTimeline` once, then
+compare complete serialized output exactly.
+
+**Tech Stack:** TypeScript, Vitest, Decimal.js, Zod, JSON,
+`@shared/lib/fund-math`, `@shared/schemas/fee-profile`.
+
+## Global Constraints
+
+- Scope: issue #1337 production-fee truth only. Do not add production exports,
+  dependencies, schemas, or fee arithmetic.
+- `docs/fees.truth-cases.json` is frozen legacy characterization, non-normative,
+  SHA-256 `fafd55c32684f911feba20f26ca5a227744a82f63378b746acb421f2682374f8`.
+- `tests/unit/truth-cases/fee-adapter.ts` is frozen, SHA-256
+  `1baeaa864e5d5873142cc8d913a2c9f8bceafc034436bc60b3776016cad9d781`.
+- Preserve existing ten-case Truth Cases: Fees (Phase 1.3 - Active) runner block
+  plus `feesCases.length === 10` and all its tag assertions byte-for-byte. Its
+  `computeFeePreview` execution remains legacy-only.
+- Future #1337 branch owns only `docs/fee-profile.truth-cases.json`,
+  `tests/unit/truth-cases/fee-profile-adapter.ts`, and
+  `tests/unit/truth-cases/runner.test.ts`.
+- Keep types and runtime validators test-local. Never promote them to `shared/`.
+- Every monetary JSON value uses six decimals. Represent brief whole-dollar
+  amount `"100000000"` as `"100000000.000000"`; value is unchanged. Percentages
+  retain supplied decimal fractions: `"0.02"` is 2%; `"2"` must fail.
+- Called-capital, distribution, and invested schedules are cumulative
+  quarter-end balances. FMV and unrealized-cost schedules are quarter-end
+  stocks.
+- Keep `tests/unit/economics/retroactive-fee-catch-up.test.ts` unmodified as
+  secondary regression evidence for holidays, `maxCatchUpMonths`, fractional
+  periods, and catch-up-plus-period-flow rejection.
+- All test commands use `TZ=UTC`. Do not use `any`, add dependencies, or use
+  emoji.
+
+## Implementation Surface
+
+| File                                                    | Action    | Responsibility                                                                                     |
+| ------------------------------------------------------- | --------- | -------------------------------------------------------------------------------------------------- |
+| `docs/fee-profile.truth-cases.json`                     | Create    | Eleven FeeProfile production-truth records with serialized money.                                  |
+| `tests/unit/truth-cases/fee-profile-adapter.ts`         | Create    | Test-local interfaces/validators, Decimal conversion, one production call, result serialization.   |
+| `tests/unit/truth-cases/runner.test.ts`                 | Modify    | Separate FeeProfile describe block, exact result equality, negative tests, separate summary count. |
+| `docs/fees.truth-cases.json`                            | Read only | Frozen legacy corpus.                                                                              |
+| `tests/unit/truth-cases/fee-adapter.ts`                 | Read only | Frozen legacy adapter.                                                                             |
+| `tests/unit/economics/retroactive-fee-catch-up.test.ts` | Read only | Retained secondary regression citations.                                                           |
+
+## Program Lifecycle Gates, Branch Preflight, and Ownership Guard
+
+These gates are cumulative and fail closed. This plan may be written and
+reviewed while G3 is open, but no #1337 implementation task, test edit, or other
+code command begins until every Gate 0 attestation is true. After only the first
+three attestations pass, creating or rebasing the empty #1337 branch onto
+current `origin/main` is the sole permitted action; it exists only to satisfy
+the fourth attestation and does not authorize implementation. Authority:
+`docs/1-plans/F_1.3.0_fee-economics-convergence.plan.md`, Lifecycle gates and
+sequence. An unmerged plan, preview status, or unrecorded verbal approval is not
+durable evidence.
+
+### Gate 0: Durable program authority before implementation
+
+- [ ] Durable G3 acceptance is recorded on `main` for one accepted exact SHA,
+      with zero G3-or-earlier obligations, the required verification battery for
+      that exact SHA, and an authoritative reviewer verdict.
+- [ ] The governing planning authority and this ratified #1337 child plan are
+      merged and reachable from `origin/main`.
+- [ ] Approved #1337 supersession text and named owner-scope ratification are
+      recorded durably. Proposed, offline, unassigned, or stale issue text
+      fails.
+- [ ] Only after the first three conditions pass, create or rebase the empty
+      #1337 branch onto current `origin/main`. Before any implementation task,
+      test edit, or other code command, its HEAD equals that current main SHA.
+      All four conditions must then pass before implementation begins.
+
+Record the durable external references before running the gate: each `*_REF`
+variable is the authoritative main-branch evidence URL or immutable record
+identifier; `G3_ACCEPTED_SHA` and `PLANNING_AUTHORITY_SHA` are full commit IDs
+from those records. The command intentionally stops for a missing or stale
+record.
+
+```bash
+set -euo pipefail
+git fetch --quiet origin main
+ORIGIN_MAIN=$(git rev-parse --verify origin/main^{commit})
+: "${G3_ACCEPTED_SHA:?record durable G3 accepted SHA on main}"
+: "${G3_ZERO_OBLIGATIONS_REF:?record zero G3-or-earlier obligations evidence}"
+: "${G3_VERIFICATION_REF:?record required exact-SHA verification evidence}"
+: "${G3_REVIEW_VERDICT_REF:?record authoritative G3 reviewer verdict}"
+: "${PLANNING_AUTHORITY_SHA:?record merged planning-authority SHA}"
+: "${F1337_SUPERSESSION_RATIFICATION_REF:?record approved #1337 supersession}"
+: "${F1337_OWNER_SCOPE_RATIFICATION_REF:?record named #1337 owner-scope ratification}"
+G3_ACCEPTED_SHA=$(git rev-parse --verify "$G3_ACCEPTED_SHA^{commit}")
+PLANNING_AUTHORITY_SHA=$(git rev-parse --verify "$PLANNING_AUTHORITY_SHA^{commit}")
+git merge-base --is-ancestor "$G3_ACCEPTED_SHA" "$ORIGIN_MAIN"
+git merge-base --is-ancestor "$PLANNING_AUTHORITY_SHA" "$ORIGIN_MAIN"
+test "$(git rev-parse HEAD)" = "$ORIGIN_MAIN"
+BASELINE=$(git merge-base HEAD "$ORIGIN_MAIN")
+test -n "$BASELINE"
+test "$BASELINE" = "$ORIGIN_MAIN"
+test "$BASELINE" = "$(git rev-parse "$BASELINE^{commit}")"
+git -c core.fsmonitor=false status --short --branch
+shasum -a 256 docs/fees.truth-cases.json tests/unit/truth-cases/fee-adapter.ts
+TZ=UTC npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/truth-cases/runner.test.ts
+```
+
+Expected: every required durable reference is supplied and reviewed against its
+named criterion; both governing SHAs are ancestors of current `origin/main`;
+future branch HEAD and immutable `BASELINE` equal current main; no unrelated
+tracked, staged, unstaged, or untracked status exists; frozen hashes match; and
+runner baseline is `118 passed (118)`. Any failed command blocks all code work.
+
+### Fresh-shell ownership guard
+
+Every fenced shell block below that uses `BASELINE` begins with this same
+prologue. It re-fetches current main, resolves a non-empty immutable merge base
+in that shell, proves branch contains current main, and enables `pipefail` so a
+failure inside the grouped ownership pipeline cannot be hidden by `sort`.
+
+```bash
+set -euo pipefail
+git fetch --quiet origin main
+ORIGIN_MAIN=$(git rev-parse --verify origin/main^{commit})
+BASELINE=$(git merge-base HEAD "$ORIGIN_MAIN")
+test -n "$BASELINE"
+test "$BASELINE" = "$ORIGIN_MAIN"
+test "$BASELINE" = "$(git rev-parse "$BASELINE^{commit}")"
+{
+  git diff --name-only "$BASELINE"
+  git ls-files --others --exclude-standard
+} | sort -u
+git diff -- docs/fees.truth-cases.json tests/unit/truth-cases/fee-adapter.ts
+git diff --check
+```
+
+Expected: output contains only owned paths, if any; no unrelated tracked,
+staged, unstaged, or untracked path appears. Frozen-file diff is empty;
+whitespace check is silent. Review runner diff with
+`git diff --unified=0 "$BASELINE" -- tests/unit/truth-cases/runner.test.ts`.
+Allowed changes: FeeProfile imports, a new describe block, runner header
+wording, and overall-summary field/term. Any line edit inside legacy ten-case
+block, its count, or tag assertions fails gate. Repair only branch-owned change;
+never overwrite concurrent edits.
+
+---
+
+### Task 1: Establish baseline and lock secondary evidence
+
+**Files:** none (read-only).
+
+**Interfaces:**
+
+- Produces: `BASELINE`, green 118/118 baseline, exact legacy hashes, and fixed
+  secondary regression citations.
+
+- [ ] **Step 1: Record branch and clean ownership baseline.**
+
+```bash
+set -euo pipefail
+git fetch --quiet origin main
+ORIGIN_MAIN=$(git rev-parse --verify origin/main^{commit})
+BASELINE=$(git merge-base HEAD "$ORIGIN_MAIN")
+test -n "$BASELINE"
+test "$BASELINE" = "$ORIGIN_MAIN"
+test "$BASELINE" = "$(git rev-parse "$BASELINE^{commit}")"
+printf '%s\n' "$BASELINE"
+git -c core.fsmonitor=false status --short --branch
+{
+  git diff --name-only "$BASELINE"
+  git ls-files --others --exclude-standard
+} | sort -u
+```
+
+Expected: immutable SHA prints and equals current `origin/main`; intended branch
+contains current main; no branch-owned diff. Ownership block and status show no
+unrelated tracked, staged, unstaged, or untracked file. Stop for any unrelated
+status or a branch not rebased onto current main.
+
+- [ ] **Step 2: Prove legacy state and current runner baseline.**
+
+```bash
+shasum -a 256 docs/fees.truth-cases.json tests/unit/truth-cases/fee-adapter.ts
+TZ=UTC npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/truth-cases/runner.test.ts
+```
+
+Expected: hash output exactly equals both Global Constraints values; Vitest
+exits 0 with `118 passed (118)`.
+
+- [ ] **Step 3: Cite, do not duplicate, existing catch-up regressions.**
+
+```bash
+rg -n -C 2 'fee holiday|maxCatchUpMonths|fractional|period-flow' tests/unit/economics/retroactive-fee-catch-up.test.ts
+```
+
+Expected: existing coverage covers holidays, `maxCatchUpMonths`, fractional
+periods, and catch-up-plus-flow rejection. Do not edit this test.
+
+- [ ] **Step 4: Run lifecycle gate.**
+
+```bash
+set -euo pipefail
+git fetch --quiet origin main
+ORIGIN_MAIN=$(git rev-parse --verify origin/main^{commit})
+BASELINE=$(git merge-base HEAD "$ORIGIN_MAIN")
+test -n "$BASELINE"
+test "$BASELINE" = "$ORIGIN_MAIN"
+test "$BASELINE" = "$(git rev-parse "$BASELINE^{commit}")"
+{
+  git diff --name-only "$BASELINE"
+  git ls-files --others --exclude-standard
+} | sort -u
+git diff --check
+```
+
+Expected: no changed or untracked paths and no whitespace output.
+
+### Task 2: Write failing FeeProfile production contract in unified runner
+
+**Files:**
+
+- Modify: `tests/unit/truth-cases/runner.test.ts`
+- Create later: `docs/fee-profile.truth-cases.json`
+- Create later: `tests/unit/truth-cases/fee-profile-adapter.ts`
+
+**Interfaces:**
+
+- Consumes later default JSON import plus
+  `executeFeeProfileTruthCase(testCase): FeeProfileTruthResult`.
+- Produces a standalone production block without changing legacy fee execution.
+
+- [ ] **Step 1: Add production imports and separate failing describe block.**
+
+Place imports beside existing legacy fee imports, leaving their text unchanged:
+
+```ts
+import feeProfileCases from '../../../docs/fee-profile.truth-cases.json';
+import {
+  executeFeeProfileTruthCase,
+  type FeeProfileTruthCase,
+} from './fee-profile-adapter';
+```
+
+Add this block after legacy Fees describe block:
+
+```ts
+describe('Truth Cases: FeeProfile production truth', () => {
+  const cases = feeProfileCases as FeeProfileTruthCase[];
+
+  cases.forEach((testCase) => {
+    it(`${testCase.id}: ${testCase.description}`, () => {
+      expect(executeFeeProfileTruthCase(testCase)).toEqual(testCase.expected);
+    });
+  });
+
+  it('has exactly eleven unique production cases and required tags', () => {
+    expect(cases).toHaveLength(11);
+    expect(new Set(cases.map((testCase) => testCase.id)).size).toBe(11);
+
+    const tags = new Set(cases.flatMap((testCase) => testCase.tags));
+    [
+      'baseline',
+      'step-down',
+      'catch-up',
+      'recycling',
+      'cap',
+      'cumulative-distributions',
+      'downward-adjustment',
+      'committed-capital',
+      'called-capital-cumulative',
+      'called-capital-period',
+      'called-capital-net-of-returns',
+      'invested-capital',
+      'fair-market-value',
+      'unrealized-cost',
+    ].forEach((tag) => expect(tags.has(tag)).toBe(true));
+  });
+```
+
+Add remaining negative tests to same production describe block:
+
+```ts
+  it('rejects zero numQuarters', () => {
+    const testCase = structuredClone(cases[0]!);
+    testCase.input.numQuarters = 0;
+    expect(() => executeFeeProfileTruthCase(testCase)).toThrow(
+      'input.numQuarters must be a positive integer'
+    );
+  });
+
+  it('rejects schedule length mismatch', () => {
+    const testCase = structuredClone(cases[2]!);
+    testCase.input.calledCapitalScheduleUsd = ['10000000.000000'];
+    expect(() => executeFeeProfileTruthCase(testCase)).toThrow(
+      'input.calledCapitalScheduleUsd must contain exactly 4 entries'
+    );
+  });
+
+  it('rejects negative monetary strings', () => {
+    const testCase = structuredClone(cases[0]!);
+    testCase.input.fundSizeUsd = '-0.000001';
+    expect(() => executeFeeProfileTruthCase(testCase)).toThrow(
+      'input.fundSizeUsd must be a finite non-negative decimal'
+    );
+  });
+
+  it('rejects percentages above one', () => {
+    const testCase = structuredClone(cases[0]!);
+    testCase.input.feeProfile.tiers[0]!.annualRatePercent = '2';
+    expect(() => executeFeeProfileTruthCase(testCase)).toThrow(
+      'Percentage must be between 0 and 1 (0% to 100%)'
+    );
+  });
+});
+```
+
+In overall summary, add `feeProfileCases.length` to `totalScenarios` and
+`feeProfile: feeProfileCases.length` to `breakdown`. Keep
+`fees: feesCases.length` separate. Update runner header to name Fees as legacy
+characterization (10) and FeeProfile as production truth (11).
+
+- [ ] **Step 2: Run RED before either new dependency exists.**
+
+```bash
+TZ=UTC npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/truth-cases/runner.test.ts
+```
+
+Expected: FAIL resolving `../../../docs/fee-profile.truth-cases.json` and/or
+`./fee-profile-adapter`. Do not bypass failure or alter production code.
+
+- [ ] **Step 3: Check legacy boundary.**
+
+```bash
+set -euo pipefail
+git fetch --quiet origin main
+ORIGIN_MAIN=$(git rev-parse --verify origin/main^{commit})
+BASELINE=$(git merge-base HEAD "$ORIGIN_MAIN")
+test -n "$BASELINE"
+test "$BASELINE" = "$ORIGIN_MAIN"
+test "$BASELINE" = "$(git rev-parse "$BASELINE^{commit}")"
+git diff --unified=0 "$BASELINE" -- tests/unit/truth-cases/runner.test.ts
+shasum -a 256 docs/fees.truth-cases.json tests/unit/truth-cases/fee-adapter.ts
+```
+
+Expected: only allowed imports/block/summary changes; frozen hashes exact.
+
+### Task 3: Create exact eleven-case serialized corpus
+
+**Files:**
+
+- Create: `docs/fee-profile.truth-cases.json`
+
+**Interfaces:**
+
+- Produces exactly eleven `FeeProfileTruthCase` objects consumed by Tasks 2
+  and 4.
+- Each object has `id`, `description`, `tags`, `input`, and complete `expected`.
+
+- [ ] **Step 1: Use complete static expected-result objects.**
+
+Every `expected` has these fields and no monetary JSON number:
+
+```ts
+interface FeeProfileTruthResult {
+  quarterlyManagementFeesUsd: string[];
+  totalManagementFeesUsd: string;
+  quarterlyRecyclableFeesUsd: string[];
+  totalRecyclableFeesUsd: string;
+  quarterlyRetroactiveCatchUpFeesUsd: string[];
+  totalRetroactiveCatchUpFeesUsd: string;
+  quarterlyRetroactiveCatchUpMonths: number[];
+  retroactiveCatchUpQuarters: number[];
+}
+```
+
+For every non-special output, write explicit zero strings for each quarter,
+total `"0.000000"`, zero months for each quarter, and `[]` for catch-up
+quarters. Omit unused optional schedules; do not use calculated values or
+abbreviated arrays in JSON.
+
+- [ ] **Step 2: Enter all records with exact inputs and results.**
+
+All `fundSizeUsd` values are `"100000000.000000"`. Tier shorthand means JSON
+keys `basis`, `annualRatePercent`, `startYear`, optional `endYear`,
+`capPercent`, and `capAmount`; no behavior is implicit.
+
+| ID; exact tags                                                                               | Input profile/schedules                                                                                        | Quarterly management fees; total                                   | Other non-zero expected result                                       |
+| -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | -------------------------------------------------------------------- |
+| `committed-capital-baseline`; `baseline`, `committed-capital`                                | 4Q; `committed_capital`, `"0.02"`, start 1                                                                     | four `"500000.000000"`; `"2000000.000000"`                         | none                                                                 |
+| `committed-capital-step-down`; `step-down`, `committed-capital`                              | 8Q; committed `"0.02"` start 1/end 1; committed `"0.01"` start 2                                               | four `"500000.000000"`, four `"250000.000000"`; `"3000000.000000"` | none                                                                 |
+| `called-capital-cumulative`; `called-capital-cumulative`                                     | 4Q; `called_capital_cumulative`, `"0.02"`, start 1; calls 10m, 25m, 50m, 100m                                  | 50k, 125k, 250k, 500k; `"925000.000000"`                           | none                                                                 |
+| `called-capital-period-flow`; `called-capital-period`, `downward-adjustment`                 | 4Q; `called_capital_period`, `"0.02"`, start 1; cumulative calls 0, 20m, 30m, 28m                              | 0, 400k, 200k, 0; `"600000.000000"`                                | none; pins downward-delta floor                                      |
+| `called-capital-net-of-returns`; `called-capital-net-of-returns`, `cumulative-distributions` | 4Q; `called_capital_net_of_returns`, `"0.02"`, start 1; calls 20m, 40m, 60m, 80m; distributions 0, 0, 10m, 30m | 100k, 200k, 250k, 250k; `"800000.000000"`                          | none                                                                 |
+| `invested-capital-basis`; `invested-capital`                                                 | 4Q; `invested_capital`, `"0.02"`, start 1; invested 10m, 20m, 40m, 50m                                         | 50k, 100k, 200k, 250k; `"600000.000000"`                           | none                                                                 |
+| `fair-market-value-basis`; `fair-market-value`                                               | 4Q; `fair_market_value`, `"0.015"`, start 1; FMV 50m, 75m, 100m, 120m                                          | 187500, 281250, 375000, 450000; `"1293750.000000"`                 | none                                                                 |
+| `unrealized-cost-basis`; `unrealized-cost`                                                   | 4Q; `unrealized_cost`, `"0.01"`, start 1; cost 40m, 35m, 25m, 10m                                              | 100k, 87500, 62500, 25000; `"275000.000000"`                       | none                                                                 |
+| `retroactive-fee-catch-up`; `catch-up`, `committed-capital`                                  | 12Q; committed `"0.02"` start 3; policy enabled, accrual start 0                                               | Q0-Q7 0; Q8 4.5m; Q9-Q11 500k; `"6000000.000000"`                  | Q8 catch-up 4m; total 4m; months 0,0,0,0,0,0,0,0,24,0,0,0; quarter 8 |
+| `fee-recycling-cap-term`; `recycling`, `committed-capital`                                   | 4Q; committed `"0.02"` start 1; enabled recycling, cap `"0.01"`, term 6                                        | four 500k; `"2000000.000000"`                                      | recyclable 500k, 1m, 1m, 0; `"2500000.000000"`                       |
+| `tier-caps`; `cap`, `committed-capital`                                                      | 8Q; committed `"0.02"` start 1/end 1/cap % `"0.001"`; committed `"0.02"` start 2/cap amount 100k               | eight 300k; `"2400000.000000"`                                     | none                                                                 |
+
+Expand all abbreviated amounts in table into six-decimal JSON strings: 10m is
+`"10000000.000000"`; 25m is `"25000000.000000"`; 50m is `"50000000.000000"`;
+100m is `"100000000.000000"`; 20m is `"20000000.000000"`; 30m is
+`"30000000.000000"`; 28m is `"28000000.000000"`; 40m is `"40000000.000000"`; 60m
+is `"60000000.000000"`; 80m is `"80000000.000000"`; 75m is `"75000000.000000"`;
+120m is `"120000000.000000"`; 35m is `"35000000.000000"`.
+
+Expand fee vectors likewise: 0 is `"0.000000"`; 50k is `"50000.000000"`; 100k is
+`"100000.000000"`; 125k is `"125000.000000"`; 187500 is `"187500.000000"`; 200k
+is `"200000.000000"`; 250k is `"250000.000000"`; 281250 is `"281250.000000"`;
+375k is `"375000.000000"`; 400k is `"400000.000000"`; 450k is `"450000.000000"`;
+500k is `"500000.000000"`; 1m is `"1000000.000000"`; 4m is `"4000000.000000"`;
+4.5m is `"4500000.000000"`.
+
+Use this literal JSON shape for every profile. Add stated optional fields only.
+
+```json
+{
+  "id": "committed-capital-baseline",
+  "name": "Committed capital baseline",
+  "tiers": [
+    {
+      "basis": "committed_capital",
+      "annualRatePercent": "0.02",
+      "startYear": 1
+    }
+  ]
+}
+```
+
+For catch-up use
+`"retroactiveFeeCatchUp": { "enabled": true, "accrualStartMonth": 0 }`. For
+recycling use
+`"recyclingPolicy": { "enabled": true, "recyclingCapPercent": "0.01", "recyclingTermMonths": 6 }`.
+For caps use first-tier `"capPercent": "0.001"` and second-tier
+`"capAmount": "100000.000000"`.
+
+- [ ] **Step 3: Run RED after fixture creation, before adapter creation.**
+
+```bash
+TZ=UTC npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/truth-cases/runner.test.ts
+```
+
+Expected: JSON resolves but run FAILS solely because `./fee-profile-adapter` is
+missing.
+
+- [ ] **Step 4: Parse fixture and run ownership gate.**
+
+```bash
+set -euo pipefail
+git fetch --quiet origin main
+ORIGIN_MAIN=$(git rev-parse --verify origin/main^{commit})
+BASELINE=$(git merge-base HEAD "$ORIGIN_MAIN")
+test -n "$BASELINE"
+test "$BASELINE" = "$ORIGIN_MAIN"
+test "$BASELINE" = "$(git rev-parse "$BASELINE^{commit}")"
+node -e "JSON.parse(require('node:fs').readFileSync('docs/fee-profile.truth-cases.json', 'utf8')); console.log('fee-profile truth JSON parses')"
+{
+  git diff --name-only "$BASELINE"
+  git ls-files --others --exclude-standard
+} | sort -u
+git diff --check
+```
+
+Expected: parser prints `fee-profile truth JSON parses`; only runner/new corpus
+changed; whitespace check silent.
+
+### Task 4: Add test-local adapter and make exact-object contract green
+
+**Files:**
+
+- Create: `tests/unit/truth-cases/fee-profile-adapter.ts`
+
+**Interfaces:**
+
+- Consumes `FeeProfileSchema.parse`, canonical `Decimal`, and
+  `computeFeeBasisTimeline`.
+- Produces `FeeProfileTruthCase`, `FeeProfileTruthResult`, and
+  `executeFeeProfileTruthCase`.
+
+- [ ] **Step 1: Add exact test-local serialized types.**
+
+```ts
+import Decimal from '@shared/lib/decimal-config';
+import { computeFeeBasisTimeline } from '@shared/lib/fund-math';
+import {
+  FeeProfileSchema,
+  type FeeBasisType,
+  type FeeCapitalStockBasis,
+} from '@shared/schemas/fee-profile';
+
+export type SerializedMoney = string;
+export type SerializedPercentage = string;
+
+export interface SerializedFeeProfile {
+  id: string;
+  name: string;
+  tiers: Array<{
+    basis: FeeBasisType;
+    annualRatePercent: SerializedPercentage;
+    startYear: number;
+    endYear?: number;
+    capPercent?: SerializedPercentage;
+    capAmount?: SerializedMoney;
+  }>;
+  stepDownMonths?: number[];
+  recyclingPolicy?: {
+    enabled: boolean;
+    recyclingCapPercent: SerializedPercentage;
+    recyclingTermMonths: number;
+    basis?: FeeCapitalStockBasis;
+    anticipatedRecycling?: boolean;
+  };
+  feeHolidays?: Array<{
+    startMonth: number;
+    durationMonths: number;
+    reason?: string;
+  }>;
+  retroactiveFeeCatchUp?: {
+    enabled: boolean;
+    accrualStartMonth?: number;
+    maxCatchUpMonths?: number;
+  };
+}
+
+export interface FeeProfileTruthCase {
+  id: string;
+  description: string;
+  tags: string[];
+  input: {
+    fundSizeUsd: SerializedMoney;
+    numQuarters: number;
+    feeProfile: SerializedFeeProfile;
+    calledCapitalScheduleUsd?: SerializedMoney[];
+    distributionScheduleUsd?: SerializedMoney[];
+    investedCapitalScheduleUsd?: SerializedMoney[];
+    fmvScheduleUsd?: SerializedMoney[];
+    unrealizedCostScheduleUsd?: SerializedMoney[];
+  };
+  expected: FeeProfileTruthResult;
+}
+
+export interface FeeProfileTruthResult {
+  quarterlyManagementFeesUsd: string[];
+  totalManagementFeesUsd: string;
+  quarterlyRecyclableFeesUsd: string[];
+  totalRecyclableFeesUsd: string;
+  quarterlyRetroactiveCatchUpFeesUsd: string[];
+  totalRetroactiveCatchUpFeesUsd: string;
+  quarterlyRetroactiveCatchUpMonths: number[];
+  retroactiveCatchUpQuarters: number[];
+}
+```
+
+- [ ] **Step 2: Implement local positive-quarter, schedule, and money
+      validators.**
+
+```ts
+function parseNumQuarters(value: number): number {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new RangeError('input.numQuarters must be a positive integer');
+  }
+  return value;
+}
+
+function parseMoney(value: unknown, field: string): Decimal {
+  if (typeof value !== 'string') {
+    throw new RangeError(`${field} must be a finite non-negative decimal`);
+  }
+
+  try {
+    const decimal = new Decimal(value);
+    if (!decimal.isFinite() || decimal.isNegative()) {
+      throw new RangeError(`${field} must be a finite non-negative decimal`);
+    }
+    return decimal;
+  } catch (error: unknown) {
+    if (error instanceof RangeError) {
+      throw error;
+    }
+    throw new RangeError(`${field} must be a finite non-negative decimal`);
+  }
+}
+
+function parseSchedule(
+  value: SerializedMoney[] | undefined,
+  field: string,
+  numQuarters: number
+): Decimal[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(value) || value.length !== numQuarters) {
+    throw new RangeError(
+      `${field} must contain exactly ${numQuarters} entries`
+    );
+  }
+  return value.map((entry, index) => parseMoney(entry, `${field}[${index}]`));
+}
+```
+
+Pass complete serialized profile directly to
+`FeeProfileSchema.parse(input.feeProfile)`, including tier caps and recycling
+percentages. Therefore percentage `"2"` fails schema validation. Map
+`distributionScheduleUsd` directly to production `distributionSchedule`; never
+difference it into a flow. Map called capital as cumulative; production floors
+negative period delta.
+
+- [ ] **Step 3: Implement exactly one production invocation and six-decimal
+      serialization.**
+
+```ts
+export function executeFeeProfileTruthCase(
+  testCase: FeeProfileTruthCase
+): FeeProfileTruthResult {
+  const { input } = testCase;
+  const numQuarters = parseNumQuarters(input.numQuarters);
+  const feeProfile = FeeProfileSchema.parse(input.feeProfile);
+
+  const timeline = computeFeeBasisTimeline({
+    fundSize: parseMoney(input.fundSizeUsd, 'input.fundSizeUsd'),
+    numQuarters,
+    feeProfile,
+    calledCapitalSchedule: parseSchedule(
+      input.calledCapitalScheduleUsd,
+      'input.calledCapitalScheduleUsd',
+      numQuarters
+    ),
+    distributionSchedule: parseSchedule(
+      input.distributionScheduleUsd,
+      'input.distributionScheduleUsd',
+      numQuarters
+    ),
+    investedCapitalSchedule: parseSchedule(
+      input.investedCapitalScheduleUsd,
+      'input.investedCapitalScheduleUsd',
+      numQuarters
+    ),
+    fmvSchedule: parseSchedule(input.fmvScheduleUsd, 'input.fmvScheduleUsd', numQuarters),
+    unrealizedCostSchedule: parseSchedule(
+      input.unrealizedCostScheduleUsd,
+      'input.unrealizedCostScheduleUsd',
+      numQuarters
+    ),
+  });
+```
+
+Complete the same function with this exact return and closing brace:
+
+```ts
+  return {
+    quarterlyManagementFeesUsd: timeline.periods.map((period) =>
+      period.managementFees.toFixed(6)
+    ),
+    totalManagementFeesUsd: timeline.totalFees.toFixed(6),
+    quarterlyRecyclableFeesUsd: timeline.periods.map((period) =>
+      period.recyclableFees.toFixed(6)
+    ),
+    totalRecyclableFeesUsd: timeline.totalRecyclable.toFixed(6),
+    quarterlyRetroactiveCatchUpFeesUsd: timeline.periods.map((period) =>
+      period.retroactiveCatchUpFees.toFixed(6)
+    ),
+    totalRetroactiveCatchUpFeesUsd: timeline.totalRetroactiveCatchUpFees.toFixed(6),
+    quarterlyRetroactiveCatchUpMonths: timeline.periods.map(
+      (period) => period.retroactiveCatchUpMonths
+    ),
+    retroactiveCatchUpQuarters: timeline.periods
+      .filter((period) => period.retroactiveCatchUpFees.gt(0))
+      .map((period) => period.quarter),
+  };
+}
+```
+
+`computeFeeBasisTimeline` appears once in adapter, therefore exactly once per
+case. Do not add a second total-only invocation.
+
+- [ ] **Step 4: Run GREEN.**
+
+```bash
+TZ=UTC npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/truth-cases/runner.test.ts
+```
+
+Expected: exit 0, one test file, `134 passed (134)`: legacy 118 plus eleven
+complete-object cases, count/tag test, and four negative tests. FeeProfile uses
+`toEqual`, never numeric tolerance.
+
+- [ ] **Step 5: Run ownership/hash/legacy gate.**
+
+```bash
+set -euo pipefail
+git fetch --quiet origin main
+ORIGIN_MAIN=$(git rev-parse --verify origin/main^{commit})
+BASELINE=$(git merge-base HEAD "$ORIGIN_MAIN")
+test -n "$BASELINE"
+test "$BASELINE" = "$ORIGIN_MAIN"
+test "$BASELINE" = "$(git rev-parse "$BASELINE^{commit}")"
+shasum -a 256 docs/fees.truth-cases.json tests/unit/truth-cases/fee-adapter.ts
+{
+  git diff --name-only "$BASELINE"
+  git ls-files --others --exclude-standard
+} | sort -u
+git diff --unified=0 "$BASELINE" -- tests/unit/truth-cases/runner.test.ts
+git diff --check
+```
+
+Expected: exact frozen hashes; exactly corpus, adapter, runner paths; no changed
+line in old ten-case block; silent whitespace check.
+
+### Task 5: Verify lifecycle gates and commit production-truth slice
+
+**Files:**
+
+- Create: `docs/fee-profile.truth-cases.json`
+- Create: `tests/unit/truth-cases/fee-profile-adapter.ts`
+- Modify: `tests/unit/truth-cases/runner.test.ts`
+
+**Interfaces:**
+
+- Produces one verified truth-corpus commit, with no production-code scope
+  expansion.
+
+- [ ] **Step 1: Run required verification commands in exact order.**
+
+```bash
+TZ=UTC npx vitest run --config vitest.config.mjs --configLoader native --project=server tests/unit/truth-cases/runner.test.ts
+TZ=UTC npm run phoenix:truth
+TZ=UTC npm run calc-gate:orphans
+npm run check
+npm run lint
+TZ=UTC npm test
+git diff --check
+```
+
+Expected: every command exits 0; targeted runner reports `134 passed (134)`;
+Phoenix truth, orphan calculation regression, typecheck, lint, and full suite
+pass; final whitespace check silent. If failure is outside three-file ownership,
+stop and report it rather than broaden scope.
+
+- [ ] **Step 2: Repeat final ownership and frozen-content guards.**
+
+```bash
+set -euo pipefail
+git fetch --quiet origin main
+ORIGIN_MAIN=$(git rev-parse --verify origin/main^{commit})
+BASELINE=$(git merge-base HEAD "$ORIGIN_MAIN")
+test -n "$BASELINE"
+test "$BASELINE" = "$ORIGIN_MAIN"
+test "$BASELINE" = "$(git rev-parse "$BASELINE^{commit}")"
+shasum -a 256 docs/fees.truth-cases.json tests/unit/truth-cases/fee-adapter.ts
+{
+  git diff --name-only "$BASELINE"
+  git ls-files --others --exclude-standard
+} | sort -u
+git diff --unified=0 "$BASELINE" -- tests/unit/truth-cases/runner.test.ts
+git diff --check
+```
+
+Expected: hashes exact; changed paths exactly three owned files; legacy
+block/count/tag assertions unchanged; no whitespace errors.
+
+- [ ] **Step 3: Commit only the truth slice.**
+
+```bash
+git add docs/fee-profile.truth-cases.json \
+  tests/unit/truth-cases/fee-profile-adapter.ts \
+  tests/unit/truth-cases/runner.test.ts
+git diff --cached --name-only
+git commit -m "test(truth): add FeeProfile production truth corpus"
+```
+
+Expected: staged list contains exactly three owned paths; commit subject exactly
+`test(truth): add FeeProfile production truth corpus`.
+
+- [ ] **Step 4: Verify committed result.**
+
+```bash
+git diff --check HEAD^..HEAD
+git show --stat --oneline HEAD
+git status --short
+```
+
+Expected: diff check exits 0; commit shows only three allowed files and exact
+subject; tracked worktree clean. Overall summary reports separate `fees: 10` and
+`feeProfile: 11`, both included in total.
+
+### Handoff and merge hold
+
+- [ ] Default: hold this #1337 truth slice unmerged until durable G5 / #1299
+      activation is complete. A green branch, a planning merge, or a preview
+      does not activate this merge gate.
+- [ ] Exception: a durable ELIG decision may explicitly promote #1337 only when
+      its immutable evidence records both the explicit #1337 promotion and #1338
+      disposition. Silence about #1338 is a failed exception.
+- [ ] The ELIG exception does not waive Gate 0, #1337 owner-scope ratification,
+      the green production FeeProfile truth suite, frozen legacy hashes,
+      required verification, or any applicable domain approval.
+- [ ] Handoff includes current origin/main SHA, accepted G3 SHA and reviewer
+      verdict reference, planning-authority SHA, #1337 supersession/owner-scope
+      references, all required command output, and either G5/#1299 activation
+      record or ELIG promotion plus #1338 disposition. Do not merge if any
+      record is absent or changed.
+
+## Final Acceptance Checklist
+
+- [ ] Frozen legacy corpus and adapter match mandated SHA-256 values.
+- [ ] Ten-case legacy `computeFeePreview` block and its count/tag assertions are
+      unchanged.
+- [ ] New block has eleven unique cases; all seven basis tags plus baseline,
+      step-down, catch-up, recycling, cap, cumulative-distributions, and
+      downward-adjustment exist.
+- [ ] Test-local adapter validates positive quarter count, exact schedule
+      length, non-negative finite money, and percentage fraction through
+      `FeeProfileSchema`.
+- [ ] Adapter parses full profiles, maps cumulative distributions directly, uses
+      canonical `Decimal`, invokes `computeFeeBasisTimeline` exactly once per
+      case, and serializes monetary results with `toFixed(6)`.
+- [ ] Runner compares complete output objects with exact strings and retains
+      cited secondary catch-up tests unchanged.
+- [ ] Required commands pass in order; commit has exact subject and only three
+      owned files.


### PR DESCRIPTION
## Summary

- add a standalone #1337 FeeProfile production-truth implementation plan
- reconcile F1.3 fee/economics sequencing and F1.4 post-activation governance
- normalize fee and GP terminology under ADR-070
- regenerate committed documentation-routing artifacts

## Why

Existing planning documents mixed stale issue language, compatibility paths, and unresolved lifecycle authority. This change records production seams, offline issue dispositions, owner and specialist gates, and fail-closed sequencing without changing product code.

G3, G5/#1299, and #1337 owner-scope ratification remain unsatisfied. This PR creates planning authority only; it does not authorize #1337 implementation or activation.

## Impact

Documentation-only change across seven paths. No source, runtime, schema, migration, dependency, or ADR changes.

## Validation

- `npm run docs:routing:check`
- `npm run docs:check-links` — 1,566 links valid
- explicit four-file `remark --frail`
- deterministic routing generation across two runs
- FeeProfile production oracle — 11/11 exact
- `TZ=UTC npm test` — 12,140 passed, 90 skipped
- independent whole-branch review — APPROVED
- Sol Advisor final review — `VERDICT: proceed`
