### PR TITLE
chore: usage-synthesis N1-N5 (dead hooks, mutating lint, eslint ^_ ignore, pre-action rules)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,7 +34,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash --noprofile --norc -c \"source 'C:/dev/Updog_restore/scripts/hooks/session-start-hook.sh'\"",
+            "command": "bash --noprofile --norc -c \"source '${CLAUDE_PROJECT_DIR}/scripts/hooks/session-start-hook.sh'\"",
             "timeout": 10
           }
         ]
@@ -46,7 +46,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash --noprofile --norc -c \"source 'C:/dev/Updog_restore/scripts/hooks/complexity-checkpoint-hook.sh'\"",
+            "command": "bash --noprofile --norc -c \"source '${CLAUDE_PROJECT_DIR}/scripts/hooks/complexity-checkpoint-hook.sh'\"",
             "timeout": 20
           }
         ]
@@ -69,7 +69,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npm run lint:fix"
+            "command": "npm run lint:eslint"
           }
         ]
       },
@@ -91,6 +91,7 @@
   },
   "enabledPlugins": {
     "cicd-automation@claude-code-workflows": false,
-    "playwright@claude-plugins-official": true
+    "playwright@claude-plugins-official": true,
+    "vercel@claude-plugins-official": true
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,6 +305,12 @@ This is a single-context repo using root governance docs plus `docs/adr/`. See
   `npm run lint:fix`. Type errors -> `npm run check` with targeted fix. Test
   fails -> run targeted test first, full suite only if targeted passes but
   suspicion remains.
+- BEFORE advancing a multi-step task, create a durable, attributable checkpoint
+  — prefer an atomic green commit; when committing is prohibited or the batch is
+  incomplete, preserve the exact diff and record why it couldn't be committed.
+- BEFORE declaring a file, plan, or branch missing, search all worktrees
+  (`git worktree list`) and origin refs, not just the current working tree — and
+  name which tree was authoritative once found.
 
 ## AI-Augmented Development
 

--- a/docs/_generated/router-index.json
+++ b/docs/_generated/router-index.json
@@ -261,7 +261,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".agents-feedback.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -276,7 +276,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".agents-metrics.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -304,7 +304,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Team",
       "path": ".claude/AGENT-DIRECTORY.md",
-      "staleDays": 224,
+      "staleDays": 223,
       "status": "ACTIVE"
     },
     {
@@ -333,7 +333,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Platform Team",
       "path": ".claude/AGENT-METRICS.md",
-      "staleDays": 82,
+      "staleDays": 81,
       "status": "ACTIVE"
     },
     {
@@ -348,7 +348,7 @@
       "lastUpdated": "2026-03-27",
       "owner": null,
       "path": ".claude/ANTI-DRIFT-CHECKLIST.md",
-      "staleDays": 136,
+      "staleDays": 135,
       "status": "ACTIVE"
     },
     {
@@ -363,7 +363,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/DELIVERY-SUMMARY.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "HISTORICAL"
     },
     {
@@ -392,7 +392,7 @@
       "lastUpdated": "2026-04-18",
       "owner": "Platform Team",
       "path": ".claude/DISCOVERY-MAP.md",
-      "staleDays": 114,
+      "staleDays": 113,
       "status": "ACTIVE"
     },
     {
@@ -407,7 +407,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/PHOENIX-AGENTS-REGISTRY.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -422,7 +422,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/PHOENIX-TOOL-ROUTING.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -437,7 +437,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/PROJECT-UNDERSTANDING.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -452,7 +452,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": ".claude/WORKFLOW.md",
-      "staleDays": 114,
+      "staleDays": 113,
       "status": "ACTIVE"
     },
     {
@@ -472,7 +472,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/baseline-regression-explainer.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -489,7 +489,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/chaos-engineer.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -507,7 +507,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/code-explorer.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -525,7 +525,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/code-reviewer.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -542,7 +542,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/code-simplifier.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -560,7 +560,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/comment-analyzer.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -577,7 +577,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/context-orchestrator.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -594,7 +594,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/database-expert.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -612,7 +612,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/db-migration.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -629,7 +629,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/debug-expert.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -646,7 +646,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/devops-troubleshooter.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -663,7 +663,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/docs-architect.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -680,7 +680,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/dx-optimizer.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -697,7 +697,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/incident-responder.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -714,7 +714,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/legacy-modernizer.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -734,7 +734,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/parity-auditor.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -752,7 +752,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/perf-guard.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -772,7 +772,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/perf-regression-triager.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -794,7 +794,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-brand-reporting-stylist.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -816,7 +816,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-capital-allocation-analyst.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -838,7 +838,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-docs-scribe.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -860,7 +860,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-precision-guardian.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -882,7 +882,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-probabilistic-engineer.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -904,7 +904,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-reserves-optimizer.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -926,7 +926,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/phoenix-truth-case-runner.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -946,7 +946,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/playwright-test-author.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -964,7 +964,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/pr-test-analyzer.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -984,7 +984,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/schema-drift-checker.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -1002,7 +1002,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/silent-failure-hunter.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -1019,7 +1019,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/test-automator.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -1037,7 +1037,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/test-repair.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -1055,7 +1055,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/test-scaffolder.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -1073,7 +1073,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/type-design-analyzer.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -1094,7 +1094,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/waterfall-specialist.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -1111,7 +1111,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/workflow-orchestrator.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -1133,7 +1133,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/agents/xirr-fees-validator.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -1151,7 +1151,7 @@
       "lastUpdated": "2026-06-23",
       "owner": "Platform / GP Modeling",
       "path": ".claude/artifacts/debate-rubric-v33.md",
-      "staleDays": 48,
+      "staleDays": 47,
       "status": "REFERENCE"
     },
     {
@@ -1169,7 +1169,7 @@
       "lastUpdated": "2026-06-23",
       "owner": "Platform / GP Modeling",
       "path": ".claude/artifacts/debate-synthesis-v33.md",
-      "staleDays": 48,
+      "staleDays": 47,
       "status": "REFERENCE"
     },
     {
@@ -1196,7 +1196,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/advise.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -1212,7 +1212,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/catalog-tooling.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -1228,7 +1228,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/db-validate.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -1243,7 +1243,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/deploy-check.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -1260,7 +1260,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/enable-agent-memory.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -1276,7 +1276,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/evaluate-tools.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -1291,7 +1291,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/fix-auto.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -1308,7 +1308,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/log-change.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -1325,7 +1325,7 @@
       "lastUpdated": "2026-04-06",
       "owner": null,
       "path": ".claude/commands/log-decision.md",
-      "staleDays": 126,
+      "staleDays": 125,
       "status": "UNKNOWN"
     },
     {
@@ -1343,7 +1343,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/phoenix-phase2.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -1360,7 +1360,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/phoenix-prob-report.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -1377,7 +1377,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/phoenix-truth.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -1393,7 +1393,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/pr-ready.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -1408,7 +1408,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/pre-commit-check.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -1423,7 +1423,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/retrospective.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -1438,7 +1438,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/session-learnings.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "HISTORICAL"
     },
     {
@@ -1454,7 +1454,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/session-start.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -1469,7 +1469,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/test-smart.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -1484,7 +1484,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/commands/workflows.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -1499,7 +1499,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/wshobson/deps-audit.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -1514,7 +1514,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/commands/wshobson/tech-debt.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -1542,7 +1542,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Team",
       "path": ".claude/docs/TEST-STRATEGY.md",
-      "staleDays": 224,
+      "staleDays": 223,
       "status": "ACTIVE"
     },
     {
@@ -1558,7 +1558,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": ".claude/hermes/SOUL.md",
-      "staleDays": 82,
+      "staleDays": 81,
       "status": "UNKNOWN"
     },
     {
@@ -1621,7 +1621,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-execution-summary.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "HISTORICAL"
     },
     {
@@ -1636,7 +1636,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-final-report.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "HISTORICAL"
     },
     {
@@ -1651,7 +1651,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-plan-comparison.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -1666,7 +1666,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-reenable-plan-v2.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -1681,7 +1681,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/integration-test-reenable-plan.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -1734,7 +1734,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Developer",
       "path": ".claude/plan.md",
-      "staleDays": 224,
+      "staleDays": 223,
       "status": "ACTIVE"
     },
     {
@@ -1748,7 +1748,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/ci-workflow-cleanup.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -1762,7 +1762,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4-final-plan.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -1776,7 +1776,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4-review-findings.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -1790,7 +1790,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4.5-findings.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -1804,7 +1804,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p4.5-plan.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -1818,7 +1818,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p5-findings.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -1832,7 +1832,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/plans/p5-plan.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -1847,7 +1847,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/integration-test-continuation-prompt.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -1862,7 +1862,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/portfolio-intelligence-timeout-fix.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -1877,7 +1877,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-next-session-kickoff.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "HISTORICAL"
     },
     {
@@ -1892,7 +1892,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase2-quickstart.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -1907,7 +1907,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v10.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -1922,7 +1922,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v2.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -1937,7 +1937,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v3.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -1952,7 +1952,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v4.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -1967,7 +1967,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v5.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -1986,7 +1986,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v6.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "ready"
     },
     {
@@ -2005,7 +2005,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v8.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "ready"
     },
     {
@@ -2024,7 +2024,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation-v9.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "ready"
     },
     {
@@ -2039,7 +2039,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase3-continuation.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2054,7 +2054,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/prompts/week2.5-phase4-next-steps.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2093,7 +2093,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/security-fixes-lp-reporting.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "HISTORICAL"
     },
     {
@@ -2108,7 +2108,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/session-summary-portfolio-intelligence-implementation.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "HISTORICAL"
     },
     {
@@ -2123,7 +2123,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/sessions/PHASE4-CONTINUATION-KICKOFF.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2149,7 +2149,7 @@
       "lastUpdated": "2026-05-21",
       "owner": null,
       "path": ".claude/skills/INDEX.md",
-      "staleDays": 81,
+      "staleDays": 80,
       "status": "UNKNOWN"
     },
     {
@@ -2164,7 +2164,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/README.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2191,7 +2191,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/api-design-principles.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2206,7 +2206,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/architecture-patterns.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2221,7 +2221,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/async-error-resilience.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2236,7 +2236,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/baseline-governance/SKILL.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2252,7 +2252,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": ".claude/skills/bias-audit/SKILL.md",
-      "staleDays": 91,
+      "staleDays": 90,
       "status": "UNKNOWN"
     },
     {
@@ -2268,7 +2268,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/bundle-size/SKILL.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -2283,7 +2283,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/bundle-size/references/capability-tiers.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2298,7 +2298,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/bundle-size/references/troubleshooting.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2313,7 +2313,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/claude-infra-integrity/SKILL.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2328,7 +2328,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/continuous-improvement.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2344,7 +2344,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": ".claude/skills/control-plane/SKILL.md",
-      "staleDays": 91,
+      "staleDays": 90,
       "status": "UNKNOWN"
     },
     {
@@ -2359,7 +2359,7 @@
       "lastUpdated": "2026-07-29",
       "owner": null,
       "path": ".claude/skills/database-schema-evolution.md",
-      "staleDays": 12,
+      "staleDays": 11,
       "status": "ACTIVE"
     },
     {
@@ -2374,7 +2374,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/extended-thinking-framework.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2389,7 +2389,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/financial-calc-correctness/SKILL.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2405,7 +2405,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/frontend-ui-ux/SKILL.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -2420,7 +2420,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/inversion-thinking.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2435,7 +2435,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/iterative-improvement.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2450,7 +2450,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/memory-management.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2464,7 +2464,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/owasp-security/SKILL.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -2479,7 +2479,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/pattern-recognition.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2495,7 +2495,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-advanced-forecasting/SKILL.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -2511,7 +2511,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-brand-reporting/SKILL.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -2527,7 +2527,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-capital-exit-investigator/SKILL.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -2543,7 +2543,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-docs-sync/SKILL.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -2559,7 +2559,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-precision-guard/SKILL.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -2575,7 +2575,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-reserves-optimizer/SKILL.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -2591,7 +2591,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-truth-case-orchestrator/SKILL.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -2607,7 +2607,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-waterfall-ledger-semantics/SKILL.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -2622,7 +2622,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/phoenix-workflow-orchestrator/SKILL.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2638,7 +2638,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/phoenix-xirr-fees-validator/SKILL.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -2653,7 +2653,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/prompt-caching-usage.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2668,7 +2668,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/react-hook-form-stability/SKILL.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2683,7 +2683,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/react-performance-optimization.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2699,7 +2699,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/refactor-code/SKILL.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -2715,7 +2715,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/regression-checker/SKILL.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -2730,7 +2730,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/root-cause-tracing.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2748,7 +2748,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/session-learnings/SKILL.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -2763,7 +2763,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/statistical-testing/SKILL.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2778,7 +2778,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/task-decomposition.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2793,7 +2793,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/test-fixture-generator/SKILL.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2808,7 +2808,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/test-pyramid/SKILL.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2824,7 +2824,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/skills/ui-design-system/SKILL.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -2839,7 +2839,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/skills/xlsx.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2854,7 +2854,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/platform-test-checklist.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2869,7 +2869,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": ".claude/testing/platform-testing-rubric-index.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "ACTIVE"
     },
     {
@@ -2884,7 +2884,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-api-integration.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2899,7 +2899,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-calculation-engines.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2914,7 +2914,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-cross-cutting.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2929,7 +2929,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/rubric-fund-setup.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2944,7 +2944,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/scenario-comparison-manual-test-rubric.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2959,7 +2959,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": ".claude/testing/seed-script-remaining-fixes.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -2974,7 +2974,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": "AGENTS.md",
-      "staleDays": 82,
+      "staleDays": 81,
       "status": "ACTIVE"
     },
     {
@@ -2989,7 +2989,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "AI-WORKFLOW-COMPLETE-GUIDE.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3004,7 +3004,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "ANTI_PATTERNS.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3040,7 +3040,7 @@
       "lastUpdated": "2026-03-27",
       "owner": "Core Team",
       "path": "CAPABILITIES.md",
-      "staleDays": 136,
+      "staleDays": 135,
       "status": "ACTIVE"
     },
     {
@@ -3053,11 +3053,11 @@
         "status": "ACTIVE"
       },
       "hasExecutionClaims": true,
-      "isStale": true,
+      "isStale": false,
       "lastUpdated": "2026-08-03",
       "owner": "Core Team",
       "path": "CHANGELOG.md",
-      "staleDays": 7,
+      "staleDays": 6,
       "status": "ACTIVE"
     },
     {
@@ -3072,7 +3072,7 @@
       "lastUpdated": "2026-05-20",
       "owner": null,
       "path": "CLAUDE.md",
-      "staleDays": 82,
+      "staleDays": 81,
       "status": "ACTIVE"
     },
     {
@@ -3087,7 +3087,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "CLAUDE_COOKBOOK_INTEGRATION.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3102,7 +3102,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "COMPREHENSIVE-WORKFLOW-GUIDE.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3131,7 +3131,7 @@
       "lastUpdated": "2026-08-07",
       "owner": "Core Team",
       "path": "DECISIONS.md",
-      "staleDays": 3,
+      "staleDays": 2,
       "status": "ACTIVE"
     },
     {
@@ -3162,7 +3162,7 @@
       "lastUpdated": "2026-08-08",
       "owner": "Product + Frontend",
       "path": "DESIGN.md",
-      "staleDays": 2,
+      "staleDays": 1,
       "status": "ACTIVE"
     },
     {
@@ -3177,7 +3177,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "DEV_BOOTSTRAP_README.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3192,7 +3192,7 @@
       "lastUpdated": "2026-07-28",
       "owner": null,
       "path": "DEV_BRAIN.md",
-      "staleDays": 13,
+      "staleDays": 12,
       "status": "ACTIVE"
     },
     {
@@ -3219,7 +3219,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "ITERATION-A-QUICKSTART.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3234,7 +3234,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "MIGRATION-NATIVE-MEMORY.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3249,7 +3249,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "NATIVE-MEMORY-INTEGRATION.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3264,7 +3264,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "PRE_MERGE_CHECKLIST.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3279,7 +3279,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "PRODUCTION_RUNBOOK.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3294,7 +3294,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "PROMPT_PATTERNS.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3309,7 +3309,7 @@
       "lastUpdated": "2026-07-11",
       "owner": null,
       "path": "README.md",
-      "staleDays": 30,
+      "staleDays": 29,
       "status": "ACTIVE"
     },
     {
@@ -3324,7 +3324,7 @@
       "lastUpdated": "2026-07-12",
       "owner": null,
       "path": "SECURITY.md",
-      "staleDays": 29,
+      "staleDays": 28,
       "status": "ACTIVE"
     },
     {
@@ -3339,7 +3339,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "STEP_2_AND_4_IMPROVEMENTS.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3366,7 +3366,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "UNIFIED_METRICS_IMPLEMENTATION.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3383,7 +3383,7 @@
       "lastUpdated": "2026-03-27",
       "owner": "Core Team",
       "path": "cheatsheets/INDEX.md",
-      "staleDays": 136,
+      "staleDays": 135,
       "status": "ACTIVE"
     },
     {
@@ -3398,7 +3398,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/agent-architecture.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3413,7 +3413,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/agent-memory-integration.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "ACTIVE"
     },
     {
@@ -3428,7 +3428,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/agent-memory/database-expert-schema-tdd.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3443,7 +3443,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/ai-code-review.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3458,7 +3458,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/anti-pattern-prevention.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3473,7 +3473,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/api.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3488,7 +3488,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "cheatsheets/baseline-governance.md",
-      "staleDays": 91,
+      "staleDays": 90,
       "status": "ACTIVE"
     },
     {
@@ -3503,7 +3503,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/capability-checklist.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3518,7 +3518,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/ci-validator-guide.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3533,7 +3533,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/claude-code-best-practices.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "ACTIVE"
     },
     {
@@ -3548,7 +3548,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/claude-commands.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3563,7 +3563,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/claude-md-guidelines.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3578,7 +3578,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/codex-collaboration-protocol.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3593,7 +3593,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/coding-pairs-playbook.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3608,7 +3608,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/command-summary.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "HISTORICAL"
     },
     {
@@ -3623,7 +3623,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/correct-workflow-example.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3638,7 +3638,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/daily-workflow.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "ACTIVE"
     },
     {
@@ -3653,7 +3653,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/document-review-workflow.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3668,7 +3668,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/documentation-validation.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3683,7 +3683,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/emoji-free-documentation.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3698,7 +3698,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/evaluator-optimizer-workflow.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "ACTIVE"
     },
     {
@@ -3713,7 +3713,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/exact-optional-property-types.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3728,7 +3728,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/extended-thinking.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3743,7 +3743,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/init-vs-update.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3758,7 +3758,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/lp-deployment-quick-reference.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3774,7 +3774,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/lp-reporting-quick-reference.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "active"
     },
     {
@@ -3789,7 +3789,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/memory-commands.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3804,7 +3804,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/memory-commit-strategy.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3819,7 +3819,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/memory-patterns.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3834,7 +3834,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/multi-agent-orchestration.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3849,7 +3849,7 @@
       "lastUpdated": "2026-04-06",
       "owner": null,
       "path": "cheatsheets/pr-merge-verification.md",
-      "staleDays": 126,
+      "staleDays": 125,
       "status": "ACTIVE"
     },
     {
@@ -3864,7 +3864,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/pr-review-workflow.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3879,7 +3879,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "cheatsheets/prompt-improver-hook.md",
-      "staleDays": 91,
+      "staleDays": 90,
       "status": "ACTIVE"
     },
     {
@@ -3894,7 +3894,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/react-performance-patterns.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3909,7 +3909,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "cheatsheets/rls-cheatsheet.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "ACTIVE"
     },
     {
@@ -3924,7 +3924,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/schema-alignment.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3939,7 +3939,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/service-testing-patterns.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3954,7 +3954,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/test-fix-patterns.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3969,7 +3969,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/test-pyramid.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3984,7 +3984,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/testcontainers-guide.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -3999,7 +3999,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "cheatsheets/testing.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -4014,7 +4014,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/.templates/DEPRECATION-HEADER.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -4029,7 +4029,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/.templates/DOC-FRONTMATTER-SCHEMA.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -4284,7 +4284,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ADR-00X-resilience-circuit-breaker.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -4299,7 +4299,7 @@
       "lastUpdated": "2026-06-03",
       "owner": null,
       "path": "docs/ANALYTICS_IMPLEMENTATION.md",
-      "staleDays": 68,
+      "staleDays": 67,
       "status": "ACTIVE"
     },
     {
@@ -4326,7 +4326,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/ARCHITECTURAL-DEBT.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "ACTIVE"
     },
     {
@@ -4341,7 +4341,7 @@
       "lastUpdated": "2026-07-30",
       "owner": null,
       "path": "docs/BUILD_READINESS.md",
-      "staleDays": 11,
+      "staleDays": 10,
       "status": "ACTIVE"
     },
     {
@@ -4356,7 +4356,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CA-IMPLEMENTATION-PLAN.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -4383,7 +4383,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CA-SEMANTIC-LOCK.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -4398,7 +4398,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CI_GATING_TEST.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -4413,7 +4413,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CLAUDE-INFRA-V4-INTEGRATION-PLAN.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -4440,7 +4440,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/CRITICAL_OPTIMIZATIONS.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -4455,7 +4455,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DECISIONS.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -4470,7 +4470,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DELIVERY_PLAYBOOK.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -4485,7 +4485,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DEPLOYMENT.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -4524,7 +4524,7 @@
       "lastUpdated": "2026-04-18",
       "owner": "Core Team",
       "path": "docs/DEVELOPMENT-TOOLING-CATALOG.md",
-      "staleDays": 114,
+      "staleDays": 113,
       "status": "ACTIVE"
     },
     {
@@ -4539,7 +4539,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/DEVELOPMENT_STRATEGY.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -4554,7 +4554,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/IDEMPOTENCY_GUIDE.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -4569,7 +4569,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/INCIDENT_RESPONSE.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -4605,7 +4605,7 @@
       "lastUpdated": "2026-08-08",
       "owner": "Core Team",
       "path": "docs/INDEX.md",
-      "staleDays": 2,
+      "staleDays": 1,
       "status": "ACTIVE"
     },
     {
@@ -4620,7 +4620,7 @@
       "lastUpdated": "2026-07-01",
       "owner": null,
       "path": "docs/INFRASTRUCTURE_REMEDIATION.md",
-      "staleDays": 40,
+      "staleDays": 39,
       "status": "HISTORICAL"
     },
     {
@@ -4635,7 +4635,7 @@
       "lastUpdated": "2026-04-20",
       "owner": null,
       "path": "docs/INTEGRATION_PR_CHECKLIST.md",
-      "staleDays": 112,
+      "staleDays": 111,
       "status": "HISTORICAL"
     },
     {
@@ -4650,7 +4650,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/METRICS_OPERATOR_RUNBOOK.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -4665,7 +4665,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/MIGRATION_GUIDE_DB_CIRCUIT.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -4680,7 +4680,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/MILESTONE-XIRR-PHASE0-COMPLETE.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -4695,7 +4695,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/MULTI-AI-DEVELOPMENT-WORKFLOW.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "ACTIVE"
     },
     {
@@ -4710,7 +4710,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/NAV_TREATMENT.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -4725,7 +4725,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/OPERATOR_RUNBOOK.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -4740,7 +4740,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/OPTIMIZED_ROADMAP.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -4755,7 +4755,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHASE1B-ASSEMBLY-INSTRUCTIONS.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -4770,7 +4770,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHASE1B-FEES-IN-PROGRESS.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -4785,7 +4785,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHASE1B-TRUTH-CASES-REFERENCE.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -4826,7 +4826,7 @@
       "lastUpdated": "2026-04-03",
       "owner": "Phoenix Team",
       "path": "docs/PHOENIX-SOT/README.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "ACTIVE"
     },
     {
@@ -4841,7 +4841,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/brand-bridge.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -4856,7 +4856,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/deferred-vesting-plan.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -4871,7 +4871,7 @@
       "lastUpdated": "2026-04-05",
       "owner": null,
       "path": "docs/PHOENIX-SOT/evidence-ledger.md",
-      "staleDays": 127,
+      "staleDays": 126,
       "status": "STALE-VALIDATION"
     },
     {
@@ -4886,7 +4886,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/execution-plan-v2.34.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -4901,7 +4901,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/execution-plan-v3.0-phase3-addendum.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -4916,7 +4916,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/mcp-tools-guide.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -4931,7 +4931,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/prompt-templates.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -4945,7 +4945,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/PHOENIX-SOT/scope-boundary-map.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -4960,7 +4960,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PHOENIX-SOT/skills-overview.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -4975,7 +4975,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PORTFOLIO_TABS_ARCHITECTURE.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -4990,7 +4990,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PRODUCTION_CHECKLIST.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5005,7 +5005,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/PR_NOTES/CODACY_JCURVE_NOTE.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5020,7 +5020,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/RATE_LIMITING_SUMMARY.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "HISTORICAL"
     },
     {
@@ -5035,7 +5035,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/RLS-DEVELOPMENT-GUIDE.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5050,7 +5050,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ROLLBACK_TRIGGERS.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5065,7 +5065,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ROLLOUT_STRATEGY.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5080,7 +5080,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SCENARIO_ANALYSIS_IMPLEMENTATION_STATUS.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5095,7 +5095,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SCENARIO_ANALYSIS_STABILITY_REVIEW.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5110,7 +5110,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SCENARIO_DEPLOY_GUIDE.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5125,7 +5125,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SETUP_NOTES.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5140,7 +5140,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/SLO.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5169,7 +5169,7 @@
       "lastUpdated": "2026-05-11",
       "owner": "Core Team",
       "path": "docs/STABILIZATION-ROADMAP.md",
-      "staleDays": 91,
+      "staleDays": 90,
       "status": "ACTIVE"
     },
     {
@@ -5184,7 +5184,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/TYPESCRIPT_BASELINE.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5199,7 +5199,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/VALIDATION-FRAMEWORK-IMPLEMENTATION.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5214,7 +5214,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/VERIFICATION_CHECKLIST.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5229,7 +5229,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/WINDOWS_NODE_CORRUPTION_PREVENTION.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5244,7 +5244,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/WIZARD_RESERVE_BRIDGE_IMPLEMENTATION.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5259,7 +5259,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/WSL2_BUILD_TEST.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5274,7 +5274,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/action-plans/CODEX-FIXES-EXECUTION-SUMMARY.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "HISTORICAL"
     },
     {
@@ -5289,7 +5289,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/action-plans/CODEX-ISSUES-RESOLUTION-PLAN.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5304,7 +5304,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/0001-evaluator-metrics.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5319,7 +5319,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/0002-token-budgeting.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5334,7 +5334,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/0003-streaming-architecture.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5349,7 +5349,7 @@
       "lastUpdated": "2026-08-03",
       "owner": null,
       "path": "docs/adr/ADR-004-waterfall-names.md",
-      "staleDays": 7,
+      "staleDays": 6,
       "status": "ACTIVE"
     },
     {
@@ -5364,7 +5364,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/adr/ADR-005-xirr-excel-parity.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "ACTIVE"
     },
     {
@@ -5379,7 +5379,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-006-fee-calculation-standards.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5394,7 +5394,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-007-exit-recycling-policy.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5409,7 +5409,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-008-capital-allocation-policy.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5424,7 +5424,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-009-RESERVED.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5439,7 +5439,7 @@
       "lastUpdated": "2026-05-08",
       "owner": null,
       "path": "docs/adr/ADR-010-xirr-day-count-and-bounds.md",
-      "staleDays": 94,
+      "staleDays": 93,
       "status": "ACTIVE"
     },
     {
@@ -5454,7 +5454,7 @@
       "lastUpdated": "2026-05-08",
       "owner": null,
       "path": "docs/adr/ADR-011-decimal-string-api-convention.md",
-      "staleDays": 94,
+      "staleDays": 93,
       "status": "ACTIVE"
     },
     {
@@ -5469,7 +5469,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/adr/ADR-013-scenario-comparison-activation.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "ACTIVE"
     },
     {
@@ -5484,7 +5484,7 @@
       "lastUpdated": "2026-05-22",
       "owner": null,
       "path": "docs/adr/ADR-014-snapshot-governance.md",
-      "staleDays": 80,
+      "staleDays": 79,
       "status": "ACTIVE"
     },
     {
@@ -5499,7 +5499,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-015-XIRR-BOUNDED-RATES.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5514,7 +5514,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-017-monte-carlo-validation-strategy.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5529,7 +5529,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-018-stage-normalization-v2.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5544,7 +5544,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/adr/ADR-019-mem0-integration.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5570,7 +5570,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/adr/ADR-021-runtime-authority.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -5585,7 +5585,7 @@
       "lastUpdated": "2026-05-29",
       "owner": null,
       "path": "docs/adr/ADR-022-fund-scenario-architecture.md",
-      "staleDays": 73,
+      "staleDays": 72,
       "status": "Implemented"
     },
     {
@@ -5600,7 +5600,7 @@
       "lastUpdated": "2026-06-21",
       "owner": null,
       "path": "docs/adr/ADR-023-investment-event-persistence.md",
-      "staleDays": 50,
+      "staleDays": 49,
       "status": "ACCEPTED (amended 2026-06-21)"
     },
     {
@@ -5639,7 +5639,7 @@
       "lastUpdated": "2026-08-03",
       "owner": null,
       "path": "docs/adr/ADR-070-cashless-gp-commitments-and-fee-waivers.md",
-      "staleDays": 7,
+      "staleDays": 6,
       "status": "ACTIVE"
     },
     {
@@ -5654,7 +5654,7 @@
       "lastUpdated": "2026-08-04",
       "owner": null,
       "path": "docs/adr/README.md",
-      "staleDays": 6,
+      "staleDays": 5,
       "status": "ACTIVE"
     },
     {
@@ -5669,7 +5669,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/agent-2-mobile-executive-dashboard.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5720,7 +5720,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ai-enhanced-components-guide.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5735,7 +5735,7 @@
       "lastUpdated": "2026-03-17",
       "owner": null,
       "path": "docs/ai-optimization/AI_AGENT_BACKTEST_FRAMEWORK.md",
-      "staleDays": 146,
+      "staleDays": 145,
       "status": "ARCHIVED"
     },
     {
@@ -5750,7 +5750,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ai-optimization/AI_COLLABORATION_GUIDE.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5765,7 +5765,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ai-optimization/AI_ORCHESTRATOR_IMPLEMENTATION.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5780,7 +5780,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/ai-optimization/BACKTEST_QUICKSTART.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "ACTIVE"
     },
     {
@@ -5795,7 +5795,7 @@
       "lastUpdated": "2026-05-27",
       "owner": null,
       "path": "docs/ai-optimization/CODEX-REVIEW-AGENT-SETUP.md",
-      "staleDays": 75,
+      "staleDays": 74,
       "status": "HISTORICAL"
     },
     {
@@ -5810,7 +5810,7 @@
       "lastUpdated": "2026-05-27",
       "owner": null,
       "path": "docs/ai-optimization/CODEX_AGENT_MIGRATION.md",
-      "staleDays": 75,
+      "staleDays": 74,
       "status": "HISTORICAL"
     },
     {
@@ -5825,7 +5825,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/analysis/perf-watch-memoization-root-cause.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5840,7 +5840,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/analysis/wizard-steps-pattern-analysis.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5855,7 +5855,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/architecture/portfolio-route-api.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5870,7 +5870,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/contracts/portfolio-route-v1.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5885,7 +5885,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/fund-allocations-phase1b.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5900,7 +5900,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/patterns/existing-route-patterns.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5915,7 +5915,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/api/testing/portfolio-route-test-strategy.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5930,7 +5930,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/array-safety-adoption-guide.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5957,7 +5957,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/auth/RS256-SETUP.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5972,7 +5972,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/behavioral-specs/time-travel-analytics-service-specs.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -5987,7 +5987,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-and-retention.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -6002,7 +6002,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/QUICK-REFERENCE.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -6017,7 +6017,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/README.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -6032,7 +6032,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/RLS-CHAOS-TESTING-PLAN.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -6047,7 +6047,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/RLS-GAME-DAY-RUNBOOK.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -6062,7 +6062,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/RLS-MONITORING-SPECS.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -6077,7 +6077,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/chaos-engineering/catalog.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -6092,7 +6092,7 @@
       "lastUpdated": "2026-03-30",
       "owner": null,
       "path": "docs/chart-migration-decision.md",
-      "staleDays": 133,
+      "staleDays": 132,
       "status": "ACTIVE"
     },
     {
@@ -6107,7 +6107,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/ci/triage.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -6122,7 +6122,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/circuit-notion-checklist.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -6136,7 +6136,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/claude/mcp-setup.md",
-      "staleDays": 91,
+      "staleDays": 90,
       "status": "UNKNOWN"
     },
     {
@@ -6150,7 +6150,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/claude/operating-loop.md",
-      "staleDays": 91,
+      "staleDays": 90,
       "status": "UNKNOWN"
     },
     {
@@ -6165,7 +6165,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/code-review/CODEX-BOT-FINDINGS-SUMMARY.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "HISTORICAL"
     },
     {
@@ -6180,7 +6180,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/commands-and-plugins-inventory.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -6195,7 +6195,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/NumericInput.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -6210,7 +6210,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reallocation-tab-implementation.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -6225,7 +6225,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reserve-engine-architecture.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -6240,7 +6240,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reserve-engine-delivery.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -6255,7 +6255,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/reserve-engine-spec.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -6270,7 +6270,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/components/worker-implementation.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -6285,7 +6285,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/contracts/parallel-foundation.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -6300,7 +6300,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/contracts/selector-contract-readme.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -6315,7 +6315,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/database/MULTI-TENANT-RLS-INFRASTRUCTURE.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -6330,7 +6330,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/debugging/profiling-playbook.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -6345,7 +6345,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/debugging/triage-guide.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -6360,7 +6360,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/CODEX-FIXES-DEPLOYMENT-STATUS.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -6375,7 +6375,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/ROLLBACK_PLAN.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -6390,7 +6390,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/STAGING_CHECKLIST.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -6405,7 +6405,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/STAGING_DEPLOYMENT_SUMMARY.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "HISTORICAL"
     },
     {
@@ -6420,7 +6420,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/STAGING_METRICS.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -6435,7 +6435,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/deployment/vercel-setup.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -6477,7 +6477,7 @@
       "lastUpdated": "2026-08-08",
       "owner": "Product + Frontend",
       "path": "docs/design/README.md",
-      "staleDays": 2,
+      "staleDays": 1,
       "status": "ACTIVE"
     },
     {
@@ -6525,7 +6525,7 @@
       "lastUpdated": "2026-06-02",
       "owner": "Product + Frontend",
       "path": "docs/design/analytics-visualization-principles.md",
-      "staleDays": 69,
+      "staleDays": 68,
       "status": "ACTIVE"
     },
     {
@@ -6570,7 +6570,7 @@
       "lastUpdated": "2026-06-03",
       "owner": "Product + Frontend",
       "path": "docs/design/analytics-visualization-rollout.md",
-      "staleDays": 68,
+      "staleDays": 67,
       "status": "ACTIVE"
     },
     {
@@ -6603,7 +6603,7 @@
       "lastUpdated": "2026-06-22",
       "owner": "Platform Team",
       "path": "docs/design/audits/2026-06-22-entity-access-boundary.md",
-      "staleDays": 49,
+      "staleDays": 48,
       "status": "ACTIVE"
     },
     {
@@ -6636,7 +6636,7 @@
       "lastUpdated": "2026-06-23",
       "owner": "Platform Team",
       "path": "docs/design/audits/2026-06-23-entity-access-boundary.md",
-      "staleDays": 48,
+      "staleDays": 47,
       "status": "ACTIVE"
     },
     {
@@ -6669,7 +6669,7 @@
       "lastUpdated": "2026-06-23",
       "owner": "Platform Team",
       "path": "docs/design/audits/2026-06-23-trust-audit.md",
-      "staleDays": 48,
+      "staleDays": 47,
       "status": "ACTIVE"
     },
     {
@@ -6707,7 +6707,7 @@
       "lastUpdated": "2026-08-08",
       "owner": "Product + Frontend",
       "path": "docs/design/audits/2026-08-08-preferred-uiux-data-contract-map.md",
-      "staleDays": 2,
+      "staleDays": 1,
       "status": "ACTIVE"
     },
     {
@@ -6738,7 +6738,7 @@
       "lastUpdated": "2026-06-23",
       "owner": "Platform Team",
       "path": "docs/design/audits/client-derived-math-inventory.md",
-      "staleDays": 48,
+      "staleDays": 47,
       "status": "ACTIVE"
     },
     {
@@ -6769,7 +6769,7 @@
       "lastUpdated": "2026-06-15",
       "owner": "Platform Team",
       "path": "docs/design/audits/server-object-readiness.md",
-      "staleDays": 56,
+      "staleDays": 55,
       "status": "ACTIVE"
     },
     {
@@ -6811,7 +6811,7 @@
       "lastUpdated": "2026-08-08",
       "owner": "Product + Frontend",
       "path": "docs/design/references/2026-08-08-preferred-uiux/README.md",
-      "staleDays": 2,
+      "staleDays": 1,
       "status": "REFERENCE"
     },
     {
@@ -6838,7 +6838,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": "docs/dev-environment-reset.md",
-      "staleDays": 114,
+      "staleDays": 113,
       "status": "ACTIVE"
     },
     {
@@ -6854,7 +6854,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/dev/async-iteration.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -6869,7 +6869,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/foreach-fix-improved.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -6884,7 +6884,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/foreach-fix.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -6899,7 +6899,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/windows-setup.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -6914,7 +6914,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/dev/wsl2-quickstart.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -6928,7 +6928,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/evidence/endpoint-ownership.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -6943,7 +6943,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/extended-thinking-integration.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -6958,7 +6958,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/fail-open-close-matrix.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -6973,7 +6973,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/failure-triage.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -6988,7 +6988,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/feature-flags.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7002,7 +7002,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/financial-precision.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -7017,7 +7017,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/fixes/PR-112-MANAGEMENT-FEE-HORIZON-FIX.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7032,7 +7032,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/fixes/vite-build-vercel-fix.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "ACTIVE"
     },
     {
@@ -7047,7 +7047,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/forecasting/CALIBRATION_GUIDE.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7062,7 +7062,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/forecasting/power-law-implementation.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7077,7 +7077,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/forecasting/streaming-monte-carlo-migration.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7092,7 +7092,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE0.5-TEST-DATA-INFRASTRUCTURE.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7107,7 +7107,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE2-ROADMAP-IMPROVEMENTS.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7122,7 +7122,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE2-ROADMAP.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7137,7 +7137,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE3-KICKOFF.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7152,7 +7152,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE4-KICKOFF.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7167,7 +7167,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/foundation/PHASE4-SESSION1-SUMMARY.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "HISTORICAL"
     },
     {
@@ -7182,7 +7182,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/fund-allocation-phase1b.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7215,7 +7215,7 @@
       "lastUpdated": "2026-05-28",
       "owner": "Core Team",
       "path": "docs/governance/2026-05-19-refactor-roadmap.md",
-      "staleDays": 74,
+      "staleDays": 73,
       "status": "ACTIVE"
     },
     {
@@ -7230,7 +7230,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/abort-matrix.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7263,7 +7263,7 @@
       "lastUpdated": "2026-05-28",
       "owner": "Core Team",
       "path": "docs/governance/cleanup-manifest.md",
-      "staleDays": 74,
+      "staleDays": 73,
       "status": "ACTIVE"
     },
     {
@@ -7278,7 +7278,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/decision-log.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7293,7 +7293,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/risk-matrix.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7308,7 +7308,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/governance/sync-point-failure-plans.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7323,7 +7323,7 @@
       "lastUpdated": "2026-04-20",
       "owner": null,
       "path": "docs/ia-consolidation-strategy.md",
-      "staleDays": 112,
+      "staleDays": 111,
       "status": "HISTORICAL"
     },
     {
@@ -7338,7 +7338,7 @@
       "lastUpdated": "2026-05-17",
       "owner": null,
       "path": "docs/integration/SCHEMA-MIGRATION-PLAN.md",
-      "staleDays": 85,
+      "staleDays": 84,
       "status": "ACTIVE"
     },
     {
@@ -7353,7 +7353,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/integration/upstash-setup.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7368,7 +7368,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/architecture/state-flow.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7383,7 +7383,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/checklists/definition-of-done.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7398,7 +7398,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/checklists/self-review.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7413,7 +7413,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/database/01-overview.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7428,7 +7428,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/database/02-patterns.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7443,7 +7443,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/database/03-optimization.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7458,7 +7458,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/index.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7473,7 +7473,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/01-overview.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7488,7 +7488,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/02-zod-patterns.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7503,7 +7503,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/03-type-system.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7518,7 +7518,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/internal/validation/04-integration.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7533,7 +7533,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/investigation/ci-failure-analysis-2026-01-10.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "HISTORICAL"
     },
     {
@@ -7548,7 +7548,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/ALIGNMENT-STATUS.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7563,7 +7563,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/IMPLEMENTATION-STATUS.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7578,7 +7578,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/PR2-PROGRESS.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7593,7 +7593,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/PRE-TEST-HARDENING.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7608,7 +7608,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/REVIEW-ACTION-PLAN.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7623,7 +7623,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/STRATEGY-SUMMARY.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "HISTORICAL"
     },
     {
@@ -7638,7 +7638,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/iterations/iteration-a-implementation-guide.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7653,7 +7653,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/lp-deployment-checklist.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7668,7 +7668,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/lp-observability-implementation.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7689,7 +7689,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/lp-reporting-database-optimization.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "active"
     },
     {
@@ -7703,7 +7703,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/lp-reporting/PHASE-1B-PLAN.md",
-      "staleDays": 91,
+      "staleDays": 90,
       "status": "UNKNOWN"
     },
     {
@@ -7718,7 +7718,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/lp-slo-definitions.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7733,7 +7733,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/metrics-meanings.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7748,7 +7748,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/PHASE2-COMPLETE.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7763,7 +7763,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/capital-allocation.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7778,7 +7778,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/cohorts/01-overview.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7793,7 +7793,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/cohorts/02-metrics.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7808,7 +7808,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/cohorts/03-analysis.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7823,7 +7823,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/exit-recycling.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7838,7 +7838,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/fees.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7853,7 +7853,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/01-overview.md",
-      "staleDays": 91,
+      "staleDays": 90,
       "status": "ACTIVE"
     },
     {
@@ -7868,7 +7868,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/02-simulation.md",
-      "staleDays": 91,
+      "staleDays": 90,
       "status": "ACTIVE"
     },
     {
@@ -7883,7 +7883,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/03-statistics.md",
-      "staleDays": 91,
+      "staleDays": 90,
       "status": "ACTIVE"
     },
     {
@@ -7898,7 +7898,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/notebooklm-sources/monte-carlo/04-validation.md",
-      "staleDays": 91,
+      "staleDays": 90,
       "status": "ACTIVE"
     },
     {
@@ -7913,7 +7913,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/01-overview.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7928,7 +7928,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/02-strategies.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7943,7 +7943,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/03-integration.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7958,7 +7958,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/pacing/VALIDATION-NOTES.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7973,7 +7973,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/01-overview.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -7988,7 +7988,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/02-algorithms.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8003,7 +8003,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/03-examples.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8018,7 +8018,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/reserves/04-integration.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8033,7 +8033,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/waterfall.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8048,7 +8048,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/notebooklm-sources/xirr.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8063,7 +8063,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/npm-bin-resolution-investigation.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8078,7 +8078,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8093,7 +8093,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/EDITORIAL-V2-CHANGELOG.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8108,7 +8108,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/README.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8123,7 +8123,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/ai-metrics.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8138,7 +8138,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/auth-comment.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8153,7 +8153,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/business-kpis.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8168,7 +8168,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/fundcalc-comment.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8183,7 +8183,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/rum.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8198,7 +8198,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/observability/split-plan-comment.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8232,7 +8232,7 @@
       "lastUpdated": "2026-06-16",
       "owner": "Platform Team",
       "path": "docs/parity/convention-matrix.md",
-      "staleDays": 55,
+      "staleDays": 54,
       "status": "ACTIVE"
     },
     {
@@ -8247,7 +8247,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/perf-baseline.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8262,7 +8262,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/performance-logging-automation.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8278,7 +8278,7 @@
       "lastUpdated": "2026-04-05",
       "owner": null,
       "path": "docs/phase0-validation-report.md",
-      "staleDays": 127,
+      "staleDays": 126,
       "status": "HISTORICAL-SNAPSHOT"
     },
     {
@@ -8293,7 +8293,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase0-xirr-analysis-eda20590.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8308,7 +8308,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1-1-1-analysis.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8323,7 +8323,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1-xirr-baseline-heatmap.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8338,7 +8338,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1-xirr-waterfall-roadmap.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8353,7 +8353,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phase1b-waterfall-evaluator-hardening.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8380,7 +8380,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/phoenix-v2.32-command-enhancements.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8395,7 +8395,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/planning/build-stabilization/00-ITERATION-LOG.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8410,7 +8410,7 @@
       "lastUpdated": "2026-06-22",
       "owner": null,
       "path": "docs/plans/2026-03-27-secondary-surface-decisions.md",
-      "staleDays": 49,
+      "staleDays": 48,
       "status": "ACTIVE"
     },
     {
@@ -8427,7 +8427,7 @@
       "lastUpdated": "2026-04-07",
       "owner": "Phoenix Probabilistic",
       "path": "docs/plans/2026-04-07-backtesting-scenario-comparison-correctness.md",
-      "staleDays": 125,
+      "staleDays": 124,
       "status": "TRACKED (not scheduled)"
     },
     {
@@ -8442,7 +8442,7 @@
       "lastUpdated": "2026-05-17",
       "owner": null,
       "path": "docs/plans/2026-04-07-phase-1c3-variance-automation-followons-backlog.md",
-      "staleDays": 85,
+      "staleDays": 84,
       "status": "BACKLOG"
     },
     {
@@ -8456,7 +8456,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/plans/2026-05-08-gp-economics-extension-design.md",
-      "staleDays": 91,
+      "staleDays": 90,
       "status": "UNKNOWN"
     },
     {
@@ -8473,7 +8473,7 @@
       "lastUpdated": "2026-05-31",
       "owner": "Core Team",
       "path": "docs/plans/2026-05-14-t4-t5-follow-up-tranches.md",
-      "staleDays": 71,
+      "staleDays": 70,
       "status": "ACTIVE"
     },
     {
@@ -8493,7 +8493,7 @@
       "lastUpdated": "2026-06-02",
       "owner": "Core Team",
       "path": "docs/plans/2026-06-02-scenario-comparison-evidence-workstream-plan.md",
-      "staleDays": 69,
+      "staleDays": 68,
       "status": "ACTIVE"
     },
     {
@@ -8522,7 +8522,7 @@
       "lastUpdated": "2026-06-13",
       "owner": "Core Team",
       "path": "docs/plans/2026-06-13-gp-trust-readiness-register.md",
-      "staleDays": 58,
+      "staleDays": 57,
       "status": "ACTIVE"
     },
     {
@@ -8556,7 +8556,7 @@
       "lastUpdated": "2026-06-22",
       "owner": "Platform Team",
       "path": "docs/plans/2026-06-22-current-state-steelman-roadmap.md",
-      "staleDays": 49,
+      "staleDays": 48,
       "status": "DRAFT"
     },
     {
@@ -8593,7 +8593,7 @@
       "lastUpdated": "2026-04-03",
       "owner": "Core Team",
       "path": "docs/plans/PHOENIX-FOUNDATION-HARDENING-CROSSWALK.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "ACTIVE"
     },
     {
@@ -8608,7 +8608,7 @@
       "lastUpdated": "2026-05-29",
       "owner": null,
       "path": "docs/plans/scenario-release-lane.md",
-      "staleDays": 73,
+      "staleDays": 72,
       "status": "ACTIVE"
     },
     {
@@ -8623,7 +8623,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/policies/feasibility-constraints.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8638,7 +8638,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/portfolio-construction-modeling.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "ACTIVE"
     },
     {
@@ -8653,7 +8653,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/portfolio-intelligence-systems-technical-memo.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8668,7 +8668,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/power-law-integration.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8683,7 +8683,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/prd.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8698,7 +8698,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/AUTOMATION_GUIDE.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8713,7 +8713,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/COMMIT_LOG.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8728,7 +8728,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/CONTRIBUTING.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8743,7 +8743,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/DEPLOYMENT_COMPLETE.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8758,7 +8758,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/DEPLOYMENT_TODO.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8773,7 +8773,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/FINAL_VALIDATION.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8788,7 +8788,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/GITHUB_COMMIT_GUIDE.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8803,7 +8803,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/GITHUB_SETUP.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8818,7 +8818,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PEER_REVIEW.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8833,7 +8833,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PIPELINE_SCHEMA_COMPLETE.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8848,7 +8848,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PIPELINE_TODO.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8863,7 +8863,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/PRE_PUSH_CHECKLIST.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8878,7 +8878,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/TEAM_SETUP.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8893,7 +8893,7 @@
       "lastUpdated": "2026-05-21",
       "owner": null,
       "path": "docs/processes/clone-guide.md",
-      "staleDays": 81,
+      "staleDays": 80,
       "status": "ACTIVE"
     },
     {
@@ -8908,7 +8908,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/processes/code-review-checklist.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8922,7 +8922,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/qa-response-2026-01-23.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -8949,7 +8949,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/reallocation-api-quickstart.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8964,7 +8964,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/references/capital-allocation-follow-on.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "ACTIVE"
     },
     {
@@ -8979,7 +8979,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-engines.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -8994,7 +8994,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-integration.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -9009,7 +9009,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-schema.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -9024,7 +9024,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/claude-agent-testing.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -9039,7 +9039,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/replit.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -9054,7 +9054,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/references/seed-cases-ca-007-020.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -9069,7 +9069,7 @@
       "lastUpdated": "2026-06-12",
       "owner": null,
       "path": "docs/release/internal-release-notes.md",
-      "staleDays": 59,
+      "staleDays": 58,
       "status": "PROVEN"
     },
     {
@@ -9084,7 +9084,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/SlackBatchAPI-v1.0.0.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -9099,7 +9099,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/compat-matrix.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -9114,7 +9114,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-phase4.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -9129,7 +9129,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-phase5.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -9144,7 +9144,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-v3.4-option-b.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -9159,7 +9159,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-norm-v3.4-review.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -9174,7 +9174,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/releases/stage-normalization-v3.4.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -9189,7 +9189,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/replit.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -9219,7 +9219,7 @@
       "lastUpdated": "2026-08-08",
       "owner": "Product + Frontend",
       "path": "docs/reviews/2026-08-08-issue-1284-prototype-review.md",
-      "staleDays": 2,
+      "staleDays": 1,
       "status": "ACTIVE"
     },
     {
@@ -9234,7 +9234,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/reviews/CA-IMPLEMENTATION-EVALUATION-FINAL.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -9249,7 +9249,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/reviews/CA-IMPLEMENTATION-EVALUATION-REFINED.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -9284,7 +9284,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/ca-period-truth-remediation-2026-05-19.md",
-      "staleDays": 82,
+      "staleDays": 81,
       "status": "COMPLETED"
     },
     {
@@ -9315,7 +9315,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/README.md",
-      "staleDays": 82,
+      "staleDays": 81,
       "status": "REFERENCE"
     },
     {
@@ -9346,7 +9346,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/architectural-audit.md",
-      "staleDays": 82,
+      "staleDays": 81,
       "status": "REFERENCE"
     },
     {
@@ -9377,7 +9377,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/code-quality-audit.md",
-      "staleDays": 82,
+      "staleDays": 81,
       "status": "REFERENCE"
     },
     {
@@ -9410,7 +9410,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/devops-dx-audit.md",
-      "staleDays": 82,
+      "staleDays": 81,
       "status": "REFERENCE"
     },
     {
@@ -9441,7 +9441,7 @@
       "lastUpdated": "2026-05-22",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/repository-structure-audit.md",
-      "staleDays": 80,
+      "staleDays": 79,
       "status": "REFERENCE"
     },
     {
@@ -9473,7 +9473,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/reviews/refactor-audit-2026-05-19/testing-infrastructure-audit.md",
-      "staleDays": 82,
+      "staleDays": 81,
       "status": "REFERENCE"
     },
     {
@@ -9488,7 +9488,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/rollback-playbook.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "ACTIVE"
     },
     {
@@ -9503,7 +9503,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbook.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -9518,7 +9518,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/blue-green.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -9533,7 +9533,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/canary.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -9572,7 +9572,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/dr.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -9587,7 +9587,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/incident.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -9615,7 +9615,7 @@
       "lastUpdated": "2026-03-30",
       "owner": "Core Team",
       "path": "docs/runbooks/integration-ready-file-handshake.md",
-      "staleDays": 133,
+      "staleDays": 132,
       "status": "ACTIVE"
     },
     {
@@ -9652,7 +9652,7 @@
       "lastUpdated": "2026-06-28",
       "owner": "gp-team",
       "path": "docs/runbooks/investment-rounds-enablement.md",
-      "staleDays": 43,
+      "staleDays": 42,
       "status": "ACTIVE"
     },
     {
@@ -9679,7 +9679,7 @@
       "lastUpdated": "2026-07-30",
       "owner": null,
       "path": "docs/runbooks/rollback.md",
-      "staleDays": 11,
+      "staleDays": 10,
       "status": "ACTIVE"
     },
     {
@@ -9694,7 +9694,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/stage-normalization-migration.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -9709,7 +9709,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/stage-normalization-rollout.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -9724,7 +9724,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/stage-validation.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -9739,7 +9739,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/runbooks/synthetic-monitoring.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -9754,7 +9754,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/schema.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -9769,7 +9769,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/schemas/README.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -9784,7 +9784,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/schemas/schema-helpers-integration.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -9799,7 +9799,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/CODACY_REMEDIATION_2025.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -9814,7 +9814,7 @@
       "lastUpdated": "2026-07-05",
       "owner": null,
       "path": "docs/security/cve-exceptions.md",
-      "staleDays": 36,
+      "staleDays": 35,
       "status": "ACTIVE"
     },
     {
@@ -9829,7 +9829,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/00-ITERATION-LOG.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -9844,7 +9844,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/01-dependency-audit.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -9859,7 +9859,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/02-risk-assessment.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -9874,7 +9874,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/03-remediation-plan.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -9889,7 +9889,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/04-verification-log.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -9904,7 +9904,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/security/remediation-2026-01-18/05-lockfile-changes.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -9918,7 +9918,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-01-20-hook-fix.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -9932,7 +9932,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-02-14-p1-financial-accuracy.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -9946,7 +9946,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-02-18.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -9960,7 +9960,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/session-learning-reports/2026-03-17.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "UNKNOWN"
     },
     {
@@ -9974,7 +9974,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/session-learning-reports/2026-04-06.md",
-      "staleDays": 91,
+      "staleDays": 90,
       "status": "UNKNOWN"
     },
     {
@@ -9988,7 +9988,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/session-learning-reports/2026-04-07.md",
-      "staleDays": 91,
+      "staleDays": 90,
       "status": "UNKNOWN"
     },
     {
@@ -10003,7 +10003,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/skills-application-log.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -10018,7 +10018,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/skills-application-synthesis.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -10033,7 +10033,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/skills/README.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -10074,7 +10074,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-001-dynamic-imports-prevent-test-side-effects.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "VERIFIED"
     },
     {
@@ -10422,7 +10422,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-011-recharts-formatter-type-signatures.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "DRAFT"
     },
     {
@@ -10620,7 +10620,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-016-vitest-include-patterns-miss-new-test-directories.md",
-      "staleDays": 91,
+      "staleDays": 90,
       "status": "DRAFT"
     },
     {
@@ -10702,7 +10702,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-018-reserve-engine-null-safety.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "VERIFIED"
     },
     {
@@ -10775,7 +10775,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-020-large-iteration-tests-need-explicit-timeouts.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "DRAFT"
     },
     {
@@ -10819,7 +10819,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-021-exact-optional-property-types-spread-pattern.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "DRAFT"
     },
     {
@@ -10949,7 +10949,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-024-integration-test-environment-leakage.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "DRAFT"
     },
     {
@@ -10996,7 +10996,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-025-ci-compilation-boundary-mismatch.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "DRAFT"
     },
     {
@@ -11038,7 +11038,7 @@
       "lastUpdated": "2026-04-03",
       "owner": null,
       "path": "docs/skills/REFL-026-drizzle-mock-chain-overwrite.md",
-      "staleDays": 129,
+      "staleDays": 128,
       "status": "DRAFT"
     },
     {
@@ -11187,7 +11187,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-030-mock-id-type-change-blast-radius.md",
-      "staleDays": 91,
+      "staleDays": 90,
       "status": "DRAFT"
     },
     {
@@ -11213,7 +11213,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-031-as-const-literal-type-arithmetic.md",
-      "staleDays": 91,
+      "staleDays": 90,
       "status": "DRAFT"
     },
     {
@@ -11244,7 +11244,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-032-ts4111-index-signature-vs-eslint-dot-notation.md",
-      "staleDays": 91,
+      "staleDays": 90,
       "status": "DRAFT"
     },
     {
@@ -11273,7 +11273,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-033-defensive-grep-before-destructive-action.md",
-      "staleDays": 91,
+      "staleDays": 90,
       "status": "DRAFT"
     },
     {
@@ -11302,7 +11302,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-034-subagent-fabrication-tool-uses-zero.md",
-      "staleDays": 91,
+      "staleDays": 90,
       "status": "DRAFT"
     },
     {
@@ -11332,7 +11332,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-035-defensive-grep-for-recovered-process-drafts.md",
-      "staleDays": 91,
+      "staleDays": 90,
       "status": "DRAFT"
     },
     {
@@ -11362,7 +11362,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-036-silent-test-discovery-loss-from-tests-dirs.md",
-      "staleDays": 91,
+      "staleDays": 90,
       "status": "DRAFT"
     },
     {
@@ -11392,7 +11392,7 @@
       "lastUpdated": "2026-05-11",
       "owner": null,
       "path": "docs/skills/REFL-037-dynamic-import-seam-for-route-handler-mocking.md",
-      "staleDays": 91,
+      "staleDays": 90,
       "status": "DRAFT"
     },
     {
@@ -11425,7 +11425,7 @@
       "lastUpdated": "2026-04-18",
       "owner": null,
       "path": "docs/skills/REFL-038-windows-agent-shell-env-missing.md",
-      "staleDays": 114,
+      "staleDays": 113,
       "status": "DRAFT"
     },
     {
@@ -11664,7 +11664,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/stage-normalization-scripts.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -11679,7 +11679,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/stage-normalization-v3.4.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -11694,7 +11694,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/standards.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -11721,7 +11721,7 @@
       "lastUpdated": "2026-05-29",
       "owner": null,
       "path": "docs/superpowers/plans/2026-05-29-allocation-sector-override-expansion.md",
-      "staleDays": 73,
+      "staleDays": 72,
       "status": "ACTIVE"
     },
     {
@@ -11749,7 +11749,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-cohort-release-readiness.md",
-      "staleDays": 73,
+      "staleDays": 72,
       "status": "ACTIVE"
     },
     {
@@ -11778,7 +11778,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-forecast-modes-actuals.md",
-      "staleDays": 73,
+      "staleDays": 72,
       "status": "ACTIVE"
     },
     {
@@ -11806,7 +11806,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-methodology-guardrails.md",
-      "staleDays": 73,
+      "staleDays": 72,
       "status": "ACTIVE"
     },
     {
@@ -11834,7 +11834,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-reserve-optimization-workflow.md",
-      "staleDays": 73,
+      "staleDays": 72,
       "status": "ACTIVE"
     },
     {
@@ -11861,7 +11861,7 @@
       "lastUpdated": "2026-05-29",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-05-29-scenario-ux-workspace.md",
-      "staleDays": 73,
+      "staleDays": 72,
       "status": "COMPLETE"
     },
     {
@@ -11902,7 +11902,7 @@
       "lastUpdated": "2026-06-07",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-06-07-m6-reserve-moic-follow-on-ranking.md",
-      "staleDays": 64,
+      "staleDays": 63,
       "status": "ACTIVE"
     },
     {
@@ -11919,7 +11919,7 @@
       "lastUpdated": "2026-06-13",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-06-08-c1-methodology-scenario-creation.md",
-      "staleDays": 58,
+      "staleDays": 57,
       "status": "COMPLETE"
     },
     {
@@ -11948,7 +11948,7 @@
       "lastUpdated": "2026-06-08",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-06-08-c2-economics-comparison-generalization.md",
-      "staleDays": 63,
+      "staleDays": 62,
       "status": "ACTIVE"
     },
     {
@@ -11977,7 +11977,7 @@
       "lastUpdated": "2026-06-09",
       "owner": "Platform Team",
       "path": "docs/superpowers/plans/2026-06-09-c3-scenario-async-worker-wiring.md",
-      "staleDays": 62,
+      "staleDays": 61,
       "status": "ACTIVE"
     },
     {
@@ -12045,7 +12045,7 @@
       "lastUpdated": "2026-06-21",
       "owner": "Core Team",
       "path": "docs/superpowers/plans/2026-06-21-investment-round-persistence-l3b.md",
-      "staleDays": 50,
+      "staleDays": 49,
       "status": "DRAFT"
     },
     {
@@ -12099,7 +12099,7 @@
       "lastUpdated": "2026-06-23",
       "owner": "Platform / GP Modeling",
       "path": "docs/superpowers/plans/2026-06-23-trust-first-milestones-v3.3.md",
-      "staleDays": 48,
+      "staleDays": 47,
       "status": "HISTORICAL"
     },
     {
@@ -12117,7 +12117,7 @@
       "lastUpdated": "2026-06-23",
       "owner": "Platform / GP Modeling",
       "path": "docs/superpowers/plans/2026-06-23-trust-first-milestones-v3.4.md",
-      "staleDays": 48,
+      "staleDays": 47,
       "status": "DRAFT"
     },
     {
@@ -12186,7 +12186,7 @@
       "lastUpdated": "2026-06-28",
       "owner": "gp-team",
       "path": "docs/superpowers/plans/2026-06-28-investment-rounds-soak.md",
-      "staleDays": 43,
+      "staleDays": 42,
       "status": "ACTIVE"
     },
     {
@@ -12325,18 +12325,6 @@
       "docType": "doc",
       "exists": true,
       "frontmatter": {},
-      "hasExecutionClaims": false,
-      "isStale": true,
-      "lastUpdated": null,
-      "owner": null,
-      "path": "docs/superpowers/plans/2026-08-10-f1337-feeprofile-truth.md",
-      "staleDays": 999,
-      "status": "UNKNOWN"
-    },
-    {
-      "docType": "doc",
-      "exists": true,
-      "frontmatter": {},
       "hasExecutionClaims": true,
       "isStale": true,
       "lastUpdated": null,
@@ -12359,7 +12347,7 @@
       "lastUpdated": "2026-06-13",
       "owner": "Platform Team",
       "path": "docs/superpowers/specs/2026-06-08-c1-methodology-scenario-creation-design.md",
-      "staleDays": 58,
+      "staleDays": 57,
       "status": "COMPLETE"
     },
     {
@@ -12388,7 +12376,7 @@
       "lastUpdated": "2026-06-08",
       "owner": "Platform Team",
       "path": "docs/superpowers/specs/2026-06-08-c2-economics-comparison-generalization-design.md",
-      "staleDays": 63,
+      "staleDays": 62,
       "status": "ACTIVE"
     },
     {
@@ -12417,7 +12405,7 @@
       "lastUpdated": "2026-06-09",
       "owner": "Platform Team",
       "path": "docs/superpowers/specs/2026-06-09-c3-scenario-async-worker-wiring-design.md",
-      "staleDays": 62,
+      "staleDays": 61,
       "status": "ACTIVE"
     },
     {
@@ -12464,7 +12452,7 @@
       "lastUpdated": "2026-06-13",
       "owner": "Core Team",
       "path": "docs/superpowers/specs/2026-06-13-gp-trust-readiness-audit-design.md",
-      "staleDays": 58,
+      "staleDays": 57,
       "status": "ACTIVE"
     },
     {
@@ -12481,7 +12469,7 @@
       "lastUpdated": "2026-06-21",
       "owner": null,
       "path": "docs/superpowers/specs/2026-06-21-investment-round-persistence-l3b-design.md",
-      "staleDays": 50,
+      "staleDays": 49,
       "status": "DRAFT (red-team hardened 2026-06-21)"
     },
     {
@@ -12553,6 +12541,37 @@
       "docType": "doc",
       "exists": true,
       "frontmatter": {
+        "audience": "agents",
+        "categories": [
+          "ai-automation",
+          "orchestration",
+          "design"
+        ],
+        "keywords": [
+          "sol-advisor",
+          "agents",
+          "routing",
+          "ledger",
+          "approval",
+          "recovery"
+        ],
+        "last_updated": "2026-08-09",
+        "owner": "Developer Experience",
+        "review_cadence": "P90D",
+        "status": "ACTIVE"
+      },
+      "hasExecutionClaims": true,
+      "isStale": false,
+      "lastUpdated": "2026-08-09",
+      "owner": "Developer Experience",
+      "path": "docs/superpowers/specs/2026-08-09-sol-advisor-orchestration-control-plane-design.md",
+      "staleDays": 0,
+      "status": "ACTIVE"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
+      "frontmatter": {
         "categories": [
           "tech-debt",
           "type-safety"
@@ -12585,7 +12604,7 @@
       "lastUpdated": "2026-05-20",
       "owner": "Core Team",
       "path": "docs/tech-debt/type-safety-remediation-summary.md",
-      "staleDays": 82,
+      "staleDays": 81,
       "status": "ACTIVE"
     },
     {
@@ -12600,7 +12619,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/templates/README.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -12615,7 +12634,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/templates/design-system-template.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -12630,7 +12649,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/templates/feature-flow-template.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -12645,7 +12664,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/test-improvement-status.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -12672,7 +12691,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/type-safety-action-plan.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -12687,7 +12706,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/type-safety-migration.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -12702,7 +12721,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/validation/DeterministicReserveEngine.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -12717,7 +12736,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/validation/stage-validation-patched.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -12732,7 +12751,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/validation/stage-validation-v3.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -12747,7 +12766,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard-calculations-integration.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -12762,7 +12781,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/COMPLETION_SUMMARY.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "HISTORICAL"
     },
     {
@@ -12777,7 +12796,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/MIGRATION_GUIDE.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -12792,7 +12811,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/RESERVES_CARD_IMPROVEMENTS.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -12807,7 +12826,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/WIZARD_INTEGRATION.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -12822,7 +12841,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/wizard/modeling-wizard-design.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -12837,7 +12856,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/CONSOLIDATION_PLAN_V2.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -12852,7 +12871,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/CONSOLIDATION_PLAN_V3_FINAL.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -12867,7 +12886,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/PAIRED-AGENT-VALIDATION.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -12882,7 +12901,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/workflows/PRODUCTION_SCRIPTS.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -12897,7 +12916,7 @@
       "lastUpdated": "2026-05-28",
       "owner": null,
       "path": "docs/workflows/README.md",
-      "staleDays": 74,
+      "staleDays": 73,
       "status": "ACTIVE"
     },
     {
@@ -12943,7 +12962,7 @@
       "lastUpdated": "2025-12-29",
       "owner": "Platform Developer",
       "path": "docs/xirr-consolidation-roadmap.md",
-      "staleDays": 224,
+      "staleDays": 223,
       "status": "ACTIVE"
     },
     {
@@ -12958,7 +12977,7 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/xirr-excel-validation.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     },
     {
@@ -12973,11 +12992,11 @@
       "lastUpdated": "2026-01-19",
       "owner": null,
       "path": "docs/xirr-golden-set-migration-plan.md",
-      "staleDays": 203,
+      "staleDays": 202,
       "status": "ACTIVE"
     }
   ],
-  "generatedAt": "2026-08-10T00:00:00.000Z",
+  "generatedAt": "2026-08-09T00:00:00.000Z",
   "patterns": [
     {
       "category": "Security",
@@ -14144,7 +14163,7 @@
   "stats": {
     "by_status": {
       "ACCEPTED (amended 2026-06-21)": 1,
-      "ACTIVE": 453,
+      "ACTIVE": 454,
       "ARCHIVED": 1,
       "BACKLOG": 1,
       "COMPLETE": 3,
@@ -14159,13 +14178,13 @@
       "REFERENCE": 9,
       "STALE-VALIDATION": 1,
       "TRACKED (not scheduled)": 1,
-      "UNKNOWN": 171,
+      "UNKNOWN": 170,
       "VERIFIED": 13,
       "active": 2,
       "ready": 3
     },
-    "missing_frontmatter": 77,
-    "stale_docs": 500,
+    "missing_frontmatter": 76,
+    "stale_docs": 498,
     "total_docs": 726
   },
   "version": "2.0"

--- a/docs/_generated/router-index.json
+++ b/docs/_generated/router-index.json
@@ -12324,6 +12324,37 @@
     {
       "docType": "doc",
       "exists": true,
+      "frontmatter": {
+        "audience": "agents",
+        "categories": [
+          "ai-automation",
+          "orchestration",
+          "implementation-plan"
+        ],
+        "keywords": [
+          "sol-advisor",
+          "codex",
+          "ultra",
+          "fast-mode",
+          "configuration",
+          "migration"
+        ],
+        "last_updated": "2026-08-09",
+        "owner": "Developer Experience",
+        "review_cadence": "P90D",
+        "status": "ACTIVE"
+      },
+      "hasExecutionClaims": false,
+      "isStale": false,
+      "lastUpdated": "2026-08-09",
+      "owner": "Developer Experience",
+      "path": "docs/superpowers/plans/2026-08-09-sol-advisor-capability-aware-configuration.md",
+      "staleDays": 0,
+      "status": "ACTIVE"
+    },
+    {
+      "docType": "doc",
+      "exists": true,
       "frontmatter": {},
       "hasExecutionClaims": true,
       "isStale": true,
@@ -14163,7 +14194,7 @@
   "stats": {
     "by_status": {
       "ACCEPTED (amended 2026-06-21)": 1,
-      "ACTIVE": 454,
+      "ACTIVE": 455,
       "ARCHIVED": 1,
       "BACKLOG": 1,
       "COMPLETE": 3,
@@ -14185,7 +14216,7 @@
     },
     "missing_frontmatter": 76,
     "stale_docs": 498,
-    "total_docs": 726
+    "total_docs": 727
   },
   "version": "2.0"
 }

--- a/docs/_generated/staleness-report.md
+++ b/docs/_generated/staleness-report.md
@@ -1,10 +1,10 @@
 ---
-last_updated: 2026-08-10
+last_updated: 2026-08-09
 ---
 
 # Staleness Report
 
-*Generated: 2026-08-10T00:00:00.000Z*
+*Generated: 2026-08-09T00:00:00.000Z*
 *Source: docs/DISCOVERY-MAP.source.yaml*
 
 ## Summary
@@ -12,15 +12,15 @@ last_updated: 2026-08-10
 | Metric | Value |
 |--------|-------|
 | Total Documents | 726 |
-| Stale Documents | 500 |
-| Missing Frontmatter | 77 |
+| Stale Documents | 498 |
+| Missing Frontmatter | 76 |
 
 ### By Status
 
 | Status | Count |
 |--------|-------|
-| ACTIVE | 453 |
-| UNKNOWN | 171 |
+| ACTIVE | 454 |
+| UNKNOWN | 170 |
 | DRAFT | 34 |
 | HISTORICAL | 22 |
 | VERIFIED | 13 |
@@ -97,105 +97,104 @@ Documents that need review (older than their cadence threshold):
 | `docs/skills/REFL-006-xirr-newton-raphson-divergence-on-extreme-returns.md` | Never | 999 | No | Unassigned |
 | `docs/skills/REFL-007-global-vi-mock-pollutes-all-tests.md` | Never | 999 | No | Unassigned |
 
-*...and 450 more stale documents.*
+*...and 448 more stale documents.*
 
 ## Documents with Execution Claims (Need Verification)
 
 These documents contain phrases like "tests pass", "PR merged", etc. and should be verified:
 
-- [ ] **.claude/commands/retrospective.md** (203 days old)
-- [ ] **.claude/commands/session-learnings.md** (203 days old)
-- [ ] **.claude/commands/wshobson/deps-audit.md** (203 days old)
-- [ ] **.claude/integration-test-execution-summary.md** (203 days old)
-- [ ] **.claude/integration-test-final-report.md** (203 days old)
-- [ ] **.claude/integration-test-reenable-plan-v2.md** (203 days old)
-- [ ] **.claude/plan.md** (224 days old)
-- [ ] **.claude/prompts/integration-test-continuation-prompt.md** (203 days old)
-- [ ] **.claude/prompts/portfolio-intelligence-timeout-fix.md** (203 days old)
-- [ ] **.claude/prompts/week2.5-next-session-kickoff.md** (203 days old)
-- [ ] **.claude/prompts/week2.5-phase3-continuation-v10.md** (203 days old)
-- [ ] **.claude/prompts/week2.5-phase3-continuation-v2.md** (203 days old)
-- [ ] **.claude/prompts/week2.5-phase3-continuation-v3.md** (203 days old)
-- [ ] **.claude/prompts/week2.5-phase3-continuation.md** (203 days old)
-- [ ] **.claude/prompts/week2.5-phase4-next-steps.md** (203 days old)
-- [ ] **.claude/session-summary-portfolio-intelligence-implementation.md** (203 days old)
-- [ ] **.claude/sessions/PHASE4-CONTINUATION-KICKOFF.md** (203 days old)
-- [ ] **.claude/skills/README.md** (203 days old)
-- [ ] **.claude/skills/iterative-improvement.md** (203 days old)
-- [ ] **.claude/skills/task-decomposition.md** (203 days old)
-- [ ] **.claude/testing/rubric-calculation-engines.md** (203 days old)
-- [ ] **.claude/testing/scenario-comparison-manual-test-rubric.md** (203 days old)
-- [ ] **.claude/testing/seed-script-remaining-fixes.md** (203 days old)
-- [ ] **ANTI_PATTERNS.md** (203 days old)
-- [ ] **CHANGELOG.md** (7 days old)
-- [ ] **COMPREHENSIVE-WORKFLOW-GUIDE.md** (203 days old)
-- [ ] **ITERATION-A-QUICKSTART.md** (203 days old)
-- [ ] **MIGRATION-NATIVE-MEMORY.md** (203 days old)
-- [ ] **PRODUCTION_RUNBOOK.md** (203 days old)
-- [ ] **PROMPT_PATTERNS.md** (203 days old)
-- [ ] **cheatsheets/baseline-governance.md** (91 days old)
-- [ ] **cheatsheets/daily-workflow.md** (129 days old)
-- [ ] **cheatsheets/emoji-free-documentation.md** (203 days old)
-- [ ] **cheatsheets/pr-merge-verification.md** (126 days old)
-- [ ] **cheatsheets/schema-alignment.md** (203 days old)
-- [ ] **docs/CA-IMPLEMENTATION-PLAN.md** (203 days old)
-- [ ] **docs/CA-SEMANTIC-LOCK.md** (203 days old)
-- [ ] **docs/DECISIONS.md** (203 days old)
-- [ ] **docs/DEPLOYMENT.md** (203 days old)
-- [ ] **docs/DEVELOPMENT_STRATEGY.md** (203 days old)
-- [ ] **docs/MILESTONE-XIRR-PHASE0-COMPLETE.md** (203 days old)
-- [ ] **docs/PRODUCTION_CHECKLIST.md** (203 days old)
-- [ ] **docs/RATE_LIMITING_SUMMARY.md** (203 days old)
-- [ ] **docs/SCENARIO_DEPLOY_GUIDE.md** (203 days old)
-- [ ] **docs/VERIFICATION_CHECKLIST.md** (203 days old)
-- [ ] **docs/action-plans/CODEX-FIXES-EXECUTION-SUMMARY.md** (203 days old)
-- [ ] **docs/action-plans/CODEX-ISSUES-RESOLUTION-PLAN.md** (203 days old)
-- [ ] **docs/adr/ADR-008-capital-allocation-policy.md** (203 days old)
-- [ ] **docs/agent-2-mobile-executive-dashboard.md** (203 days old)
-- [ ] **docs/api/architecture/portfolio-route-api.md** (203 days old)
-- [ ] **docs/api/testing/portfolio-route-test-strategy.md** (203 days old)
-- [ ] **docs/behavioral-specs/time-travel-analytics-service-specs.md** (203 days old)
-- [ ] **docs/chaos-engineering/README.md** (203 days old)
-- [ ] **docs/chaos-engineering/RLS-CHAOS-TESTING-PLAN.md** (203 days old)
-- [ ] **docs/deployment/CODEX-FIXES-DEPLOYMENT-STATUS.md** (203 days old)
-- [ ] **docs/deployment/ROLLBACK_PLAN.md** (203 days old)
-- [ ] **docs/deployment/STAGING_CHECKLIST.md** (203 days old)
-- [ ] **docs/deployment/STAGING_DEPLOYMENT_SUMMARY.md** (203 days old)
-- [ ] **docs/deployment/STAGING_METRICS.md** (203 days old)
-- [ ] **docs/failure-triage.md** (203 days old)
-- [ ] **docs/forecasting/power-law-implementation.md** (203 days old)
-- [ ] **docs/foundation/PHASE2-ROADMAP-IMPROVEMENTS.md** (203 days old)
-- [ ] **docs/foundation/PHASE2-ROADMAP.md** (203 days old)
-- [ ] **docs/foundation/PHASE3-KICKOFF.md** (203 days old)
-- [ ] **docs/foundation/PHASE4-KICKOFF.md** (203 days old)
-- [ ] **docs/integration/upstash-setup.md** (203 days old)
-- [ ] **docs/notebooklm-sources/reserves/01-overview.md** (203 days old)
-- [ ] **docs/notebooklm-sources/waterfall.md** (203 days old)
-- [ ] **docs/notebooklm-sources/xirr.md** (203 days old)
-- [ ] **docs/npm-bin-resolution-investigation.md** (203 days old)
-- [ ] **docs/observability/EDITORIAL-V2-CHANGELOG.md** (203 days old)
-- [ ] **docs/observability/README.md** (203 days old)
-- [ ] **docs/phase0-xirr-analysis-eda20590.md** (203 days old)
-- [ ] **docs/phase1-1-1-analysis.md** (203 days old)
-- [ ] **docs/phase1-xirr-baseline-heatmap.md** (203 days old)
-- [ ] **docs/phase1b-waterfall-evaluator-hardening.md** (203 days old)
-- [ ] **docs/processes/CONTRIBUTING.md** (203 days old)
-- [ ] **docs/processes/code-review-checklist.md** (203 days old)
-- [ ] **docs/references/claude-agent-testing.md** (203 days old)
-- [ ] **docs/references/replit.md** (203 days old)
-- [ ] **docs/releases/stage-norm-phase5.md** (203 days old)
-- [ ] **docs/releases/stage-normalization-v3.4.md** (203 days old)
-- [ ] **docs/replit.md** (203 days old)
-- [ ] **docs/reviews/CA-IMPLEMENTATION-EVALUATION-FINAL.md** (203 days old)
-- [ ] **docs/skills-application-log.md** (203 days old)
+- [ ] **.claude/commands/retrospective.md** (202 days old)
+- [ ] **.claude/commands/session-learnings.md** (202 days old)
+- [ ] **.claude/commands/wshobson/deps-audit.md** (202 days old)
+- [ ] **.claude/integration-test-execution-summary.md** (202 days old)
+- [ ] **.claude/integration-test-final-report.md** (202 days old)
+- [ ] **.claude/integration-test-reenable-plan-v2.md** (202 days old)
+- [ ] **.claude/plan.md** (223 days old)
+- [ ] **.claude/prompts/integration-test-continuation-prompt.md** (202 days old)
+- [ ] **.claude/prompts/portfolio-intelligence-timeout-fix.md** (202 days old)
+- [ ] **.claude/prompts/week2.5-next-session-kickoff.md** (202 days old)
+- [ ] **.claude/prompts/week2.5-phase3-continuation-v10.md** (202 days old)
+- [ ] **.claude/prompts/week2.5-phase3-continuation-v2.md** (202 days old)
+- [ ] **.claude/prompts/week2.5-phase3-continuation-v3.md** (202 days old)
+- [ ] **.claude/prompts/week2.5-phase3-continuation.md** (202 days old)
+- [ ] **.claude/prompts/week2.5-phase4-next-steps.md** (202 days old)
+- [ ] **.claude/session-summary-portfolio-intelligence-implementation.md** (202 days old)
+- [ ] **.claude/sessions/PHASE4-CONTINUATION-KICKOFF.md** (202 days old)
+- [ ] **.claude/skills/README.md** (202 days old)
+- [ ] **.claude/skills/iterative-improvement.md** (202 days old)
+- [ ] **.claude/skills/task-decomposition.md** (202 days old)
+- [ ] **.claude/testing/rubric-calculation-engines.md** (202 days old)
+- [ ] **.claude/testing/scenario-comparison-manual-test-rubric.md** (202 days old)
+- [ ] **.claude/testing/seed-script-remaining-fixes.md** (202 days old)
+- [ ] **ANTI_PATTERNS.md** (202 days old)
+- [ ] **COMPREHENSIVE-WORKFLOW-GUIDE.md** (202 days old)
+- [ ] **ITERATION-A-QUICKSTART.md** (202 days old)
+- [ ] **MIGRATION-NATIVE-MEMORY.md** (202 days old)
+- [ ] **PRODUCTION_RUNBOOK.md** (202 days old)
+- [ ] **PROMPT_PATTERNS.md** (202 days old)
+- [ ] **cheatsheets/baseline-governance.md** (90 days old)
+- [ ] **cheatsheets/daily-workflow.md** (128 days old)
+- [ ] **cheatsheets/emoji-free-documentation.md** (202 days old)
+- [ ] **cheatsheets/pr-merge-verification.md** (125 days old)
+- [ ] **cheatsheets/schema-alignment.md** (202 days old)
+- [ ] **docs/CA-IMPLEMENTATION-PLAN.md** (202 days old)
+- [ ] **docs/CA-SEMANTIC-LOCK.md** (202 days old)
+- [ ] **docs/DECISIONS.md** (202 days old)
+- [ ] **docs/DEPLOYMENT.md** (202 days old)
+- [ ] **docs/DEVELOPMENT_STRATEGY.md** (202 days old)
+- [ ] **docs/MILESTONE-XIRR-PHASE0-COMPLETE.md** (202 days old)
+- [ ] **docs/PRODUCTION_CHECKLIST.md** (202 days old)
+- [ ] **docs/RATE_LIMITING_SUMMARY.md** (202 days old)
+- [ ] **docs/SCENARIO_DEPLOY_GUIDE.md** (202 days old)
+- [ ] **docs/VERIFICATION_CHECKLIST.md** (202 days old)
+- [ ] **docs/action-plans/CODEX-FIXES-EXECUTION-SUMMARY.md** (202 days old)
+- [ ] **docs/action-plans/CODEX-ISSUES-RESOLUTION-PLAN.md** (202 days old)
+- [ ] **docs/adr/ADR-008-capital-allocation-policy.md** (202 days old)
+- [ ] **docs/agent-2-mobile-executive-dashboard.md** (202 days old)
+- [ ] **docs/api/architecture/portfolio-route-api.md** (202 days old)
+- [ ] **docs/api/testing/portfolio-route-test-strategy.md** (202 days old)
+- [ ] **docs/behavioral-specs/time-travel-analytics-service-specs.md** (202 days old)
+- [ ] **docs/chaos-engineering/README.md** (202 days old)
+- [ ] **docs/chaos-engineering/RLS-CHAOS-TESTING-PLAN.md** (202 days old)
+- [ ] **docs/deployment/CODEX-FIXES-DEPLOYMENT-STATUS.md** (202 days old)
+- [ ] **docs/deployment/ROLLBACK_PLAN.md** (202 days old)
+- [ ] **docs/deployment/STAGING_CHECKLIST.md** (202 days old)
+- [ ] **docs/deployment/STAGING_DEPLOYMENT_SUMMARY.md** (202 days old)
+- [ ] **docs/deployment/STAGING_METRICS.md** (202 days old)
+- [ ] **docs/failure-triage.md** (202 days old)
+- [ ] **docs/forecasting/power-law-implementation.md** (202 days old)
+- [ ] **docs/foundation/PHASE2-ROADMAP-IMPROVEMENTS.md** (202 days old)
+- [ ] **docs/foundation/PHASE2-ROADMAP.md** (202 days old)
+- [ ] **docs/foundation/PHASE3-KICKOFF.md** (202 days old)
+- [ ] **docs/foundation/PHASE4-KICKOFF.md** (202 days old)
+- [ ] **docs/integration/upstash-setup.md** (202 days old)
+- [ ] **docs/notebooklm-sources/reserves/01-overview.md** (202 days old)
+- [ ] **docs/notebooklm-sources/waterfall.md** (202 days old)
+- [ ] **docs/notebooklm-sources/xirr.md** (202 days old)
+- [ ] **docs/npm-bin-resolution-investigation.md** (202 days old)
+- [ ] **docs/observability/EDITORIAL-V2-CHANGELOG.md** (202 days old)
+- [ ] **docs/observability/README.md** (202 days old)
+- [ ] **docs/phase0-xirr-analysis-eda20590.md** (202 days old)
+- [ ] **docs/phase1-1-1-analysis.md** (202 days old)
+- [ ] **docs/phase1-xirr-baseline-heatmap.md** (202 days old)
+- [ ] **docs/phase1b-waterfall-evaluator-hardening.md** (202 days old)
+- [ ] **docs/processes/CONTRIBUTING.md** (202 days old)
+- [ ] **docs/processes/code-review-checklist.md** (202 days old)
+- [ ] **docs/references/claude-agent-testing.md** (202 days old)
+- [ ] **docs/references/replit.md** (202 days old)
+- [ ] **docs/releases/stage-norm-phase5.md** (202 days old)
+- [ ] **docs/releases/stage-normalization-v3.4.md** (202 days old)
+- [ ] **docs/replit.md** (202 days old)
+- [ ] **docs/reviews/CA-IMPLEMENTATION-EVALUATION-FINAL.md** (202 days old)
+- [ ] **docs/skills-application-log.md** (202 days old)
 - [ ] **docs/skills/REFL-003-cross-platform-file-enumeration-fragility.md** (999 days old)
 - [ ] **docs/skills/REFL-014-test-key-reuse-across-test-cases.md** (999 days old)
 - [ ] **docs/skills/REFL-015-postgresql-service-missing-test-database.md** (999 days old)
 - [ ] **docs/superpowers/plans/2026-06-07-forecast-drift-ux-completion.md** (999 days old)
 - [ ] **docs/superpowers/plans/2026-07-29-task160-internal-waterfall-governance.md** (999 days old)
 - [ ] **docs/superpowers/specs/2026-05-16-refactor-stability-strategy-design.md** (999 days old)
-- [ ] **docs/xirr-consolidation-roadmap.md** (224 days old)
-- [ ] **docs/xirr-excel-validation.md** (203 days old)
+- [ ] **docs/xirr-consolidation-roadmap.md** (223 days old)
+- [ ] **docs/xirr-excel-validation.md** (202 days old)
 
 ## Missing Frontmatter
 
@@ -270,7 +269,6 @@ Documents without proper YAML frontmatter:
 - [ ] `docs/superpowers/plans/2026-07-28-tiered-model-routing.md`
 - [ ] `docs/superpowers/plans/2026-07-29-task160-internal-waterfall-governance.md`
 - [ ] `docs/superpowers/plans/2026-07-30-task163-wp-l2b-cash-assembly-and-nonzero-fees-plan.md`
-- [ ] `docs/superpowers/plans/2026-08-10-f1337-feeprofile-truth.md`
 - [ ] `docs/superpowers/specs/2026-05-16-refactor-stability-strategy-design.md`
 - [ ] `docs/superpowers/specs/2026-06-11-worker-prod-ops-design.md`
 - [ ] `docs/superpowers/specs/2026-06-21-investment-rounds-ui-v2-design.md`

--- a/docs/_generated/staleness-report.md
+++ b/docs/_generated/staleness-report.md
@@ -11,7 +11,7 @@ last_updated: 2026-08-09
 
 | Metric | Value |
 |--------|-------|
-| Total Documents | 726 |
+| Total Documents | 727 |
 | Stale Documents | 498 |
 | Missing Frontmatter | 76 |
 
@@ -19,7 +19,7 @@ last_updated: 2026-08-09
 
 | Status | Count |
 |--------|-------|
-| ACTIVE | 454 |
+| ACTIVE | 455 |
 | UNKNOWN | 170 |
 | DRAFT | 34 |
 | HISTORICAL | 22 |

--- a/docs/superpowers/plans/2026-08-09-sol-advisor-capability-aware-configuration.md
+++ b/docs/superpowers/plans/2026-08-09-sol-advisor-capability-aware-configuration.md
@@ -1,0 +1,1319 @@
+---
+status: ACTIVE
+audience: agents
+last_updated: 2026-08-09
+owner: Developer Experience
+review_cadence: P90D
+categories: [ai-automation, orchestration, implementation-plan]
+keywords: [sol-advisor, codex, ultra, fast-mode, configuration, migration]
+---
+
+# Sol Advisor Capability-Aware Configuration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build Sol Advisor's capability-aware v2 configuration foundation so
+canonical `ultra` reasoning and Codex fast mode are valid where the live host
+supports them, while legacy mixed-case effort values require an explicit
+previewed migration.
+
+**Architecture:** Implement this phase in the Sol Advisor source repository at
+`/Users/nikhil/.codex/.tmp/marketplaces/sol-advisor`. Split pure contracts,
+Codex capability discovery, and migration planning out of the current MCP
+server; keep filesystem transactions and MCP dispatch in `server.ts`. Store a
+capability snapshot with each v2 profile, validate model/effort pairs against
+the live Codex catalog, treat fast mode as a run-scoped service choice, and fail
+closed when evidence is unavailable or stale.
+
+**Tech Stack:** TypeScript, Bun, Bun test, newline-delimited JSON-RPC MCP, JSON
+configuration, Codex CLI capability commands.
+
+## Global Constraints
+
+- Source repository: `/Users/nikhil/.codex/.tmp/marketplaces/sol-advisor`.
+- Design authority:
+  `docs/superpowers/specs/2026-08-09-sol-advisor-orchestration-control-plane-design.md`
+  in `/Users/nikhil/code/Updog_restore`.
+- No new runtime dependency; Bun remains the only plugin runtime prerequisite.
+- Preserve all existing client adapters and transactional install, uninstall,
+  backup, and recovery behavior.
+- Accept only exact lowercase effort tokens; never silently normalize `Max`,
+  `xHigh`, or other mixed-case values.
+- Accept `ultra` only when the selected model's live Codex catalog entry reports
+  it.
+- Current capability evidence must reject `gpt-5.6-luna` plus `ultra` unless
+  Luna later reports support.
+- Permit Codex fast mode independently from model and effort; it cannot alter
+  A-tier, E-class, reviewer obligations, or acceptance evidence.
+- Record fast mode at run scope until the host proves a native per-agent
+  binding.
+- Existing v1 profiles migrate only through an exact preview and one-time
+  confirmation token.
+- Fail closed when the Codex executable, model catalog, or fast-mode capability
+  cannot be observed.
+- Do not invent timeouts, retry counts, or freshness windows; use an existing
+  host or project authority before adding any numeric limit.
+- Keep user-owned `.codex-marketplace-install.json` untracked and unchanged.
+- Use normal prose and no emoji in code, documentation, test names, or output.
+
+## File Structure
+
+Implementation repository paths below are relative to
+`/Users/nikhil/.codex/.tmp/marketplaces/sol-advisor`.
+
+- Create `plugins/sol-advisor/mcp/contracts.ts`: v2 preference, model-binding,
+  service-mode, and capability-evidence types plus pure canonical-token
+  validation.
+- Create `plugins/sol-advisor/mcp/contracts.test.ts`: pure contract and
+  model/effort compatibility tests.
+- Create `plugins/sol-advisor/mcp/codex-capabilities.ts`: fixed-command Codex
+  capability probe, parser, canonical snapshot, and digest.
+- Create `plugins/sol-advisor/mcp/codex-capabilities.test.ts`: probe/parser
+  tests using injected command results.
+- Create `plugins/sol-advisor/mcp/migration.ts`: pure v1-to-v2 preview
+  construction and confirmation-bound migration plan.
+- Create `plugins/sol-advisor/mcp/migration.test.ts`: mixed-case,
+  unsupported-combination, and no-op migration tests.
+- Modify `plugins/sol-advisor/mcp/server.ts`: v2 persistence, tool schemas,
+  capability injection, migration tools, live validation, and adapter rendering.
+- Modify `plugins/sol-advisor/mcp/server.test.ts`: MCP integration, persistence,
+  migration, rendering, and stale-capability coverage.
+- Modify `plugins/sol-advisor/skills/setup/SKILL.md`: capability discovery,
+  `ultra`, fast-mode, and migration interview behavior.
+- Modify `plugins/sol-advisor/skills/orchestration/SKILL.md`: run-level
+  service-mode observation and fail-closed dispatch language.
+- Modify `README.md`: v2 profile, capability, migration, `ultra`, and fast-mode
+  behavior.
+- Modify `CHANGELOG.md`: user-visible configuration changes.
+- Modify `package.json`, `plugins/sol-advisor/plugin.json`,
+  `plugins/sol-advisor/.codex-plugin/plugin.json`, and
+  `plugins/sol-advisor/mcp/server.ts`: one consistent minor version after
+  behavior passes tests.
+- Modify `plugins/sol-advisor/scripts/verify.sh`: exact version, documentation,
+  and generated-adapter assertions.
+
+---
+
+### Task 1: Define canonical configuration and capability contracts
+
+**Files:**
+
+- Create: `plugins/sol-advisor/mcp/contracts.ts`
+- Create: `plugins/sol-advisor/mcp/contracts.test.ts`
+- Modify: `plugins/sol-advisor/mcp/server.ts:1-103`
+
+**Interfaces:**
+
+- Consumes: existing `Client`, `RoleName`, `RolePreference`, and `Preferences`
+  concepts from `server.ts`.
+- Produces: `PreferencesV2`, `CapabilitySnapshot`, `ModelCapability`,
+  `ServiceMode`, `assertCanonicalToken()`, `validateCodexBinding()`, and
+  `validateServiceMode()`.
+
+- [ ] **Step 1: Write failing pure contract tests**
+
+```ts
+import { describe, expect, test } from 'bun:test';
+import {
+  assertCanonicalToken,
+  validateCodexBinding,
+  validateServiceMode,
+  type CapabilitySnapshot,
+} from './contracts';
+
+const snapshot: CapabilitySnapshot = {
+  client: 'codex',
+  source: 'codex-cli',
+  observedAt: '2026-08-09T00:00:00.000Z',
+  digest: 'fixture-digest',
+  models: {
+    'gpt-5.6-sol': { efforts: ['low', 'high', 'xhigh', 'max', 'ultra'] },
+    'gpt-5.6-terra': { efforts: ['low', 'high', 'xhigh', 'max', 'ultra'] },
+    'gpt-5.6-luna': { efforts: ['low', 'high', 'xhigh', 'max'] },
+  },
+  serviceModes: {
+    default: { scope: 'run' },
+    fast: { scope: 'run' },
+  },
+};
+
+describe('canonical capability contracts', () => {
+  test('rejects mixed-case effort tokens', () => {
+    expect(() => assertCanonicalToken('Max', 'effort')).toThrow(
+      'canonical lowercase'
+    );
+    expect(() => assertCanonicalToken('xHigh', 'effort')).toThrow(
+      'canonical lowercase'
+    );
+  });
+
+  test('accepts ultra only for models that report it', () => {
+    expect(validateCodexBinding(snapshot, 'gpt-5.6-sol', 'ultra')).toEqual([]);
+    expect(validateCodexBinding(snapshot, 'gpt-5.6-terra', 'ultra')).toEqual(
+      []
+    );
+    expect(validateCodexBinding(snapshot, 'gpt-5.6-luna', 'ultra')).toContain(
+      'gpt-5.6-luna does not report effort ultra'
+    );
+  });
+
+  test('keeps fast mode independent and run-scoped', () => {
+    expect(validateServiceMode(snapshot, 'fast', 'run')).toEqual([]);
+    expect(validateServiceMode(snapshot, 'fast', 'role')).toContain(
+      'fast is supported at run scope, not role scope'
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run tests and verify module is missing**
+
+Run:
+
+```bash
+cd /Users/nikhil/.codex/.tmp/marketplaces/sol-advisor
+bun test plugins/sol-advisor/mcp/contracts.test.ts
+```
+
+Expected: FAIL because `./contracts` does not exist.
+
+- [ ] **Step 3: Implement focused contracts module**
+
+```ts
+export type Client = 'codex' | 'cursor' | 'vscode' | 'github-copilot' | 'kiro';
+export type RoleName = 'routine' | 'high' | 'advisor';
+export type ServiceMode = 'inherit' | 'default' | 'fast';
+export type ServiceModeScope = 'run' | 'role';
+
+export type ModelCapability = { efforts: string[] };
+export type CapabilitySnapshot = {
+  client: Client;
+  source: 'codex-cli' | 'client-declared';
+  observedAt: string;
+  digest: string;
+  models: Record<string, ModelCapability>;
+  serviceModes: Partial<
+    Record<Exclude<ServiceMode, 'inherit'>, { scope: ServiceModeScope }>
+  >;
+};
+
+export type RolePreference = {
+  model: string;
+  effort?: string;
+  readonly?: boolean;
+};
+
+export type PreferencesV2 = {
+  schemaVersion: 2;
+  client: Client;
+  scope: 'project' | 'user';
+  orchestrator: {
+    model: 'inherit';
+    recommendation?: { model: string; effort?: string };
+  };
+  roles: Record<RoleName, RolePreference>;
+  runDefaults: { serviceMode: ServiceMode };
+  capabilityEvidence: CapabilitySnapshot;
+  fallbackPolicy: 'fail-closed';
+  fallbacks: [];
+  appTaskLane?: { enabled: true; model: 'gpt-5.6-luna'; effort: 'max' };
+  profileKey: string;
+  workspace: string;
+  createdAt: string;
+  updatedAt: string;
+  pluginVersion: string;
+};
+
+export function assertCanonicalToken(
+  value: unknown,
+  label: string
+): asserts value is string {
+  if (typeof value !== 'string' || value.length === 0)
+    throw new Error(`${label} must be an exact non-empty string`);
+  if (!/^[a-z][a-z0-9_-]*$/.test(value))
+    throw new Error(`${label} must use canonical lowercase spelling`);
+}
+
+export function validateCodexBinding(
+  snapshot: CapabilitySnapshot,
+  model: string,
+  effort?: string
+): string[] {
+  const errors: string[] = [];
+  const capability = snapshot.models[model];
+  if (!capability) return [`Codex model catalog does not report ${model}`];
+  if (effort !== undefined) {
+    try {
+      assertCanonicalToken(effort, 'effort');
+    } catch (error) {
+      errors.push(error instanceof Error ? error.message : String(error));
+      return errors;
+    }
+    if (!capability.efforts.includes(effort))
+      errors.push(`${model} does not report effort ${effort}`);
+  }
+  return errors;
+}
+
+export function validateServiceMode(
+  snapshot: CapabilitySnapshot,
+  mode: ServiceMode,
+  requestedScope: ServiceModeScope
+): string[] {
+  if (mode === 'inherit') return [];
+  const capability = snapshot.serviceModes[mode];
+  if (!capability) return [`Codex host does not report service mode ${mode}`];
+  return capability.scope === requestedScope
+    ? []
+    : [
+        `${mode} is supported at ${capability.scope} scope, not ${requestedScope} scope`,
+      ];
+}
+```
+
+- [ ] **Step 4: Move duplicate type declarations out of `server.ts`**
+
+Replace local declarations with imports and retain any server-only types:
+
+```ts
+import {
+  assertCanonicalToken,
+  validateCodexBinding,
+  validateServiceMode,
+  type CapabilitySnapshot,
+  type Client,
+  type PreferencesV2,
+  type RoleName,
+  type RolePreference,
+  type ServiceMode,
+} from './contracts';
+```
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+bun test plugins/sol-advisor/mcp/contracts.test.ts plugins/sol-advisor/mcp/server.test.ts
+```
+
+Expected: PASS, with existing server behavior unchanged.
+
+- [ ] **Step 6: Commit contract extraction**
+
+```bash
+git add plugins/sol-advisor/mcp/contracts.ts plugins/sol-advisor/mcp/contracts.test.ts plugins/sol-advisor/mcp/server.ts
+git commit -m "refactor: extract Sol Advisor configuration contracts"
+```
+
+---
+
+### Task 2: Discover Codex models, efforts, and fast-mode capability
+
+**Files:**
+
+- Create: `plugins/sol-advisor/mcp/codex-capabilities.ts`
+- Create: `plugins/sol-advisor/mcp/codex-capabilities.test.ts`
+
+**Interfaces:**
+
+- Consumes: `CapabilitySnapshot` from Task 1.
+- Produces: `CommandRunner`, `CommandResult`, `parseCodexModels()`,
+  `parseCodexFeatures()`, and `probeCodexCapabilities()`.
+
+- [ ] **Step 1: Write failing parser and probe tests**
+
+```ts
+import { describe, expect, test } from 'bun:test';
+import {
+  probeCodexCapabilities,
+  type CommandRunner,
+} from './codex-capabilities';
+
+const models = JSON.stringify({
+  models: [
+    {
+      slug: 'gpt-5.6-sol',
+      supported_reasoning_levels: [{ effort: 'high' }, { effort: 'ultra' }],
+    },
+    {
+      slug: 'gpt-5.6-luna',
+      supported_reasoning_levels: [{ effort: 'high' }, { effort: 'max' }],
+    },
+  ],
+});
+
+test('builds deterministic Codex capability evidence', async () => {
+  const runner: CommandRunner = async (args) => {
+    if (args.join(' ') === 'debug models')
+      return { exitCode: 0, stdout: models, stderr: '' };
+    if (args.join(' ') === 'features list') {
+      return { exitCode: 0, stdout: 'fast_mode stable true\n', stderr: '' };
+    }
+    throw new Error(`unexpected command: ${args.join(' ')}`);
+  };
+
+  const snapshot = await probeCodexCapabilities(
+    runner,
+    () => '2026-08-09T00:00:00.000Z'
+  );
+  expect(snapshot.models['gpt-5.6-sol']?.efforts).toEqual(['high', 'ultra']);
+  expect(snapshot.models['gpt-5.6-luna']?.efforts).toEqual(['high', 'max']);
+  expect(snapshot.serviceModes.fast).toEqual({ scope: 'run' });
+  expect(snapshot.digest).toMatch(/^[a-f0-9]{64}$/);
+});
+
+test('fails closed when either fixed Codex command fails', async () => {
+  const runner: CommandRunner = async () => ({
+    exitCode: 1,
+    stdout: '',
+    stderr: 'unavailable',
+  });
+  await expect(probeCodexCapabilities(runner)).rejects.toThrow(
+    'Codex capability probe failed'
+  );
+});
+```
+
+- [ ] **Step 2: Run test and verify module is missing**
+
+Run:
+
+```bash
+bun test plugins/sol-advisor/mcp/codex-capabilities.test.ts
+```
+
+Expected: FAIL because `./codex-capabilities` does not exist.
+
+- [ ] **Step 3: Implement a fixed-command, injected capability probe**
+
+```ts
+import { createHash } from 'node:crypto';
+import type { CapabilitySnapshot } from './contracts';
+
+export type CommandResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+export type CommandRunner = (args: readonly string[]) => Promise<CommandResult>;
+
+const defaultRunner: CommandRunner = async (args) => {
+  const process = Bun.spawn(['codex', ...args], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+    process.exited,
+  ]);
+  return { exitCode, stdout, stderr };
+};
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>).sort(
+      ([a], [b]) => a.localeCompare(b)
+    );
+    return `{${entries.map(([key, item]) => `${JSON.stringify(key)}:${canonicalJson(item)}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export async function probeCodexCapabilities(
+  run: CommandRunner = defaultRunner,
+  now: () => string = () => new Date().toISOString()
+): Promise<CapabilitySnapshot> {
+  const [modelResult, featureResult] = await Promise.all([
+    run(['debug', 'models']),
+    run(['features', 'list']),
+  ]);
+  if (modelResult.exitCode !== 0 || featureResult.exitCode !== 0) {
+    throw new Error(
+      'Codex capability probe failed; model and fast-mode evidence are required'
+    );
+  }
+  const raw = JSON.parse(modelResult.stdout) as {
+    models?: Array<{
+      slug?: unknown;
+      supported_reasoning_levels?: Array<{ effort?: unknown }>;
+    }>;
+  };
+  const models = Object.fromEntries(
+    (raw.models ?? []).flatMap((model) => {
+      if (typeof model.slug !== 'string') return [];
+      const efforts = (model.supported_reasoning_levels ?? [])
+        .map((level) => level.effort)
+        .filter((effort): effort is string => typeof effort === 'string')
+        .sort();
+      return [[model.slug, { efforts }]];
+    })
+  );
+  const fastEnabled = /^fast_mode\s+\S+\s+true$/m.test(featureResult.stdout);
+  const material = {
+    client: 'codex' as const,
+    source: 'codex-cli' as const,
+    models,
+    serviceModes: {
+      default: { scope: 'run' as const },
+      ...(fastEnabled ? { fast: { scope: 'run' as const } } : {}),
+    },
+  };
+  return {
+    ...material,
+    observedAt: now(),
+    digest: createHash('sha256').update(canonicalJson(material)).digest('hex'),
+  };
+}
+```
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+bun test plugins/sol-advisor/mcp/codex-capabilities.test.ts plugins/sol-advisor/mcp/contracts.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit capability discovery**
+
+```bash
+git add plugins/sol-advisor/mcp/codex-capabilities.ts plugins/sol-advisor/mcp/codex-capabilities.test.ts
+git commit -m "feat: discover Codex model and fast-mode capabilities"
+```
+
+---
+
+### Task 3: Persist and validate v2 profiles
+
+**Files:**
+
+- Modify: `plugins/sol-advisor/mcp/server.ts:60-103,220-270`
+- Modify: `plugins/sol-advisor/mcp/server.test.ts:1-75`
+
+**Interfaces:**
+
+- Consumes: `PreferencesV2`, validation helpers, and `probeCodexCapabilities()`.
+- Produces: async `savePreferencesV2()`, v2 `save_preferences` MCP schema, and
+  `__setCapabilityProbeForTests()`.
+
+- [ ] **Step 1: Add failing v2 persistence tests**
+
+```ts
+import type { CapabilitySnapshot } from './contracts';
+import { __setCapabilityProbeForTests } from './server';
+
+const codexSnapshot: CapabilitySnapshot = {
+  client: 'codex',
+  source: 'codex-cli',
+  observedAt: '2026-08-09T00:00:00.000Z',
+  digest: 'fixture',
+  models: {
+    'gpt-5.6-sol': { efforts: ['high', 'ultra'] },
+    'gpt-5.6-terra': { efforts: ['high', 'ultra'] },
+    'gpt-5.6-luna': { efforts: ['high', 'max'] },
+  },
+  serviceModes: { default: { scope: 'run' }, fast: { scope: 'run' } },
+};
+
+beforeEach(() => {
+  __setCapabilityProbeForTests(async () => codexSnapshot);
+});
+
+afterEach(() => {
+  __setCapabilityProbeForTests(undefined);
+});
+
+test('persists Sol ultra and run-scoped fast mode', async () => {
+  const input = base('codex') as any;
+  input.roles.advisor.effort = 'ultra';
+  input.runDefaults = { serviceMode: 'fast' };
+  await callTool('save_preferences', input);
+  const saved = (await callTool('get_preferences')) as any;
+  expect(saved.schemaVersion).toBe(2);
+  expect(saved.roles.advisor.effort).toBe('ultra');
+  expect(saved.runDefaults).toEqual({ serviceMode: 'fast' });
+  expect(saved.capabilityEvidence.digest).toBe('fixture');
+});
+
+test('rejects Luna ultra and mixed-case effort before writing', async () => {
+  const lunaUltra = base('codex') as any;
+  lunaUltra.roles.routine = { model: 'gpt-5.6-luna', effort: 'ultra' };
+  await expect(callTool('save_preferences', lunaUltra)).rejects.toThrow(
+    'gpt-5.6-luna does not report effort ultra'
+  );
+  const mixed = base('codex') as any;
+  mixed.roles.routine.effort = 'Max';
+  await expect(callTool('save_preferences', mixed)).rejects.toThrow(
+    'canonical lowercase'
+  );
+  expect(existsSync(join(data, 'config.json'))).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run integration test and verify it fails**
+
+Run:
+
+```bash
+bun test plugins/sol-advisor/mcp/server.test.ts --filter "persists Sol ultra|rejects Luna ultra"
+```
+
+Expected: FAIL because v2 fields and capability injection do not exist.
+
+- [ ] **Step 3: Add capability-probe injection and async validation**
+
+```ts
+type CapabilityProbe = () => Promise<CapabilitySnapshot>;
+let capabilityProbe: CapabilityProbe = probeCodexCapabilities;
+
+export function __setCapabilityProbeForTests(probe?: CapabilityProbe): void {
+  capabilityProbe = probe ?? probeCodexCapabilities;
+}
+
+async function validateLivePreferences(
+  candidate: PreferencesV2
+): Promise<string[]> {
+  if (candidate.client !== 'codex') return [];
+  const snapshot = await capabilityProbe();
+  candidate.capabilityEvidence = snapshot;
+  const errors = (Object.keys(candidate.roles) as RoleName[]).flatMap(
+    (role) => {
+      const preference = candidate.roles[role];
+      return validateCodexBinding(
+        snapshot,
+        preference.model,
+        preference.effort
+      ).map((message) => `roles.${role}: ${message}`);
+    }
+  );
+  errors.push(
+    ...validateServiceMode(snapshot, candidate.runDefaults.serviceMode, 'run')
+  );
+  if (candidate.appTaskLane) {
+    errors.push(
+      ...validateCodexBinding(
+        snapshot,
+        candidate.appTaskLane.model,
+        candidate.appTaskLane.effort
+      )
+    );
+  }
+  return errors;
+}
+```
+
+- [ ] **Step 4: Build and save a v2 candidate only after live validation**
+
+Rename current `validatePreferences()` to `validateStoredPreferences()` and keep
+its structural, unknown-field, client, scope, readonly, and fail-closed checks.
+Define the current package version once, then use this exact shape in
+`savePreferences`:
+
+```ts
+const PLUGIN_VERSION = '0.5.0';
+
+const candidate: PreferencesV2 = {
+  schemaVersion: 2,
+  client: args.client,
+  scope: args.scope,
+  orchestrator: {
+    model: 'inherit',
+    ...(args.orchestrator?.recommendation
+      ? { recommendation: args.orchestrator.recommendation }
+      : {}),
+  },
+  roles: {
+    routine: { ...args.roles.routine },
+    high: { ...args.roles.high },
+    advisor: { ...args.roles.advisor, readonly: true },
+  },
+  runDefaults: { serviceMode: args.runDefaults?.serviceMode ?? 'inherit' },
+  capabilityEvidence: {
+    client: args.client,
+    source: 'client-declared',
+    observedAt: now,
+    digest: 'pending-live-validation',
+    models: {},
+    serviceModes: {},
+  },
+  fallbackPolicy: 'fail-closed',
+  fallbacks: [],
+  ...(args.appTaskLane?.enabled === true
+    ? { appTaskLane: { enabled: true, model: 'gpt-5.6-luna', effort: 'max' } }
+    : {}),
+  profileKey,
+  workspace,
+  createdAt:
+    existing.preferences?.profileKey === profileKey
+      ? existing.preferences.createdAt
+      : now,
+  updatedAt: now,
+  pluginVersion: PLUGIN_VERSION,
+};
+const errors = [
+  ...validateStoredPreferences(candidate),
+  ...(await validateLivePreferences(candidate)),
+];
+if (errors.length) throw new Error(errors.join('; '));
+```
+
+Extend the MCP input schema with:
+
+```ts
+runDefaults: {
+  type: "object",
+  properties: { serviceMode: { type: "string", enum: ["inherit", "default", "fast"] } },
+  required: ["serviceMode"],
+  additionalProperties: false,
+},
+```
+
+- [ ] **Step 5: Preserve non-Codex capability semantics explicitly**
+
+For Cursor, VS Code, GitHub Copilot, and Kiro, store a `client-declared`
+snapshot with no claim of machine-verified model availability. Keep current
+per-client effort restrictions. Do not mark fast mode supported for those
+clients in this phase.
+
+```ts
+if (candidate.client !== 'codex') {
+  candidate.capabilityEvidence = {
+    client: candidate.client,
+    source: 'client-declared',
+    observedAt: now,
+    digest: sha(
+      JSON.stringify({ client: candidate.client, serviceMode: 'inherit' })
+    ),
+    models: {},
+    serviceModes: {},
+  };
+  if (candidate.runDefaults.serviceMode !== 'inherit') {
+    errors.push(
+      `${candidate.client} does not expose a verified Sol Advisor service-mode binding`
+    );
+  }
+}
+```
+
+- [ ] **Step 6: Run focused and full MCP tests**
+
+Run:
+
+```bash
+bun test plugins/sol-advisor/mcp/contracts.test.ts plugins/sol-advisor/mcp/codex-capabilities.test.ts plugins/sol-advisor/mcp/server.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit v2 persistence**
+
+```bash
+git add plugins/sol-advisor/mcp/server.ts plugins/sol-advisor/mcp/server.test.ts
+git commit -m "feat: validate Sol Advisor profiles against Codex capabilities"
+```
+
+---
+
+### Task 4: Add previewed, confirmation-bound v1 migration
+
+**Files:**
+
+- Create: `plugins/sol-advisor/mcp/migration.ts`
+- Create: `plugins/sol-advisor/mcp/migration.test.ts`
+- Modify: `plugins/sol-advisor/mcp/server.ts:45-60,220-280`
+- Modify: `plugins/sol-advisor/mcp/server.test.ts:35-75`
+
+**Interfaces:**
+
+- Consumes: v1 stored profile, current `CapabilitySnapshot`, existing `sha()`,
+  `atomicWrite()`, backup directory, and one-time preview-plan pattern.
+- Produces: `MigrationChange`, `MigrationPreview`, `buildMigrationPreview()`,
+  `preview_configuration_migration`, and `apply_configuration_migration`.
+
+- [ ] **Step 1: Write failing pure migration tests**
+
+```ts
+import { expect, test } from 'bun:test';
+import { buildMigrationPreview } from './migration';
+import type { CapabilitySnapshot } from './contracts';
+
+const codexSnapshot: CapabilitySnapshot = {
+  client: 'codex',
+  source: 'codex-cli',
+  observedAt: '2026-08-09T00:00:00.000Z',
+  digest: 'fixture',
+  models: {
+    'gpt-5.6-sol': { efforts: ['high', 'xhigh', 'ultra'] },
+    'gpt-5.6-terra': { efforts: ['high', 'ultra'] },
+    'gpt-5.6-luna': { efforts: ['high', 'max'] },
+  },
+  serviceModes: { default: { scope: 'run' }, fast: { scope: 'run' } },
+};
+
+const legacyBase = () => ({
+  schemaVersion: 1,
+  client: 'codex',
+  scope: 'project',
+  workspace: '/fixture',
+  orchestrator: { model: 'inherit' },
+  roles: {
+    routine: { model: 'gpt-5.6-luna', effort: 'Max' },
+    high: { model: 'gpt-5.6-terra', effort: 'high' },
+    advisor: { model: 'gpt-5.6-sol', effort: 'xHigh', readonly: true },
+  },
+  fallbackPolicy: 'fail-closed',
+  fallbacks: [],
+  profileKey: 'codex:project:/fixture',
+  createdAt: '2026-08-08T00:00:00.000Z',
+  updatedAt: '2026-08-08T00:00:00.000Z',
+  pluginVersion: '0.5.0',
+});
+
+test('previews provable lowercase corrections without applying them', () => {
+  const preview = buildMigrationPreview(legacyBase() as any, codexSnapshot);
+  expect(preview.changes).toEqual([
+    { path: 'roles.advisor.effort', before: 'xHigh', after: 'xhigh' },
+    { path: 'roles.routine.effort', before: 'Max', after: 'max' },
+    { path: 'runDefaults.serviceMode', before: undefined, after: 'inherit' },
+  ]);
+  expect(preview.candidate.schemaVersion).toBe(2);
+});
+
+test('refuses a lowercase correction the selected model does not support', () => {
+  const input = legacyBase();
+  input.roles.routine = { model: 'gpt-5.6-luna', effort: 'Ultra' };
+  expect(() => buildMigrationPreview(input, codexSnapshot)).toThrow(
+    'gpt-5.6-luna does not report effort ultra'
+  );
+});
+```
+
+- [ ] **Step 2: Run test and verify module is missing**
+
+Run:
+
+```bash
+bun test plugins/sol-advisor/mcp/migration.test.ts
+```
+
+Expected: FAIL because `./migration` does not exist.
+
+- [ ] **Step 3: Implement pure migration planning**
+
+```ts
+import {
+  validateCodexBinding,
+  type CapabilitySnapshot,
+  type PreferencesV2,
+} from './contracts';
+
+export type MigrationChange = { path: string; before: unknown; after: unknown };
+export type MigrationPreview = {
+  candidate: PreferencesV2;
+  changes: MigrationChange[];
+};
+export type LegacyPreferencesV1 = Omit<
+  PreferencesV2,
+  'schemaVersion' | 'runDefaults' | 'capabilityEvidence'
+> & { schemaVersion: 1 };
+
+function migrateEffort(
+  path: string,
+  model: string,
+  effort: string | undefined,
+  snapshot: CapabilitySnapshot,
+  changes: MigrationChange[]
+): string | undefined {
+  if (effort === undefined) return undefined;
+  const canonical = effort.toLowerCase();
+  const errors = validateCodexBinding(snapshot, model, canonical);
+  if (errors.length) throw new Error(`${path}: ${errors.join('; ')}`);
+  if (canonical !== effort)
+    changes.push({ path, before: effort, after: canonical });
+  return canonical;
+}
+
+export function buildMigrationPreview(
+  input: LegacyPreferencesV1,
+  snapshot: CapabilitySnapshot,
+  now: () => string = () => new Date().toISOString()
+): MigrationPreview {
+  if (input.client !== 'codex')
+    throw new Error('automatic migration requires Codex capability evidence');
+  const changes: MigrationChange[] = [];
+  const roles = Object.fromEntries(
+    (['routine', 'high', 'advisor'] as const).map((role) => {
+      const preference = input.roles[role];
+      const effort = migrateEffort(
+        `roles.${role}.effort`,
+        preference.model,
+        preference.effort,
+        snapshot,
+        changes
+      );
+      return [
+        role,
+        { ...preference, ...(effort === undefined ? {} : { effort }) },
+      ];
+    })
+  ) as PreferencesV2['roles'];
+  changes.push({
+    path: 'runDefaults.serviceMode',
+    before: undefined,
+    after: 'inherit',
+  });
+  return {
+    candidate: {
+      ...input,
+      schemaVersion: 2,
+      roles,
+      runDefaults: { serviceMode: 'inherit' },
+      capabilityEvidence: snapshot,
+      updatedAt: now(),
+    },
+    changes: changes.sort((left, right) => left.path.localeCompare(right.path)),
+  };
+}
+```
+
+- [ ] **Step 4: Add migration MCP tools with exact preview binding**
+
+Add two tools:
+
+```ts
+{
+  name: "preview_configuration_migration",
+  description: "Preview exact v1-to-v2 preference changes without writing",
+  inputSchema: objectSchema(),
+},
+{
+  name: "apply_configuration_migration",
+  description: "Apply only the exact unexpired one-time migration preview",
+  inputSchema: objectSchema({ confirmationToken: str }, ["confirmationToken"]),
+},
+```
+
+Reuse the adapter preview pattern: bind the token to the current config hash,
+candidate hash, capability digest, profile key, and exact change list. Mark it
+used before writing. Reuse the existing adapter preview's ten-minute lifetime;
+that limit comes from current plugin behavior rather than a new guessed cap.
+Back up the old config, atomically write v2, and leave installed adapter files
+untouched so `validate_configuration` can report any managed-file mismatch until
+the user previews and confirms adapter installation.
+
+- [ ] **Step 5: Add integration tests proving no silent mutation**
+
+```ts
+function writeLegacyConfig({
+  routineEffort,
+  advisorEffort,
+}: {
+  routineEffort: string;
+  advisorEffort: string;
+}): void {
+  const profileKey = `codex:project:${workspace}`;
+  const profile = {
+    ...base('codex', 'project'),
+    schemaVersion: 1,
+    roles: {
+      ...(base('codex', 'project') as any).roles,
+      routine: { model: 'gpt-5.6-luna', effort: routineEffort },
+      advisor: { model: 'gpt-5.6-sol', effort: advisorEffort, readonly: true },
+    },
+    profileKey,
+    createdAt: '2026-08-08T00:00:00.000Z',
+    updatedAt: '2026-08-08T00:00:00.000Z',
+    pluginVersion: '0.5.0',
+  };
+  writeFileSync(
+    join(data, 'config.json'),
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        activeProfile: profileKey,
+        profiles: { [profileKey]: profile },
+      },
+      null,
+      2
+    )}\n`
+  );
+}
+
+test('migration requires exact preview and leaves managed files unchanged', async () => {
+  writeLegacyConfig({ routineEffort: 'Max', advisorEffort: 'xHigh' });
+  const before = readFileSync(join(data, 'config.json'), 'utf8');
+  const preview = (await callTool('preview_configuration_migration')) as any;
+  expect(readFileSync(join(data, 'config.json'), 'utf8')).toBe(before);
+  await expect(
+    callTool('apply_configuration_migration', { confirmationToken: 'wrong' })
+  ).rejects.toThrow('exact unexpired one-time migration preview');
+  const applied = (await callTool('apply_configuration_migration', {
+    confirmationToken: preview.confirmationToken,
+  })) as any;
+  expect(applied.preferences.roles.routine.effort).toBe('max');
+  expect(applied.preferences.roles.advisor.effort).toBe('xhigh');
+  expect(existsSync(join(data, 'backups'))).toBe(true);
+});
+```
+
+- [ ] **Step 6: Run migration and server tests**
+
+Run:
+
+```bash
+bun test plugins/sol-advisor/mcp/migration.test.ts plugins/sol-advisor/mcp/server.test.ts
+```
+
+Expected: PASS, including tool count updated from 8 to 10.
+
+- [ ] **Step 7: Commit migration flow**
+
+```bash
+git add plugins/sol-advisor/mcp/migration.ts plugins/sol-advisor/mcp/migration.test.ts plugins/sol-advisor/mcp/server.ts plugins/sol-advisor/mcp/server.test.ts
+git commit -m "feat: add confirmed Sol Advisor configuration migration"
+```
+
+---
+
+### Task 5: Render and validate capability-bound adapters
+
+**Files:**
+
+- Modify: `plugins/sol-advisor/mcp/server.ts:120-155,280-310`
+- Modify: `plugins/sol-advisor/mcp/server.test.ts:75-130`
+
+**Interfaces:**
+
+- Consumes: persisted v2 profile and live capability probe.
+- Produces: `validateLiveConfiguration()`, stale-capability status,
+  capability-bound preview digest, and run-scoped fast-mode warning.
+
+- [ ] **Step 1: Add failing rendering and stale-evidence tests**
+
+```ts
+test('renders canonical ultra but never a per-agent fast field', async () => {
+  const input = base('codex') as any;
+  input.roles.advisor.effort = 'ultra';
+  input.runDefaults = { serviceMode: 'fast' };
+  await callTool('save_preferences', input);
+  const preview = (await callTool('render_client_adapter', {
+    workspace,
+  })) as any;
+  const advisor = preview.files.find((file: any) => file.role === 'advisor');
+  expect(advisor.content).toContain('model_reasoning_effort = "ultra"');
+  expect(advisor.content).not.toMatch(/fast|service_tier/);
+  expect(preview.warnings).toContain(
+    'Codex fast mode is run-scoped; generated role files inherit the parent run service mode.'
+  );
+});
+
+test('marks a profile stale when a selected binding disappears', async () => {
+  const input = base('codex') as any;
+  input.roles.advisor.effort = 'ultra';
+  input.runDefaults = { serviceMode: 'fast' };
+  await callTool('save_preferences', input);
+  __setCapabilityProbeForTests(async () => ({
+    ...codexSnapshot,
+    digest: 'changed',
+    models: { ...codexSnapshot.models, 'gpt-5.6-sol': { efforts: ['high'] } },
+  }));
+  const result = (await callTool('validate_configuration', {
+    workspace,
+  })) as any;
+  expect(result.status).toBe('stale-capability');
+  expect(result.valid).toBe(false);
+  expect(result.detail).toContain('gpt-5.6-sol does not report effort ultra');
+});
+```
+
+- [ ] **Step 2: Run focused tests and verify failure**
+
+Run:
+
+```bash
+bun test plugins/sol-advisor/mcp/server.test.ts --filter "canonical ultra|selected binding disappears"
+```
+
+Expected: FAIL because rendering does not know v2 service mode and validation
+does not reprobe.
+
+- [ ] **Step 3: Bind rendering to v2 capability evidence**
+
+Keep existing TOML rendering for model and `model_reasoning_effort`. Add no
+fast-mode field. Add this warning when `runDefaults.serviceMode === "fast"`:
+
+```ts
+warnings.push(
+  'Codex fast mode is run-scoped; generated role files inherit the parent run service mode.'
+);
+```
+
+Include `capabilityEvidence.digest` and `runDefaults` in `planDigest`, so a
+catalog or service-mode change invalidates an old installation token.
+
+- [ ] **Step 4: Reprobe before validation and adapter preview**
+
+```ts
+async function validateLiveConfiguration(
+  preferences: PreferencesV2
+): Promise<string[]> {
+  if (preferences.client !== 'codex') return [];
+  const live = await capabilityProbe();
+  const errors = (Object.keys(preferences.roles) as RoleName[]).flatMap(
+    (role) => {
+      const selected = preferences.roles[role];
+      return validateCodexBinding(live, selected.model, selected.effort).map(
+        (message) => `roles.${role}: ${message}`
+      );
+    }
+  );
+  errors.push(
+    ...validateServiceMode(live, preferences.runDefaults.serviceMode, 'run')
+  );
+  return errors;
+}
+```
+
+`validate_configuration` returns `status: "stale-capability"` and no preview
+when these errors exist. `render_client_adapter` refuses with the same detail. A
+digest change that leaves every selected binding supported is recorded as
+refreshed evidence during the next explicit save; it does not invalidate solely
+because unrelated catalog entries changed.
+
+- [ ] **Step 5: Verify installed-file mismatch remains visible after migration**
+
+```ts
+test('migration exposes managed adapter drift until confirmed reinstall', async () => {
+  writeLegacyConfig({ routineEffort: 'high', advisorEffort: 'high' });
+  const oldPreview = (await callTool('render_client_adapter', {
+    workspace,
+  })) as any;
+  await callTool('install_client_adapter', {
+    workspace,
+    confirmationToken: oldPreview.confirmationToken,
+  });
+  writeLegacyConfig({ routineEffort: 'Max', advisorEffort: 'xHigh' });
+  const migration = (await callTool('preview_configuration_migration')) as any;
+  await callTool('apply_configuration_migration', {
+    confirmationToken: migration.confirmationToken,
+  });
+  const stale = (await callTool('validate_configuration', {
+    workspace,
+  })) as any;
+  expect(stale.valid).toBe(false);
+  expect(stale.detail).toContain(
+    'managed adapter differs from active preferences'
+  );
+  const replacement = (await callTool('render_client_adapter', {
+    workspace,
+  })) as any;
+  await callTool('install_client_adapter', {
+    workspace,
+    confirmationToken: replacement.confirmationToken,
+  });
+  expect(
+    (await callTool('validate_configuration', { workspace })) as any
+  ).toMatchObject({
+    status: 'ready',
+    valid: true,
+  });
+});
+```
+
+- [ ] **Step 6: Run all MCP tests**
+
+Run:
+
+```bash
+bun test plugins/sol-advisor/mcp/contracts.test.ts plugins/sol-advisor/mcp/codex-capabilities.test.ts plugins/sol-advisor/mcp/migration.test.ts plugins/sol-advisor/mcp/server.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit adapter validation**
+
+```bash
+git add plugins/sol-advisor/mcp/server.ts plugins/sol-advisor/mcp/server.test.ts
+git commit -m "feat: bind Sol Advisor adapters to live capabilities"
+```
+
+---
+
+### Task 6: Update setup, orchestration guidance, version, and release gates
+
+**Files:**
+
+- Modify: `plugins/sol-advisor/skills/setup/SKILL.md:1-55`
+- Modify: `plugins/sol-advisor/skills/orchestration/SKILL.md:1-190`
+- Modify: `README.md:1-150`
+- Modify: `CHANGELOG.md:5-18`
+- Modify: `package.json:1-20`
+- Modify: `plugins/sol-advisor/plugin.json:1-16`
+- Modify: `plugins/sol-advisor/.codex-plugin/plugin.json:1-16`
+- Modify: `plugins/sol-advisor/mcp/server.ts:240-330`
+- Modify: `plugins/sol-advisor/scripts/verify.sh:1-180`
+
+**Interfaces:**
+
+- Consumes: completed v2 tools and behavior from Tasks 1-5.
+- Produces: exact setup instructions, runtime observation contract, consistent
+  minor release version, and CI assertions.
+
+- [ ] **Step 1: Add failing release-script assertions**
+
+Add checks to `verify.sh` before changing prose:
+
+```sh
+grep -Fq 'canonical `ultra`' "$plugin_dir/skills/setup/SKILL.md" || fail "setup does not permit capability-backed ultra"
+grep -Fq 'fast mode is run-scoped' "$plugin_dir/skills/setup/SKILL.md" || fail "setup does not explain fast-mode scope"
+grep -Fq 'stale-capability' "$plugin_dir/skills/orchestration/SKILL.md" || fail "orchestration does not fail closed on stale capability"
+grep -Fq 'preview_configuration_migration' "$plugin_dir/skills/setup/SKILL.md" || fail "setup omits migration preview"
+```
+
+- [ ] **Step 2: Run verification and confirm documentation assertions fail**
+
+Run:
+
+```bash
+sh plugins/sol-advisor/scripts/verify.sh
+```
+
+Expected: FAIL at the first newly added guidance assertion.
+
+- [ ] **Step 3: Update setup skill with exact user flow**
+
+Add these requirements in normal prose:
+
+```markdown
+- For Codex, call the capability probe before presenting effort choices. Offer
+  only efforts reported for the selected model. Canonical `ultra` is valid when
+  that exact model reports it; never offer or save Luna / `ultra` when Luna does
+  not.
+- Ask for run service mode separately: `inherit`, `default`, or `fast`. Codex
+  fast mode is run-scoped unless live capability evidence proves a role-scoped
+  binding. Fast mode does not reduce reasoning effort or verification policy.
+- When setup status is `schema-old`, call `preview_configuration_migration`,
+  show every before/after change and the full candidate profile, and call
+  `apply_configuration_migration` only after the user repeats its exact one-time
+  token.
+```
+
+- [ ] **Step 4: Update orchestration skill with runtime observation rules**
+
+Add this exact contract:
+
+```markdown
+Before roster approval, show each role's exact model and effort plus the run's
+observed service mode. A run-scoped fast-mode selection is inherited context,
+not a per-role pin. If configuration status is `stale-capability`, stop before
+dispatch and route to setup. Never claim role-scoped fast mode from run-level
+evidence, and never weaken verification because fast mode is active.
+```
+
+- [ ] **Step 5: Update README and changelog**
+
+Document:
+
+- v2 profile shape and exact casing;
+- current model-specific `ultra` behavior;
+- Luna's current lack of `ultra` in the local Codex catalog;
+- fast mode as independent, run-scoped, and optional;
+- two-step preview/apply migration;
+- adapter re-preview after a migrated preference changes generated content.
+
+In `CHANGELOG.md`, add under `Unreleased`:
+
+```markdown
+### Added
+
+- Capability-aware Codex model/effort validation, including model-gated `ultra`
+  reasoning and independent run-scoped fast mode.
+- Explicit preview-and-confirm migration for legacy mixed-case effort values.
+
+### Changed
+
+- Sol Advisor profiles now use schema v2 and retain capability evidence for
+  fail-closed adapter validation.
+```
+
+- [ ] **Step 6: Apply version `0.6.0` consistently**
+
+Set `0.6.0` in `package.json`, both plugin manifests, persisted `pluginVersion`,
+JSON-RPC `serverInfo.version`, release checks, and README examples. If
+repository HEAD is no longer `0.5.x` when execution begins, stop this task and
+report the version conflict rather than guessing a replacement.
+
+- [ ] **Step 7: Run formatter, focused tests, and complete CI**
+
+Run:
+
+```bash
+bun test plugins/sol-advisor/mcp/contracts.test.ts plugins/sol-advisor/mcp/codex-capabilities.test.ts plugins/sol-advisor/mcp/migration.test.ts plugins/sol-advisor/mcp/server.test.ts
+bun run ci
+git diff --check
+```
+
+Expected: every test and release gate passes; `git diff --check` prints nothing.
+
+- [ ] **Step 8: Inspect scope before commit**
+
+Run:
+
+```bash
+git status --short
+git diff --name-only
+```
+
+Expected: only files listed by this plan are modified;
+`.codex-marketplace-install.json` remains untracked and unstaged.
+
+- [ ] **Step 9: Commit completed capability foundation**
+
+```bash
+git add package.json README.md CHANGELOG.md plugins/sol-advisor
+git commit -m "feat: add capability-aware Sol Advisor configuration"
+```
+
+## Completion Evidence
+
+Phase is complete only when all statements below are proven by fresh output:
+
+- `bun run ci` passes in `/Users/nikhil/.codex/.tmp/marketplaces/sol-advisor`.
+- A fresh Codex v2 profile accepts Sol or Terra with canonical `ultra` when
+  reported by the live catalog.
+- Same profile rejects Luna with `ultra` while Luna lacks that capability.
+- Mixed-case `Max` and `xHigh` fail fresh-profile validation.
+- Existing mixed-case v1 values change only after exact preview and one-time
+  confirmation.
+- Fast mode saves as a run-scoped service choice and does not appear in
+  generated role TOML.
+- Fast mode does not change model, effort, assurance, authority, or evidence
+  policy.
+- A removed selected capability produces `stale-capability` and blocks adapter
+  rendering.
+- Existing adapter transaction, rollback, ownership, symlink, and recovery tests
+  still pass.
+- No unrelated or user-owned files are staged.
+
+## Deferred Follow-On Plans
+
+This phase intentionally stops before roster schema and execution-controller
+work. After this foundation ships, create separate implementation plans for:
+
+1. versioned roster manifest, autonomy envelope, skills, A0-A3, and E0-E4 policy
+   materialization;
+2. event-sourced ledger, deterministic convergence controller, circuit states,
+   idempotency, and safe resumption;
+3. model-directed dispatch, script fan-out, bounded reduction, reviewer
+   independence, and primary acceptance.
+
+Each follow-on plan must consume the capability evidence and service-mode
+contracts defined here rather than reimplementing model or effort validation.

--- a/docs/superpowers/specs/2026-08-09-sol-advisor-orchestration-control-plane-design.md
+++ b/docs/superpowers/specs/2026-08-09-sol-advisor-orchestration-control-plane-design.md
@@ -178,11 +178,26 @@ Each slot declares:
 - ad hoc specialty contract;
 - exact client-native model ID;
 - canonical reasoning effort;
+- requested service mode and its enforcement scope;
 - baseline skills;
 - action-specific skills;
 - reviewer lineage and independence requirements.
 
 The roster exposes these values for user modification before approval.
+
+Reasoning effort and service mode remain independent. `ultra` is permissible for
+a Codex role only when the selected model's live Codex capability catalog
+reports `ultra`; current capability evidence must therefore accept it for
+supporting Sol and Terra models and reject it for Luna unless Luna later reports
+support. This Codex-native token must not be conflated with the public API's
+reasoning-effort vocabulary.
+
+Fast mode is also permissible. It is a latency/service choice, not an assurance
+downgrade, and cannot silently reduce the selected reasoning effort, proof tier,
+or reviewer obligation. When Codex exposes fast mode only at the parent session
+or run level, roster slots record `inherit` plus observed run-level capability
+instead of claiming an unenforceable per-agent setting. A future host-native
+per-agent binding may be used only after capability evidence proves it.
 
 ### Axis 4: runtime envelope
 
@@ -245,6 +260,7 @@ The run-level record contains:
 - canonical workspace and base revision;
 - approval status, manifest hash, approver, and timestamp;
 - editable policy defaults;
+- run-level service mode, including supported Codex fast mode;
 - autonomy envelope;
 - compatibility and capability evidence from the host.
 
@@ -276,6 +292,8 @@ routing
 model_binding
   exact_model_id
   canonical_effort
+  service_mode: inherit | default | fast
+  service_mode_scope: run | role
   selection_source
   host_validation_evidence
 
@@ -526,6 +544,7 @@ including:
 - required skill;
 - exact model ID;
 - canonical effort token;
+- supported service mode at its declared enforcement scope;
 - runtime authority source;
 - ownership boundary;
 - dependency evidence;
@@ -548,6 +567,18 @@ Fresh Codex profiles accept only canonical tokens reported or supported by the
 Codex adapter. Unsupported casing fails configuration preview before any file is
 installed.
 
+Capability validation is model-specific rather than one global effort enum. A
+Codex profile may select canonical `ultra` for a role whose resolved model
+reports that effort. It must reject the same value for a model that does not
+report it. The adapter records the model-catalog evidence used for that
+decision, so a later catalog change can mark an affected roster stale.
+
+The schema also permits `service_mode: fast`. Fast mode is validated separately
+from model effort. If the host exposes it only as a run-level capability, the
+adapter stores it in the run envelope and requires role slots to inherit it. It
+must neither inject an unsupported per-agent field nor describe fast mode as
+changing A-tier, E-class, or reasoning effort.
+
 Existing v1 profiles do not change silently. Migration must either:
 
 1. present an explicit preview showing each legacy value and proposed canonical
@@ -566,6 +597,8 @@ managed hashes disagreeing without validation reporting the mismatch.
 - schema parsing and unknown-field rejection;
 - canonical manifest and node hashes;
 - exact model and effort validation;
+- model-specific `ultra` capability validation;
+- fast-mode validation independent of effort and assurance;
 - A0-A3 evidence-policy materialization;
 - E0-E4 batchability and approval classification;
 - finding fingerprint canonicalization and versioning;
@@ -581,6 +614,7 @@ managed hashes disagreeing without validation reporting the mismatch.
 - conditional-slot activation;
 - consolidated and isolated approval deltas;
 - missing roles, skills, models, efforts, and host capabilities;
+- unsupported per-role fast-mode claims and stale capability evidence;
 - worker attempts to spawn nested agents;
 - forged or incomplete independence metadata.
 
@@ -617,6 +651,15 @@ completion without required evidence.
 Tests must prove that legacy `Max` and `xHigh` values cannot silently render
 into Codex TOML. Fresh profiles accept canonical lowercase values. Migration is
 previewed and confirmed or fails closed.
+
+### Required routing-mode regressions
+
+Tests must prove that canonical `ultra` is accepted for models whose current
+Codex catalog reports it and rejected for models that do not. Tests must also
+prove that fast mode can be selected or inherited without changing reasoning
+effort, assurance tier, authority class, or acceptance evidence, and that the
+adapter never claims per-role fast-mode enforcement when only run-level support
+is observable.
 
 ## Acceptance gates
 
@@ -658,6 +701,10 @@ continue to work until the new adapter is explicitly configured and approved.
 - Quality is preferred over speed, except when richer routing is unambiguously
   unnecessary.
 - The user approves the initial roster and may edit model and effort per slot.
+- Canonical `ultra` reasoning is permissible when the selected model's live
+  Codex capability catalog supports it.
+- Codex fast mode is permissible as an independent service choice; it never
+  weakens effort, assurance, authority, or acceptance policy.
 - Ad hoc specialists are allowed through base-role plus task-and-skill
   composition.
 - Specialists cannot spawn subagents.

--- a/docs/superpowers/specs/2026-08-09-sol-advisor-orchestration-control-plane-design.md
+++ b/docs/superpowers/specs/2026-08-09-sol-advisor-orchestration-control-plane-design.md
@@ -1,0 +1,677 @@
+---
+status: ACTIVE
+audience: agents
+last_updated: 2026-08-09
+owner: Developer Experience
+review_cadence: P90D
+categories: [ai-automation, orchestration, design]
+keywords: [sol-advisor, agents, routing, ledger, approval, recovery]
+---
+
+# Sol Advisor Orchestration Control Plane Design
+
+Date: 2026-08-09 Status: Approved by user Target: Sol Advisor plugin after
+v0.5.0 Scope: orchestration configuration, roster approval, routing, execution
+control, evidence, recovery, and verification
+
+## Summary
+
+Sol Advisor will evolve from three static role bindings into a user-approved,
+quality-first orchestration control plane. The primary session converts an
+approved plan into an editable roster manifest. Each roster slot exposes its
+role, exact model, reasoning effort, skills, ownership, execution topology,
+assurance tier, authority and effects class, runtime envelope, and acceptance
+policy.
+
+The user approves the initial roster and autonomy envelope. The primary may then
+make reversible execution refinements within those boundaries, including
+resequencing work, adjusting concurrency, activating preapproved conditional
+slots, and issuing same-lane corrections. Any material change to scope,
+ownership, permissions, skills, model ceiling, authority, effects, or resource
+envelope returns as a consolidated delta for approval.
+
+Specialists cannot spawn subagents. The primary owns every dispatch, correction,
+checker, state transition, and acceptance decision. Optional Luna pair-checkers
+are visible sibling roster entries, not hidden nested agents. Script-directed
+fan-out is available for embarrassingly parallel work, but execution scale
+remains independent from assurance level.
+
+## Problem
+
+Sol Advisor v0.5.0 has three configured native roles:
+
+- routine implementation;
+- high-complexity implementation;
+- read-only advisor.
+
+This is insufficient for plan-derived specialist teams. It also leaves several
+control-plane responsibilities implicit:
+
+- role specialization is coarse and static;
+- skill selection is not part of the approved roster contract;
+- model and effort choices are not visible per task;
+- routine versus high routing combines task type, risk, and cost in one
+  decision;
+- worker correction has no durable convergence state;
+- evidence provenance is described but not enforced by schema;
+- batch fan-out would overwhelm the primary context if every result re-entered
+  it;
+- run recovery is not represented as a resumable dependency graph;
+- user approval boundaries are not encoded as machine-checkable policy;
+- free-form effort strings allow invalid casing such as `Max` and `xHigh` to
+  reach generated Codex profiles.
+
+## Goals
+
+1. Prefer higher output quality while avoiding clearly unnecessary model or
+   review cost.
+2. Give the user one editable initial roster with exact model and effort
+   visibility.
+3. Permit ad hoc specialists composed from installed base roles, task contracts,
+   and approved skills.
+4. Keep all orchestration centralized in the primary session.
+5. Allow automatic corrections when role, model, effort, skills, ownership,
+   scope, effects, and acceptance obligations remain unchanged.
+6. Separate execution topology, assurance, model assignment, runtime policy,
+   acceptance, and authority into independent axes.
+7. Support script-directed fan-out without loading unbounded raw results into
+   primary context.
+8. Make convergence, retries, circuit breaking, provenance, and state
+   transitions deterministic.
+9. Resume interrupted runs from the smallest invalid dependency subgraph without
+   double-applying side effects.
+10. Fail closed when required models, efforts, roles, skills, isolation,
+    evidence, or host capabilities are unavailable.
+
+## Non-goals
+
+- Specialists do not create their own subagents.
+- The plugin does not silently substitute models, roles, effort levels, or
+  skills.
+- The plugin does not invent retry counts, timeouts, budgets, concurrency
+  limits, or other numeric policy.
+- The plugin does not store narrative session journals in the repository.
+- The plugin does not treat model disagreement as authority; models propose
+  findings, while the controller applies policy.
+- Fan-out does not imply lower assurance.
+- Model diversity is not claimed when the host cannot prove it.
+- Prompt-only hosts do not gain false enforcement guarantees.
+
+## Design principles
+
+### User control with bounded autonomy
+
+The user approves a roster and an autonomy envelope, not every implementation
+detail. Within that envelope, the primary may:
+
+- reorder independent nodes;
+- adjust concurrency within an approved resource policy;
+- activate a predeclared conditional roster slot;
+- create another runtime instance of an already-approved slot when ownership,
+  permissions, model, effort, skills, effects, and budget remain identical;
+- issue corrections to the same slot for the same acceptance criteria.
+
+The primary must request a consolidated delta approval when a change affects:
+
+- objective or acceptance criteria;
+- files, modules, systems, or data ownership;
+- role, model, effort, required skill, or tool capability;
+- permissions, sandbox expectation, external side effect, or authority class;
+- assurance tier or reviewer-independence requirement;
+- approved runtime or cost envelope;
+- substitution of any roster slot.
+
+Safe unaffected nodes may continue while a delta awaits approval when their
+inputs, outputs, ownership, and dependencies do not intersect the changed
+boundary.
+
+### Quality-first, evidence-scaled routing
+
+Quality remains the default. Lower-cost routing is allowed only when hard policy
+rules classify the work as unambiguously bounded and low risk. Every roster
+entry contains a human-readable routing rationale. A model judgment may propose
+a route, but the controller validates that route against the approved policy
+matrix.
+
+### Positive convergence
+
+Execution continues while objective-relevant blocking findings remain
+unresolved, evidence is materially improving, and the approved resource envelope
+remains open. Execution completes when the contract is proven. Non-blocking
+findings remain in the ledger but do not prolong work. The controller opens the
+circuit when progress stops, work oscillates, verification regresses, a boundary
+changes, or an authorized budget is exhausted.
+
+## Six-axis policy matrix
+
+Triage produces six independent policy dimensions for every node.
+
+### Axis 1: execution topology
+
+- `direct`: the primary performs trivial or read-only work and proves it inline;
+- `model_directed`: one approved specialist receives a complete task packet;
+- `script_fanout`: a deterministic controller emits shard packets and aggregates
+  results outside primary context.
+
+Topology describes where work runs and where raw results live. It does not
+determine trust or proof requirements.
+
+### Axis 2: assurance
+
+| Tier | Name        | Evidence obligation                                                                                                                        |
+| ---- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| A0   | Basic       | Primary inline proof or deterministic tool evidence; no independent model review.                                                          |
+| A1   | Standard    | Producer output plus primary validation of acceptance-critical evidence.                                                                   |
+| A2   | Guarded     | Independent risk-targeted checker; model diversity recommended when available and approved.                                                |
+| A3   | Adversarial | Blind worker/refuter validation with required model-family diversity. Unavailable diversity blocks A3 or requires an approved tier change. |
+
+A Luna sibling checker is the lightweight A2 pattern. A3 may use independent
+worker and refuter sets. Convergence means no unresolved objective-relevant
+blocking finding and satisfied evidence obligations, not unanimous model
+agreement.
+
+### Axis 3: assignments
+
+Each slot declares:
+
+- installed base role;
+- ad hoc specialty contract;
+- exact client-native model ID;
+- canonical reasoning effort;
+- baseline skills;
+- action-specific skills;
+- reviewer lineage and independence requirements.
+
+The roster exposes these values for user modification before approval.
+
+### Axis 4: runtime envelope
+
+Every node declares:
+
+- runtime ceiling;
+- authority source for that ceiling;
+- retry or correction budget, when one exists;
+- authority source for each numeric value;
+- timeout action;
+- resource and concurrency bounds;
+- cancellation, checkpoint, and recovery behavior.
+
+Numeric values must come from the user, project policy, host contract, tool
+contract, or measured evidence. The controller does not create defaults by
+intuition.
+
+### Axis 5: acceptance
+
+Acceptance policy specifies:
+
+- acceptance-critical claims;
+- required checks and artifacts;
+- provenance coverage;
+- independent-validation obligations;
+- primary context-admission rules;
+- reviewer topology;
+- completion and residual-risk rules.
+
+Evidence obligations scale by A-tier. The primary remains the sole acceptor, but
+acceptance need not require another expensive inference pass. It may validate
+durable deterministic evidence when policy permits.
+
+### Axis 6: authority and effects
+
+| Class | Name              | Meaning                                                                                | Batch policy                                                            |
+| ----- | ----------------- | -------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| E0    | Observe           | No mutation.                                                                           | Batchable within approved resources.                                    |
+| E1    | Local reversible  | Isolated, disjoint workspace or artifact changes.                                      | Batchable with ownership proof.                                         |
+| E2    | Shared controlled | Idempotent or compensatable persistent effects.                                        | Conditionally batchable under explicit concurrency and recovery policy. |
+| E3    | Consequential     | External or shared effects with material blast radius.                                 | Serial execution and separate delta approval.                           |
+| E4    | Protected         | Irreversible, destructive, credential, legal, financial, or security-sensitive action. | Never batched; action-time confirmation or handoff.                     |
+
+Batchability is derived from E-class, dependency coupling, idempotency,
+ownership, and host capability. It is not derived from the numeric class alone.
+Eligible E0-E2 boundary changes may appear in one consolidated delta approval.
+E3 and E4 changes remain isolated.
+
+## Roster manifest
+
+The approved roster is a versioned execution contract.
+
+### Run envelope
+
+The run-level record contains:
+
+- schema version;
+- run identity;
+- plan identity, version, objective, and content hash;
+- canonical workspace and base revision;
+- approval status, manifest hash, approver, and timestamp;
+- editable policy defaults;
+- autonomy envelope;
+- compatibility and capability evidence from the host.
+
+### Roster slot
+
+Each active or conditional slot contains:
+
+```text
+identity
+  slot_id
+  activation: active | conditional
+  installed_base_role
+  ad_hoc_specialty
+
+task
+  objective
+  ownership
+  interfaces
+  constraints
+  dependencies
+  acceptance_criteria
+
+routing
+  topology
+  assurance_tier
+  authority_effects_class
+  rationale
+
+model_binding
+  exact_model_id
+  canonical_effort
+  selection_source
+  host_validation_evidence
+
+skills[]
+  name
+  source
+  version_or_hash
+  policy: baseline | action
+  required
+
+runtime
+  ceiling
+  ceiling_source
+  correction_budget
+  budget_source
+  timeout_outcome
+
+activation_policy
+  predicate
+  autonomy_bounds
+  replacement_policy
+```
+
+Every specialist packet explicitly forbids nested delegation. The primary alone
+activates slots, instantiates workers, adds checkers, and dispatches
+corrections.
+
+### Skill binding
+
+Baseline skills are attached by the proposed specialty. For example, a
+bug-fixing specialist may receive systematic debugging, while a test specialist
+may receive test-driven development. Action-specific skills are attached only to
+the task packet that needs them.
+
+The roster exposes every skill before approval. A worker must read each required
+skill before taking task action. Missing, unreadable, incompatible, or
+unavailable required skills fail the lane. Skills cannot authorize broader scope
+or delegation than the approved roster.
+
+### Controller-derived fields
+
+The controller derives, validates, and records:
+
+- canonical node hash;
+- batchability decision and reason;
+- materialized evidence obligation;
+- reviewer topology;
+- idempotency scope;
+- approval delta classification;
+- dependency closure;
+- current state version.
+
+Derived safety fields are not directly editable. A user changes their source
+policy, then reviews the recomputed manifest preview.
+
+## Script-directed fan-out
+
+Fan-out is selected for repeated, independent transformations with a
+deterministic partitioning and reduction contract.
+
+The controller creates a stable shard manifest. Each manifest entry contains a
+shard identity, input identity, ownership boundary, operation, operation
+version, expected output schema, and idempotency scope. Workers receive bounded
+packets. Per-item output, failure, evidence, and effect receipts remain in the
+ledger runtime.
+
+The reducer returns only:
+
+- bounded aggregate results;
+- completion and failure counts;
+- acceptance-claim coverage;
+- exception references;
+- artifact and evidence manifests;
+- unresolved blocking findings.
+
+The primary context does not receive every raw item by default. Summary bounds
+must come from approved policy. Full artifacts remain available by reference for
+targeted inspection.
+
+## Reviewer independence
+
+Independence is structured lineage, not a Boolean flag. The ledger records:
+
+- validator identity and role;
+- model ID, model family, and provider when observable;
+- task, prompt, and context lineage;
+- whether worker output or only source artifacts were visible;
+- artifact and evidence lineage;
+- thread relationship;
+- review method;
+- resulting findings and verdict.
+
+A2 recommends model-family diversity when it is available and approved. A3
+requires blind model-diverse review. If the host cannot provide or prove the
+configured independence, the controller blocks A3 and requests an approved
+policy change; it does not silently weaken the tier.
+
+## Deterministic convergence controller
+
+Models may propose structured findings. They do not own retry counters, budgets,
+fingerprints, circuit state, or acceptance transitions.
+
+The controller computes a versioned finding fingerprint from:
+
+- criterion identity and version;
+- artifact identity and hash;
+- normalized location;
+- failure type.
+
+The ledger tracks finding states such as open, resolved, reopened, and
+superseded. Repeated fingerprints indicate stasis. Alternating fingerprints at
+the same criterion and location indicate oscillation. A correction remains
+automatic only while its slot, task, ownership, model, effort, skills, effects,
+acceptance criteria, and resource envelope remain approved.
+
+The circuit state is:
+
+```text
+CLOSED -> OPEN -> HALF_OPEN -> CLOSED | OPEN
+```
+
+`OPEN` prevents broad redispatch. `HALF_OPEN` permits the minimal authorized
+probe set. Successful, independently validated probe evidence closes the
+circuit. Repeated or new blocking failure reopens it. Probe size and budgets
+come from approved policy rather than hard-coded counts.
+
+## Runtime state machine
+
+### Happy path
+
+```text
+PENDING
+  -> READY
+  -> RUNNING
+  -> OUTPUT_RECORDED
+  -> VALIDATING
+  -> ACCEPTED
+```
+
+### Correction path
+
+```text
+VALIDATING
+  -> CORRECTION_READY
+  -> RUNNING
+  -> OUTPUT_RECORDED
+  -> VALIDATING
+```
+
+The controller may repeat this path only while findings materially change and
+the approved envelope remains open.
+
+### Crash and uncertainty path
+
+```text
+RUNNING
+  -> INTERRUPTED_UNCERTAIN
+  -> RECONCILING
+  -> READY | HALF_OPEN | APPROVAL_PAUSED | HALTED
+```
+
+### Drift path
+
+An accepted node becomes `STALE` when its plan, roster, workspace, dependency,
+skill, model capability, input, or artifact hash changes. The controller
+invalidates the affected dependency closure, preserves unrelated verified nodes,
+and resumes from the earliest dirty or unaccepted node.
+
+### Approval path
+
+A boundary change moves affected active nodes to `APPROVAL_PAUSED`. Safe
+independent nodes may continue. The controller presents one eligible
+consolidated delta while keeping E3 and E4 approvals isolated.
+
+## Controller transactions
+
+Only the controller changes durable state. Every transition performs these
+steps:
+
+1. Compare expected run, roster, node, and state versions.
+2. Validate the transition table, approved packet hash, dependencies, A-tier,
+   E-class, and authorized budgets.
+3. Atomically claim the dispatch or idempotency key.
+4. Append an immutable event with prior state, next state, actor, reason,
+   evidence, fingerprint, and receipts.
+5. Update the materialized node snapshot using optimistic locking.
+6. Dispatch work only after durable commit.
+
+Duplicate delivery resolves through the claimed key. Concurrent state updates
+fail the version check and must reload current state before proposing another
+transition.
+
+The persistence implementation sits behind a `RunStore` boundary. It must
+support transactions, unique idempotency constraints, immutable events,
+optimistic versions, and durable recovery. The design does not require an
+external database dependency.
+
+## Ledger, provenance, and idempotency
+
+The runtime ledger stores:
+
+- plan and roster versions;
+- node states and state versions;
+- canonical task packets;
+- input, artifact, diff, and dependency hashes;
+- producer reports;
+- validator evidence and independence lineage;
+- findings and fingerprints;
+- approval records;
+- dispatch and correction records;
+- effect receipts;
+- idempotency claims;
+- timeout, stop, and recovery reasons.
+
+The idempotency key is derived from run identity, plan version, node identity,
+shard manifest entry, operation, and operation version. The controller claims it
+atomically before an effect. The receipt records completion state and output
+identity.
+
+Before replaying a dirty side-effecting node, the controller checks its receipt,
+E-class, idempotency contract, and completion certainty. Uncertain or
+non-idempotent work requires reconciliation, compensation, explicit delta
+approval, or user handoff. It is never retried merely because the prior worker
+disappeared.
+
+## Data flow
+
+1. The primary converts an approved plan into a proposed roster manifest.
+2. The user edits and approves the manifest and autonomy envelope.
+3. The controller validates host capabilities and compiles a versioned DAG.
+4. Ready nodes are selected by dependencies, batchability, and authorized
+   resources.
+5. Model-directed nodes receive one complete task packet; fan-out nodes receive
+   shard packets from a stable manifest.
+6. Workers write artifacts, reports, and receipts to the ledger runtime.
+7. Validators record evidence, lineage, and finding fingerprints.
+8. The reducer returns a bounded summary and exception channel.
+9. The primary accepts a node only after its A-tier obligation is satisfied.
+10. The controller checkpoints accepted state and activates newly ready nodes.
+
+## Fail-closed behavior
+
+Dispatch is refused when any required condition is missing or invalid,
+including:
+
+- approved manifest or matching packet hash;
+- installed role;
+- required skill;
+- exact model ID;
+- canonical effort token;
+- runtime authority source;
+- ownership boundary;
+- dependency evidence;
+- reviewer obligation;
+- required model diversity;
+- sandbox or host capability;
+- idempotency or recovery contract for side effects.
+
+The plugin does not normalize, substitute, lower assurance, broaden permissions,
+or retry invisibly.
+
+## Configuration migration and effort casing
+
+The configuration schema advances from v1 to a new version that validates
+client-native effort vocabularies. Current v1 free-form strings allowed values
+such as `Max` and `xHigh`, while Codex native role files require canonical
+lowercase values.
+
+Fresh Codex profiles accept only canonical tokens reported or supported by the
+Codex adapter. Unsupported casing fails configuration preview before any file is
+installed.
+
+Existing v1 profiles do not change silently. Migration must either:
+
+1. present an explicit preview showing each legacy value and proposed canonical
+   value, then apply only after user confirmation; or
+2. mark the profile stale and require reconfiguration when a correction cannot
+   be proven safely.
+
+Generated files and managed-file hashes update in the same confirmed adapter
+transaction. A manual edit cannot leave saved preferences, rendered files, and
+managed hashes disagreeing without validation reporting the mismatch.
+
+## Verification strategy
+
+### Pure contract tests
+
+- schema parsing and unknown-field rejection;
+- canonical manifest and node hashes;
+- exact model and effort validation;
+- A0-A3 evidence-policy materialization;
+- E0-E4 batchability and approval classification;
+- finding fingerprint canonicalization and versioning;
+- exhaustive state-transition table;
+- delta classification and autonomy-envelope checks.
+
+### Controller integration tests
+
+- optimistic-lock conflicts;
+- duplicate dispatch and duplicate effect delivery;
+- atomic event, snapshot, claim, and receipt writes;
+- correction, circuit-open, half-open, and probe paths;
+- conditional-slot activation;
+- consolidated and isolated approval deltas;
+- missing roles, skills, models, efforts, and host capabilities;
+- worker attempts to spawn nested agents;
+- forged or incomplete independence metadata.
+
+### End-to-end scenarios
+
+- model-directed specialist with baseline and action skills;
+- script fan-out with shard failure, bounded reduction, and exceptions;
+- A2 Luna sibling checker;
+- A3 blind model-diverse worker/refuter review;
+- crash recovery and earliest-dirty-node resumption;
+- E0-E2 consolidated approvals and E3-E4 isolated approvals;
+- stale workspace and dependency invalidation;
+- unavailable model diversity and approved tier change.
+
+### Failure injection
+
+Inject failures before and after each durable boundary:
+
+- before claim;
+- after claim;
+- before effect;
+- after effect;
+- before receipt;
+- after receipt;
+- before event append;
+- after event append but before snapshot;
+- after snapshot but before dispatch.
+
+Recovery must preserve unique effects, reconstruct state, and never claim
+completion without required evidence.
+
+### Required casing regression
+
+Tests must prove that legacy `Max` and `xHigh` values cannot silently render
+into Codex TOML. Fresh profiles accept canonical lowercase values. Migration is
+previewed and confirmed or fails closed.
+
+## Acceptance gates
+
+- **Dispatch gate:** no worker starts without an approved manifest, exact
+  bindings, required skills, ownership, runtime authority, and valid
+  dependencies.
+- **Acceptance gate:** no delegated node completes without its A-tier evidence
+  and provenance coverage.
+- **Recovery gate:** no dirty effect replays without receipt reconciliation and
+  an idempotency, compensation, approval, or handoff path.
+- **Context gate:** no fan-out pushes unbounded raw results into primary
+  context.
+- **Authority gate:** no ownership, permission, E-class, model ceiling, skill,
+  scope, or resource expansion bypasses delta approval.
+- **Completion gate:** execution stops when the objective is proven;
+  non-blocking findings do not prolong work.
+
+Performance and cost measurements inform future defaults. They are evidence, not
+gates or policy, unless an authoritative user, project, platform, tool, or
+measured contract makes them so.
+
+## Rollout
+
+1. Add the new logical schema and read-only migration preview.
+2. Add roster rendering and validation without dispatch.
+3. Add the deterministic controller and `RunStore` contract.
+4. Add model-directed execution with A0 and A1 acceptance.
+5. Add A2 sibling checking and automatic same-lane corrections.
+6. Add script-directed fan-out and bounded reduction.
+7. Add A3 adversarial review, model-diversity enforcement, and full recovery.
+8. Enable the new workflow only after contract, integration, failure-injection,
+   and migration tests pass.
+
+Each rollout stage remains fail closed. Existing v0.5.0 compatibility roles
+continue to work until the new adapter is explicitly configured and approved.
+
+## Approved decisions
+
+- Quality is preferred over speed, except when richer routing is unambiguously
+  unnecessary.
+- The user approves the initial roster and may edit model and effort per slot.
+- Ad hoc specialists are allowed through base-role plus task-and-skill
+  composition.
+- Specialists cannot spawn subagents.
+- Same-lane corrections are automatic within approved boundaries.
+- Luna pair-checkers are visible primary-owned siblings, not nested workers.
+- A record-keeper agent is rejected; the machine ledger provides the audit
+  trail.
+- Fan-out is an execution topology, not an assurance tier.
+- Primary context receives bounded summaries rather than every fan-out result.
+- Authority and effects use E0-E4 classes.
+- Assurance uses A0 Basic, A1 Standard, A2 Guarded, and A3 Adversarial.
+- Evidence obligations vary by assurance tier.
+- The controller, not a model, owns convergence state and budgets.
+- A3 requires model-diverse blind review; A2 recommends it when available.
+- Reviewer independence is structured lineage metadata.
+- The ledger is the idempotency-key and recovery source of truth.
+- Consolidated delta approval remains the response to approval fatigue.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -199,7 +199,23 @@ export default [
       // Unused imports and variables
       'no-unused-vars': 'off',
       '@typescript-eslint/no-unused-vars': 'off',
-      'unused-imports/no-unused-imports': 'error',
+      // NOTE: eslint-plugin-unused-imports does not implement its own "unused"
+      // detection -- both rules below borrow @typescript-eslint/no-unused-vars'
+      // rule object directly (see getBaseRule() in the plugin source) and run
+      // it with whatever options are passed to *this* rule entry. Options are
+      // NOT inherited from the sibling 'unused-imports/no-unused-vars' config.
+      // Without an explicit options object here, the auto-fixing rule ignores
+      // the repo's '^_' intentionally-unused convention and deletes those
+      // imports on --fix. Mirror the sibling rule's options so both agree.
+      'unused-imports/no-unused-imports': [
+        'error',
+        {
+          vars: 'all',
+          varsIgnorePattern: '^_',
+          args: 'after-used',
+          argsIgnorePattern: '^_',
+        },
+      ],
       'unused-imports/no-unused-vars': [
         'warn',
         {


### PR DESCRIPTION
## Description

Implements the near-term N1–N5 fixes from the 2026-08-10 usage-report synthesis (`~/.claude/usage-data/synthesis-2026-08-11.md`): repair dead/harmful hook config and add incident-backed policy. Goal: stop silent friction generators the synthesis confirmed as live bugs.

Three commits touch three in-repo files. **N2 and N5 are intentionally NOT in this PR** — they edit files under `~/.claude/` (global CLAUDE.md, codex-review skills), which are outside any git repo. See Non-Goals.

## Slice Summary

### Owned Files

- `.claude/settings.json` — **N1**: repoint `SessionStart` + `UserPromptSubmit` hooks from a hardcoded `C:/dev/Updog_restore/...` path (dead on darwin since the 2026-07-28 migration) to `${CLAUDE_PROJECT_DIR}/...`. **N3a**: change the `PostToolUse` Edit hook from `npm run lint:fix` (whole-repo auto-mutating `eslint . --fix` on every edit) to `npm run lint:eslint` (report-only).
- `eslint.config.js` — **N3b**: give `unused-imports/no-unused-imports` an explicit options object so it inherits the repo's `^_`-prefix ignore convention (the rule borrows `@typescript-eslint/no-unused-vars`' object but does NOT inherit the sibling rule's options; without this, `--fix` deletes intentionally-unused `_`-prefixed imports).
- `CLAUDE.md` — **N4**: two new bullets in `## Mandatory Pre-Action Checks` — commit-per-batch checkpoint discipline, and search-all-worktrees before declaring a file/branch missing.

### Explicit Non-Goals

- **N2** (strip Windows block from global `~/.claude/CLAUDE.md`) and **N5** (add `## Stopping Rule` to `~/.claude/skills/codex-{code,plan}-review/SKILL.md`) — applied as direct edits this session (backed up first); not versionable here because `~/.claude` is not a git repo.
- Long-term items **L1–L4** (git-guard extension, execution journal, gate ladder, capability-gap rule) — deferred per the synthesis sequencing.
- The 4 pre-existing dirty files in the working tree (`.gitignore`, 3× `docs/_generated/*`) — session-start drift, unrelated, deliberately left uncommitted.

### Schema Or Contract Impact

None. Config + docs only; no runtime code, no API/DB.

### Rollback Path

Revert any/all of the 3 commits, or delete the branch. Each fix is independent. Note: reverting `e456b598` also drops a pre-existing unrelated `enabledPlugins.vercel@claude-plugins-official: true` line that was already uncommitted and got bundled per the edit instruction.

### Commands Actually Run

- `npm run lint` → eslint gate passed, all guardrails pass
- `npm run check` → `[OK] 0 TypeScript errors`, baseline unchanged
- N3b behavioral proof: `eslint --fix` on a 3-import repro → `_readFile` (underscore-unused) survived, `barUnused` (plain-unused) stripped, `usedReadFile` (used) survived → confirms fix respects `^_` AND rule still removes real dead imports
- N1 resolution: committed hook commands read `${CLAUDE_PROJECT_DIR}/...`; both target scripts resolve and exist

### Docs Or Guardrail Impact

`CLAUDE.md` gains two pre-action-check bullets (N4). No guardrail scripts changed.

### Archived Active Docs

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Reviewer notes

- **N1 does not take effect until the next session.** Claude Code snapshots hook config at session start, so the session that authored this still ran the old dead hooks + old mutating `lint:fix`. Everything provable now is green (command string correct, targets resolve); live firing is only observable next session (SessionStart context block appears / `.claude/session-context.md` written). No in-session command can force it.
- **N3b root-cause correction:** the synthesis presupposed a `node:process`-specific eslint bug. Investigation falsified that — no such rule logic exists. The actual historical import-stripping was purely the mutating `lint:fix` hook racing a two-step add-import-then-use edit (fixed by N3a). N3b is a real but *separate* latent defect (the `^_` convention wasn't honored by the auto-fix rule).
- **N3a tradeoff:** dropped `--fix` (report-only) rather than scoping to changed files. Hook is now whole-repo `--max-warnings 0` — noisy on any pre-existing warning, but never mutates. Say if you'd prefer changed-file scoping instead.

## Quality Checklist

### Code Quality

- [x] TypeScript checks pass (`npm run check`)
- [x] ESLint passes (`npm run lint`)
- [x] No console.log or debug statements left

### Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Related Issues

None.
