### PR TITLE
refactor: isolate allocation read paths

### DIFF
--- a/server/routes/allocations.ts
+++ b/server/routes/allocations.ts
@@ -12,13 +12,9 @@ import type { Request, Response, NextFunction } from 'express';
 import { z } from 'zod';
 import { asyncHandler } from '../middleware/async';
 import { transaction } from '../db/pg-circuit';
-import { db } from '../db';
 import { logger } from '../lib/logger.js';
 import { applyAllocationUpdates } from '../services/allocation-write-service.js';
-import { funds, portfolioCompanies } from '@shared/schema';
 import { FundIdParamSchema } from '@shared/schemas/portfolio-route';
-import { eq, sql, desc, asc, and } from 'drizzle-orm';
-import type { SQL } from 'drizzle-orm';
 // Stage normalization and validation
 import { normalizeStage, CANONICAL_STAGES } from '@shared/schemas/parse-stage-distribution';
 import { getStageValidationMode } from '../lib/stage-validation-mode';
@@ -31,17 +27,14 @@ import { setStageWarningHeaders } from '../middleware/deprecation-headers';
 import { PARTNER_WRITE_ROLES } from '@shared/auth/effective-roles';
 import { requireWriteRole } from '../lib/auth/jwt';
 import { enforceProvidedFundScope } from '../lib/auth/provided-fund-scope';
-import { storage } from '../storage';
-import { AllocationCompanyActualsDriftV1Schema } from '@shared/contracts/allocations/allocation-actuals-drift-v1.contract';
-import type { FundCompanyActualsFactsResponse } from '@shared/contracts/fund-actuals/fund-company-actuals-fact.contract';
 import {
-  buildAllocationActualsDrift,
-  buildFailedAllocationActualsDrift,
-} from '../services/allocations/allocation-actuals-drift-service.js';
+  decodeCompanyListCursor,
+  isCompanyListCursorCompatible,
+} from '../services/allocations/company-list-cursor.js';
 import {
-  buildFundCompanyActualsFacts,
-  FundActualsFactsServiceError,
-} from '../services/fund-actuals/fund-company-actuals-facts-service.js';
+  allocationReadService,
+  type CompanyListReadInput,
+} from '../services/allocations/allocation-read-service.js';
 
 // Custom error type for HTTP status codes
 interface HttpError extends Error {
@@ -88,67 +81,7 @@ const ALLOCATION_ERROR_MAPPINGS = [
 // Validation Schemas
 // ============================================================================
 
-const COMPANY_LIST_CURSOR_BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/;
 const CompanyListSortBySchema = z.enum(['exit_moic_desc', 'planned_reserves_desc', 'name_asc']);
-
-const LatestAllocationActualsDriftSummarySchema = z
-  .object({
-    facts_status: z.enum(['available', 'failed']),
-    drifted_company_count: z.number().int().nonnegative(),
-    material_company_count: z.number().int().nonnegative(),
-    degraded_company_count: z.number().int().nonnegative(),
-    facts_input_hash: z
-      .string()
-      .regex(/^[a-f0-9]{64}$/)
-      .nullable(),
-    as_of_date: z.string().date(),
-  })
-  .strict();
-
-const LatestAllocationCompanySchema = z
-  .object({
-    company_id: z.number().int().positive(),
-    company_name: z.string(),
-    sector: z.string(),
-    stage: z.string(),
-    status: z.string(),
-    invested_amount_cents: z.number().int(),
-    planned_reserves_cents: z.number().int(),
-    deployed_reserves_cents: z.number().int(),
-    allocation_cap_cents: z.number().int().nullable(),
-    allocation_reason: z.string().nullable(),
-    allocation_version: z.number().int().nonnegative(),
-    last_allocation_at: z.string().datetime().nullable(),
-    allocation_facts_missing: z.boolean(),
-    missing_allocation_fields: z.array(z.string()),
-    actuals_drift: AllocationCompanyActualsDriftV1Schema,
-  })
-  .strict();
-
-const LatestAllocationResponseSchema = z
-  .object({
-    fund_id: z.number().int().positive(),
-    companies: z.array(LatestAllocationCompanySchema),
-    metadata: z
-      .object({
-        total_planned_cents: z.number().int(),
-        total_deployed_cents: z.number().int(),
-        companies_count: z.number().int().nonnegative(),
-        allocation_facts_missing_count: z.number().int().nonnegative(),
-        last_updated_at: z.string().datetime().nullable(),
-        actuals_drift_summary: LatestAllocationActualsDriftSummarySchema,
-      })
-      .strict(),
-  })
-  .strict();
-
-type CompanyListSortBy = z.infer<typeof CompanyListSortBySchema>;
-type CompanyListCursorKey = string | number | null;
-
-interface CompanyListCursor {
-  k: CompanyListCursorKey;
-  id: number;
-}
 
 /**
  * Schema for updating a single company's allocation
@@ -244,106 +177,9 @@ interface _UpdateAllocationResponse {
   }>;
 }
 
-interface CompanyListItem {
-  id: number;
-  fundId: number;
-  name: string;
-  sector: string;
-  stage: string;
-  status: 'active' | 'exited' | 'written-off';
-  invested_cents: number;
-  deployed_reserves_cents: number;
-  planned_reserves_cents: number;
-  exit_moic_bps: number | null;
-  ownership_pct: number;
-  allocation_cap_cents: number | null;
-  allocation_reason: string | null;
-  last_allocation_at: string | null;
-}
-
-interface CompanyListSourceRow {
-  id: number;
-  fundId: number | null;
-  name: string;
-  sector: string;
-  stage: string;
-  status: string | null;
-  investmentAmount: string | number | null;
-  deployedReservesCents?: number | bigint | null;
-  plannedReservesCents?: number | bigint | null;
-  exitMoicBps?: number | null;
-  ownershipCurrentPct?: string | number | null;
-  allocationCapCents?: number | bigint | null;
-  allocationReason?: string | null;
-  lastAllocationAt?: Date | string | null;
-}
-
-interface CompanyListResponse {
-  companies: CompanyListItem[];
-  pagination: {
-    next_cursor: string | null;
-    has_more: boolean;
-    total_count?: number;
-  };
-}
-
 // ============================================================================
 // Helper Functions
 // ============================================================================
-
-function decodeCompanyListCursor(cursor: string): CompanyListCursor | null {
-  if (!COMPANY_LIST_CURSOR_BASE64URL_PATTERN.test(cursor)) {
-    return null;
-  }
-
-  try {
-    const decoded = Buffer.from(cursor, 'base64url').toString('utf8');
-    const parsed = JSON.parse(decoded) as unknown;
-
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      return null;
-    }
-
-    const payload = parsed as Record<string, unknown>;
-    const id = payload['id'];
-    const key = payload['k'];
-
-    if (!Object.prototype.hasOwnProperty.call(payload, 'k')) {
-      return null;
-    }
-
-    if (typeof id !== 'number' || !Number.isSafeInteger(id) || id <= 0) {
-      return null;
-    }
-
-    if (
-      key !== null &&
-      typeof key !== 'string' &&
-      (typeof key !== 'number' || !Number.isFinite(key))
-    ) {
-      return null;
-    }
-
-    return { k: key as CompanyListCursorKey, id };
-  } catch {
-    return null;
-  }
-}
-
-function isCompanyListCursorCompatible(
-  cursor: CompanyListCursor,
-  sortBy: CompanyListSortBy
-): boolean {
-  if (sortBy === 'name_asc') {
-    return typeof cursor.k === 'string';
-  }
-
-  if (sortBy === 'planned_reserves_desc') {
-    return typeof cursor.k === 'number';
-  }
-
-  return cursor.k === null || typeof cursor.k === 'number';
-}
 
 function allocationErrorText(error: unknown): string {
   if (error instanceof Error) return error.message;
@@ -356,31 +192,6 @@ function findAllocationErrorMapping(message: string): AllocationErrorMapping | u
 
 function allocationErrorMappingMessage(mapping: AllocationErrorMapping | undefined): string {
   return mapping?.message ?? DEFAULT_ALLOCATION_ERROR_MESSAGE;
-}
-
-async function loadAllocationActualsFacts(input: {
-  fundId: number;
-  asOfDate: string;
-  requestId: string;
-}): Promise<FundCompanyActualsFactsResponse | null> {
-  try {
-    return await buildFundCompanyActualsFacts({
-      fundId: input.fundId,
-      asOfDate: input.asOfDate,
-    });
-  } catch (error) {
-    logger.warn(
-      {
-        requestId: input.requestId,
-        fundId: input.fundId,
-        errorCode:
-          error instanceof FundActualsFactsServiceError ? error.code : 'unexpected_facts_error',
-        error: error instanceof Error ? error.message : String(error),
-      },
-      'actuals facts unavailable for latest allocation read'
-    );
-    return null;
-  }
 }
 
 function parseActorUserId(req: Request): number | null {
@@ -397,188 +208,6 @@ function parseActorUserId(req: Request): number | null {
   }
 
   return null;
-}
-
-function missingAllocationFields(row: {
-  planned_reserves_cents: number | bigint | string | null;
-  deployed_reserves_cents: number | bigint | string | null;
-  allocation_version: number | null;
-}): string[] {
-  const fields: string[] = [];
-  if (row.planned_reserves_cents == null) fields.push('planned_reserves_cents');
-  if (row.deployed_reserves_cents == null) fields.push('deployed_reserves_cents');
-  if (row.allocation_version == null) fields.push('allocation_version');
-  return fields;
-}
-
-function normalizeCompanyListStatus(status: string | null | undefined): CompanyListItem['status'] {
-  return status === 'exited' || status === 'written-off' ? status : 'active';
-}
-
-function isoDateOrNull(value: Date | string | null | undefined): string | null {
-  if (value == null) {
-    return null;
-  }
-
-  return value instanceof Date ? value.toISOString() : value;
-}
-
-function plannedReservesSortValue(company: object): number {
-  if ('plannedReservesCents' in company) {
-    return Number(company.plannedReservesCents ?? 0);
-  }
-
-  return 0;
-}
-
-function exitMoicSortKey(company: object): number | null {
-  if ('exitMoicBps' in company) {
-    if (company.exitMoicBps == null) {
-      return null;
-    }
-    const value = Number(company.exitMoicBps);
-    return Number.isFinite(value) ? value : null;
-  }
-
-  return null;
-}
-
-function companyListSortKey(
-  company: CompanyListSourceRow,
-  sortBy: CompanyListSortBy
-): CompanyListCursorKey {
-  if (sortBy === 'name_asc') {
-    return company.name;
-  }
-
-  if (sortBy === 'planned_reserves_desc') {
-    return plannedReservesSortValue(company);
-  }
-
-  return exitMoicSortKey(company);
-}
-
-function compareNullableNumberDesc(left: number | null, right: number | null): number {
-  if (left === null && right === null) {
-    return 0;
-  }
-  if (left === null) {
-    return 1;
-  }
-  if (right === null) {
-    return -1;
-  }
-  return right - left;
-}
-
-function compareCompanyListRows(
-  left: CompanyListSourceRow,
-  right: CompanyListSourceRow,
-  sortBy: CompanyListSortBy
-): number {
-  if (sortBy === 'name_asc') {
-    return left.name.localeCompare(right.name) || right.id - left.id;
-  }
-
-  if (sortBy === 'planned_reserves_desc') {
-    return plannedReservesSortValue(right) - plannedReservesSortValue(left) || right.id - left.id;
-  }
-
-  return (
-    compareNullableNumberDesc(exitMoicSortKey(left), exitMoicSortKey(right)) || right.id - left.id
-  );
-}
-
-function isAfterCompanyListCursor(
-  company: CompanyListSourceRow,
-  cursor: CompanyListCursor,
-  sortBy: CompanyListSortBy
-): boolean {
-  const key = companyListSortKey(company, sortBy);
-
-  if (sortBy === 'name_asc') {
-    return (
-      typeof key === 'string' &&
-      typeof cursor.k === 'string' &&
-      (key.localeCompare(cursor.k) > 0 || (key === cursor.k && company.id < cursor.id))
-    );
-  }
-
-  if (sortBy === 'planned_reserves_desc') {
-    return (
-      typeof key === 'number' &&
-      typeof cursor.k === 'number' &&
-      (key < cursor.k || (key === cursor.k && company.id < cursor.id))
-    );
-  }
-
-  if (cursor.k === null) {
-    return key === null && company.id < cursor.id;
-  }
-
-  return (
-    typeof cursor.k === 'number' &&
-    (key === null ||
-      (typeof key === 'number' && (key < cursor.k || (key === cursor.k && company.id < cursor.id))))
-  );
-}
-
-function encodeCompanyListCursor(company: CompanyListSourceRow, sortBy: CompanyListSortBy): string {
-  return Buffer.from(
-    JSON.stringify({ k: companyListSortKey(company, sortBy), id: company.id })
-  ).toString('base64url');
-}
-
-function requireCompanyListCursorNumberKey(cursor: CompanyListCursor): number {
-  if (typeof cursor.k !== 'number') {
-    throw new Error('Invalid numeric company-list cursor key');
-  }
-  return cursor.k;
-}
-
-function requireCompanyListCursorStringKey(cursor: CompanyListCursor): string {
-  if (typeof cursor.k !== 'string') {
-    throw new Error('Invalid string company-list cursor key');
-  }
-  return cursor.k;
-}
-
-function companyListCursorPredicate(cursor: CompanyListCursor, sortBy: CompanyListSortBy): SQL {
-  if (sortBy === 'planned_reserves_desc') {
-    const key = requireCompanyListCursorNumberKey(cursor);
-    return sql`(${portfolioCompanies.plannedReservesCents}, ${portfolioCompanies.id}) < (${key}, ${cursor.id})`;
-  }
-
-  if (sortBy === 'name_asc') {
-    const key = requireCompanyListCursorStringKey(cursor);
-    return sql`(${portfolioCompanies.name}, -${portfolioCompanies.id}) > (${key}, ${-cursor.id})`;
-  }
-
-  if (cursor.k === null) {
-    return sql`${portfolioCompanies.exitMoicBps} IS NULL AND ${portfolioCompanies.id} < ${cursor.id}`;
-  }
-
-  const key = requireCompanyListCursorNumberKey(cursor);
-  return sql`((${portfolioCompanies.exitMoicBps}, ${portfolioCompanies.id}) < (${key}, ${cursor.id}) OR ${portfolioCompanies.exitMoicBps} IS NULL)`;
-}
-
-function companyListItemFromRow(row: CompanyListSourceRow, fundId: number): CompanyListItem {
-  return {
-    id: row.id,
-    fundId: row.fundId ?? fundId,
-    name: row.name,
-    sector: row.sector,
-    stage: row.stage,
-    status: normalizeCompanyListStatus(row.status),
-    invested_cents: Math.round(parseFloat(String(row.investmentAmount ?? '0')) * 100),
-    deployed_reserves_cents: Number(row.deployedReservesCents ?? 0),
-    planned_reserves_cents: Number(row.plannedReservesCents ?? 0),
-    exit_moic_bps: row.exitMoicBps ?? null,
-    ownership_pct: parseFloat(String(row.ownershipCurrentPct ?? '0')),
-    allocation_cap_cents: row.allocationCapCents != null ? Number(row.allocationCapCents) : null,
-    allocation_reason: row.allocationReason ?? null,
-    last_allocation_at: isoDateOrNull(row.lastAllocationAt),
-  };
 }
 
 // ============================================================================
@@ -667,189 +296,24 @@ router['get'](
       }
     }
 
-    if (storage.kind === 'memory') {
-      const storedAll = await storage.getPortfolioCompanies(fundId);
-
-      if (storedAll.length === 0 && query.cursor === undefined) {
-        return res.status(404).json({
-          error: 'fund_not_found',
-          message: `Fund with ID ${fundId} not found or has no companies`,
-        });
-      }
-
-      const sorted = storedAll
-        .filter((company) => {
-          if (query.cursor && !isAfterCompanyListCursor(company, query.cursor, query.sortBy)) {
-            return false;
-          }
-          if (query.status && normalizeCompanyListStatus(company.status) !== query.status) {
-            return false;
-          }
-          if (query.sector && company.sector !== query.sector) {
-            return false;
-          }
-          if (normalizedStage && company.stage !== normalizedStage) {
-            return false;
-          }
-          if (query.q && !company.name.toLowerCase().includes(query.q.toLowerCase())) {
-            return false;
-          }
-          return true;
-        })
-        .sort((left, right) => compareCompanyListRows(left, right, query.sortBy));
-
-      const memHasMore = sorted.length > query.limit;
-      const page = memHasMore ? sorted.slice(0, query.limit) : sorted;
-      const memNextCursor =
-        memHasMore && page.length > 0
-          ? encodeCompanyListCursor(page[page.length - 1]!, query.sortBy)
-          : null;
-      const responseCompanies = page.map((company) => companyListItemFromRow(company, fundId));
-
-      const response: CompanyListResponse = {
-        companies: responseCompanies,
-        pagination: {
-          next_cursor: memNextCursor,
-          has_more: memHasMore,
-          // Note: total_count is optional and expensive - omitted for performance
-        },
-      };
-
-      // Log request metrics
-      const duration = Date.now() - startTime;
-      logger.info(
-        {
-          requestId,
-          fundId,
-          companyCount: responseCompanies.length,
-          durationMs: duration,
-        },
-        'allocations company list served'
-      );
-
-      return res.status(200).json(response);
-    }
-
-    // Build WHERE conditions
-    const conditions: SQL[] = [eq(portfolioCompanies.fundId, fundId)];
-
-    // Cursor pagination follows the active ORDER BY key plus id DESC tiebreaker.
-    if (query.cursor !== undefined) {
-      conditions.push(companyListCursorPredicate(query.cursor, query.sortBy));
-    }
-
-    // Status filter
-    if (query.status) {
-      conditions.push(eq(portfolioCompanies.status, query.status));
-    }
-
-    // Sector filter
-    if (query.sector) {
-      conditions.push(eq(portfolioCompanies.sector, query.sector));
-    }
-
-    // Stage filter (using normalized stage)
-    if (normalizedStage) {
-      conditions.push(eq(portfolioCompanies.stage, normalizedStage));
-    }
-
-    // Search filter (case-insensitive LIKE)
-    if (query.q) {
-      conditions.push(sql`LOWER(${portfolioCompanies.name}) LIKE LOWER(${`%${query.q}%`})`);
-    }
-
-    // Build ORDER BY clause based on sortBy
-    let orderBy;
-    switch (query.sortBy) {
-      case 'exit_moic_desc':
-        // Sort by exit MOIC descending (nulls last), then by id DESC for cursor pagination
-        orderBy = [
-          sql`${portfolioCompanies.exitMoicBps} DESC NULLS LAST`,
-          desc(portfolioCompanies.id),
-        ];
-        break;
-      case 'planned_reserves_desc':
-        // Sort by planned reserves descending, then by id DESC
-        orderBy = [desc(portfolioCompanies.plannedReservesCents), desc(portfolioCompanies.id)];
-        break;
-      case 'name_asc':
-        // Sort by name ascending, then by id DESC
-        orderBy = [asc(portfolioCompanies.name), desc(portfolioCompanies.id)];
-        break;
-      default:
-        // Default to exit MOIC desc
-        orderBy = [
-          sql`${portfolioCompanies.exitMoicBps} DESC NULLS LAST`,
-          desc(portfolioCompanies.id),
-        ];
-    }
-
-    // Fetch limit + 1 to detect if there are more results
-    const fetchLimit = query.limit + 1;
-
-    // Execute query using and() which properly preserves the query builder chain
-    const results = await db
-      .select({
-        id: portfolioCompanies.id,
-        fundId: portfolioCompanies.fundId,
-        name: portfolioCompanies.name,
-        sector: portfolioCompanies.sector,
-        stage: portfolioCompanies.stage,
-        status: portfolioCompanies.status,
-        investmentAmount: portfolioCompanies.investmentAmount,
-        deployedReservesCents: portfolioCompanies.deployedReservesCents,
-        plannedReservesCents: portfolioCompanies.plannedReservesCents,
-        exitMoicBps: portfolioCompanies.exitMoicBps,
-        ownershipCurrentPct: portfolioCompanies.ownershipCurrentPct,
-        allocationCapCents: portfolioCompanies.allocationCapCents,
-        allocationReason: portfolioCompanies.allocationReason,
-        lastAllocationAt: portfolioCompanies.lastAllocationAt,
-      })
-      .from(portfolioCompanies)
-      .where(and(...conditions))
-      .orderBy(...orderBy)
-      .limit(fetchLimit);
-
-    // Check if we have more results
-    const hasMore = results.length > query.limit;
-    const companies = hasMore ? results.slice(0, query.limit) : results;
-
-    // Get next cursor from the last row's active sort key and id.
-    const nextCursor =
-      hasMore && companies.length > 0
-        ? encodeCompanyListCursor(companies[companies.length - 1]!, query.sortBy)
-        : null;
-
-    // Convert database results to response format
-    const responseCompanies: CompanyListItem[] = companies.map((row: (typeof results)[number]) =>
-      companyListItemFromRow(row, fundId)
-    );
-
-    if (responseCompanies.length === 0 && query.cursor === undefined) {
-      // Verify fund exists by checking if any companies exist for this fund
-      const fundCheck = await db
-        .select({ count: sql<number>`count(*)` })
-        .from(portfolioCompanies)
-        .where(eq(portfolioCompanies.fundId, fundId));
-
-      const totalCompanies = fundCheck[0]?.count || 0;
-
-      if (totalCompanies === 0) {
-        return res.status(404).json({
-          error: 'fund_not_found',
-          message: `Fund with ID ${fundId} not found or has no companies`,
-        });
-      }
-    }
-
-    const response: CompanyListResponse = {
-      companies: responseCompanies,
-      pagination: {
-        next_cursor: nextCursor,
-        has_more: hasMore,
-        // Note: total_count is optional and expensive - omitted for performance
-      },
+    const readInput: CompanyListReadInput = {
+      fundId,
+      limit: query.limit,
+      sortBy: query.sortBy,
+      ...(query.cursor !== undefined ? { cursor: query.cursor } : {}),
+      ...(query.q !== undefined ? { q: query.q } : {}),
+      ...(query.status !== undefined ? { status: query.status } : {}),
+      ...(query.sector !== undefined ? { sector: query.sector } : {}),
+      ...(normalizedStage !== undefined ? { stage: normalizedStage } : {}),
     };
+    const result = await allocationReadService.listCompanies(readInput);
+
+    if (result.kind === 'not_found') {
+      return res.status(404).json({
+        error: 'fund_not_found',
+        message: `Fund with ID ${fundId} not found or has no companies`,
+      });
+    }
 
     // Log request metrics
     const duration = Date.now() - startTime;
@@ -857,13 +321,13 @@ router['get'](
       {
         requestId,
         fundId,
-        companyCount: responseCompanies.length,
+        companyCount: result.response.companies.length,
         durationMs: duration,
       },
       'allocations company list served'
     );
 
-    return res.status(200).json(response);
+    return res.status(200).json(result.response);
   })
 );
 
@@ -894,129 +358,17 @@ router['get'](
     }
 
     try {
-      const [fund] = await db
-        .select({ id: funds.id })
-        .from(funds)
-        .where(eq(funds.id, fundId))
-        .limit(1);
+      const response = await allocationReadService.getLatest({
+        fundId,
+        requestId: req.rid ?? 'unknown',
+      });
 
-      if (!fund) {
+      if (!response) {
         return res.status(404).json({
           error: 'fund_not_found',
           message: `Fund with ID ${fundId} was not found`,
         });
       }
-
-      const rows = await db
-        .select({
-          company_id: portfolioCompanies.id,
-          company_name: portfolioCompanies.name,
-          sector: portfolioCompanies.sector,
-          stage: portfolioCompanies.stage,
-          status: portfolioCompanies.status,
-          invested_amount: portfolioCompanies.investmentAmount,
-          planned_reserves_cents: portfolioCompanies.plannedReservesCents,
-          deployed_reserves_cents: portfolioCompanies.deployedReservesCents,
-          allocation_cap_cents: portfolioCompanies.allocationCapCents,
-          allocation_reason: portfolioCompanies.allocationReason,
-          allocation_version: portfolioCompanies.allocationVersion,
-          last_allocation_at: portfolioCompanies.lastAllocationAt,
-        })
-        .from(portfolioCompanies)
-        .where(eq(portfolioCompanies.fundId, fundId))
-        .orderBy(asc(portfolioCompanies.id));
-
-      const asOfDate = new Date().toISOString().slice(0, 10);
-      const actualsFacts = await loadAllocationActualsFacts({
-        fundId,
-        asOfDate,
-        requestId: req.rid ?? 'unknown',
-      });
-      const factsByCompanyId = new Map(
-        actualsFacts?.facts.map((fact) => [fact.companyId, fact]) ?? []
-      );
-
-      const companies = rows.map((row) => {
-        const missingFields = missingAllocationFields(row);
-        const plannedReservesCents =
-          row.planned_reserves_cents != null ? Number(row.planned_reserves_cents) : 0;
-        const deployedReservesCents =
-          row.deployed_reserves_cents != null ? Number(row.deployed_reserves_cents) : 0;
-        const allocationVersion = row.allocation_version ?? 0;
-        const driftAllocationVersion = allocationVersion > 0 ? allocationVersion : 1;
-        const driftInput = {
-          allocation: {
-            companyId: row.company_id,
-            deployedReservesCents,
-            investmentAmount: row.invested_amount || '0',
-            allocationVersion: driftAllocationVersion,
-            lastAllocationAt: row.last_allocation_at,
-          },
-          asOfDate,
-        };
-        const actualsDrift =
-          actualsFacts === null
-            ? buildFailedAllocationActualsDrift(driftInput)
-            : buildAllocationActualsDrift({
-                ...driftInput,
-                fact: factsByCompanyId.get(row.company_id) ?? null,
-              });
-
-        return {
-          company_id: row.company_id,
-          company_name: row.company_name,
-          sector: row.sector,
-          stage: row.stage,
-          status: row.status,
-          invested_amount_cents: Math.round(parseFloat(row.invested_amount || '0') * 100),
-          planned_reserves_cents: plannedReservesCents,
-          deployed_reserves_cents: deployedReservesCents,
-          allocation_cap_cents:
-            row.allocation_cap_cents != null ? Number(row.allocation_cap_cents) : null,
-          allocation_reason: row.allocation_reason,
-          allocation_version: allocationVersion,
-          last_allocation_at: row.last_allocation_at ? row.last_allocation_at.toISOString() : null,
-          allocation_facts_missing: missingFields.length > 0,
-          missing_allocation_fields: missingFields,
-          actuals_drift: actualsDrift,
-        };
-      });
-
-      const total_planned_cents = companies.reduce((sum, c) => sum + c.planned_reserves_cents, 0);
-      const total_deployed_cents = companies.reduce((sum, c) => sum + c.deployed_reserves_cents, 0);
-      const last_updated_at =
-        companies
-          .map((c) => c.last_allocation_at)
-          .filter((d): d is string => d !== null)
-          .sort()
-          .reverse()[0] || null;
-
-      const response = LatestAllocationResponseSchema.parse({
-        fund_id: fundId,
-        companies,
-        metadata: {
-          total_planned_cents,
-          total_deployed_cents,
-          companies_count: companies.length,
-          allocation_facts_missing_count: companies.filter((c) => c.allocation_facts_missing)
-            .length,
-          last_updated_at,
-          actuals_drift_summary: {
-            facts_status: actualsFacts === null ? 'failed' : 'available',
-            drifted_company_count: companies.filter((company) =>
-              company.actuals_drift.comparisons.some((comparison) => comparison.state === 'drifted')
-            ).length,
-            material_company_count: companies.filter((company) =>
-              company.actuals_drift.comparisons.some((comparison) => comparison.material)
-            ).length,
-            degraded_company_count: companies.filter(
-              (company) => company.actuals_drift.trustState !== 'LIVE'
-            ).length,
-            facts_input_hash: actualsFacts?.inputHash ?? null,
-            as_of_date: asOfDate,
-          },
-        },
-      });
 
       return res.status(200).json(response);
     } catch (error) {

--- a/server/services/allocations/allocation-read-service.ts
+++ b/server/services/allocations/allocation-read-service.ts
@@ -1,0 +1,478 @@
+import { and, asc, desc, eq, sql } from 'drizzle-orm';
+import type { SQL } from 'drizzle-orm';
+import { z } from 'zod';
+
+import { AllocationCompanyActualsDriftV1Schema } from '@shared/contracts/allocations/allocation-actuals-drift-v1.contract';
+import type { FundCompanyActualsFactsResponse } from '@shared/contracts/fund-actuals/fund-company-actuals-fact.contract';
+import { funds, portfolioCompanies } from '@shared/schema';
+import { db } from '../../db';
+import { logger } from '../../lib/logger.js';
+import { storage } from '../../storage';
+import {
+  buildAllocationActualsDrift,
+  buildFailedAllocationActualsDrift,
+} from './allocation-actuals-drift-service.js';
+import {
+  buildFundCompanyActualsFacts,
+  FundActualsFactsServiceError,
+} from '../fund-actuals/fund-company-actuals-facts-service.js';
+import {
+  companyListCursorPredicate,
+  compareCompanyListRows,
+  encodeCompanyListCursor,
+  isAfterCompanyListCursor,
+  type CompanyListCursor,
+  type CompanyListSortBy,
+} from './company-list-cursor.js';
+
+const LatestAllocationActualsDriftSummarySchema = z
+  .object({
+    facts_status: z.enum(['available', 'failed']),
+    drifted_company_count: z.number().int().nonnegative(),
+    material_company_count: z.number().int().nonnegative(),
+    degraded_company_count: z.number().int().nonnegative(),
+    facts_input_hash: z
+      .string()
+      .regex(/^[a-f0-9]{64}$/)
+      .nullable(),
+    as_of_date: z.string().date(),
+  })
+  .strict();
+
+const LatestAllocationCompanySchema = z
+  .object({
+    company_id: z.number().int().positive(),
+    company_name: z.string(),
+    sector: z.string(),
+    stage: z.string(),
+    status: z.string(),
+    invested_amount_cents: z.number().int(),
+    planned_reserves_cents: z.number().int(),
+    deployed_reserves_cents: z.number().int(),
+    allocation_cap_cents: z.number().int().nullable(),
+    allocation_reason: z.string().nullable(),
+    allocation_version: z.number().int().nonnegative(),
+    last_allocation_at: z.string().datetime().nullable(),
+    allocation_facts_missing: z.boolean(),
+    missing_allocation_fields: z.array(z.string()),
+    actuals_drift: AllocationCompanyActualsDriftV1Schema,
+  })
+  .strict();
+
+const LatestAllocationResponseSchema = z
+  .object({
+    fund_id: z.number().int().positive(),
+    companies: z.array(LatestAllocationCompanySchema),
+    metadata: z
+      .object({
+        total_planned_cents: z.number().int(),
+        total_deployed_cents: z.number().int(),
+        companies_count: z.number().int().nonnegative(),
+        allocation_facts_missing_count: z.number().int().nonnegative(),
+        last_updated_at: z.string().datetime().nullable(),
+        actuals_drift_summary: LatestAllocationActualsDriftSummarySchema,
+      })
+      .strict(),
+  })
+  .strict();
+
+export interface CompanyListItem {
+  id: number;
+  fundId: number;
+  name: string;
+  sector: string;
+  stage: string;
+  status: 'active' | 'exited' | 'written-off';
+  invested_cents: number;
+  deployed_reserves_cents: number;
+  planned_reserves_cents: number;
+  exit_moic_bps: number | null;
+  ownership_pct: number;
+  allocation_cap_cents: number | null;
+  allocation_reason: string | null;
+  last_allocation_at: string | null;
+}
+
+interface CompanyListSourceRow {
+  id: number;
+  fundId: number | null;
+  name: string;
+  sector: string;
+  stage: string;
+  status: string | null;
+  investmentAmount: string | number | null;
+  deployedReservesCents?: number | bigint | null;
+  plannedReservesCents?: number | bigint | null;
+  exitMoicBps?: number | null;
+  ownershipCurrentPct?: string | number | null;
+  allocationCapCents?: number | bigint | null;
+  allocationReason?: string | null;
+  lastAllocationAt?: Date | string | null;
+}
+
+export interface CompanyListResponse {
+  companies: CompanyListItem[];
+  pagination: {
+    next_cursor: string | null;
+    has_more: boolean;
+    total_count?: number;
+  };
+}
+
+export interface CompanyListReadInput {
+  fundId: number;
+  cursor?: CompanyListCursor;
+  limit: number;
+  q?: string;
+  status?: CompanyListItem['status'];
+  sector?: string;
+  stage?: string;
+  sortBy: CompanyListSortBy;
+}
+
+export type CompanyListReadResult =
+  | { kind: 'not_found' }
+  | { kind: 'ok'; response: CompanyListResponse };
+
+function normalizeCompanyListStatus(status: string | null | undefined): CompanyListItem['status'] {
+  return status === 'exited' || status === 'written-off' ? status : 'active';
+}
+
+function isoDateOrNull(value: Date | string | null | undefined): string | null {
+  if (value == null) {
+    return null;
+  }
+
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+function companyListItemFromRow(row: CompanyListSourceRow, fundId: number): CompanyListItem {
+  return {
+    id: row.id,
+    fundId: row.fundId ?? fundId,
+    name: row.name,
+    sector: row.sector,
+    stage: row.stage,
+    status: normalizeCompanyListStatus(row.status),
+    invested_cents: Math.round(parseFloat(String(row.investmentAmount ?? '0')) * 100),
+    deployed_reserves_cents: Number(row.deployedReservesCents ?? 0),
+    planned_reserves_cents: Number(row.plannedReservesCents ?? 0),
+    exit_moic_bps: row.exitMoicBps ?? null,
+    ownership_pct: parseFloat(String(row.ownershipCurrentPct ?? '0')),
+    allocation_cap_cents: row.allocationCapCents != null ? Number(row.allocationCapCents) : null,
+    allocation_reason: row.allocationReason ?? null,
+    last_allocation_at: isoDateOrNull(row.lastAllocationAt),
+  };
+}
+
+async function loadAllocationActualsFacts(input: {
+  fundId: number;
+  asOfDate: string;
+  requestId: string;
+}): Promise<FundCompanyActualsFactsResponse | null> {
+  try {
+    return await buildFundCompanyActualsFacts({
+      fundId: input.fundId,
+      asOfDate: input.asOfDate,
+    });
+  } catch (error) {
+    logger.warn(
+      {
+        requestId: input.requestId,
+        fundId: input.fundId,
+        errorCode:
+          error instanceof FundActualsFactsServiceError ? error.code : 'unexpected_facts_error',
+        error: error instanceof Error ? error.message : String(error),
+      },
+      'actuals facts unavailable for latest allocation read'
+    );
+    return null;
+  }
+}
+
+function missingAllocationFields(row: {
+  planned_reserves_cents: number | bigint | string | null;
+  deployed_reserves_cents: number | bigint | string | null;
+  allocation_version: number | null;
+}): string[] {
+  const fields: string[] = [];
+  if (row.planned_reserves_cents == null) fields.push('planned_reserves_cents');
+  if (row.deployed_reserves_cents == null) fields.push('deployed_reserves_cents');
+  if (row.allocation_version == null) fields.push('allocation_version');
+  return fields;
+}
+
+export class AllocationReadService {
+  async listCompanies(input: CompanyListReadInput): Promise<CompanyListReadResult> {
+    const { fundId } = input;
+
+    if (storage.kind === 'memory') {
+      const storedAll = await storage.getPortfolioCompanies(fundId);
+
+      if (storedAll.length === 0 && input.cursor === undefined) {
+        return { kind: 'not_found' };
+      }
+
+      const sorted = storedAll
+        .filter((company) => {
+          if (input.cursor && !isAfterCompanyListCursor(company, input.cursor, input.sortBy)) {
+            return false;
+          }
+          if (input.status && normalizeCompanyListStatus(company.status) !== input.status) {
+            return false;
+          }
+          if (input.sector && company.sector !== input.sector) {
+            return false;
+          }
+          if (input.stage && company.stage !== input.stage) {
+            return false;
+          }
+          if (input.q && !company.name.toLowerCase().includes(input.q.toLowerCase())) {
+            return false;
+          }
+          return true;
+        })
+        .sort((left, right) => compareCompanyListRows(left, right, input.sortBy));
+
+      const hasMore = sorted.length > input.limit;
+      const page = hasMore ? sorted.slice(0, input.limit) : sorted;
+      const nextCursor =
+        hasMore && page.length > 0
+          ? encodeCompanyListCursor(page[page.length - 1]!, input.sortBy)
+          : null;
+
+      return {
+        kind: 'ok',
+        response: {
+          companies: page.map((company) => companyListItemFromRow(company, fundId)),
+          pagination: {
+            next_cursor: nextCursor,
+            has_more: hasMore,
+          },
+        },
+      };
+    }
+
+    const conditions: SQL[] = [eq(portfolioCompanies.fundId, fundId)];
+
+    if (input.cursor !== undefined) {
+      conditions.push(companyListCursorPredicate(input.cursor, input.sortBy));
+    }
+    if (input.status) {
+      conditions.push(eq(portfolioCompanies.status, input.status));
+    }
+    if (input.sector) {
+      conditions.push(eq(portfolioCompanies.sector, input.sector));
+    }
+    if (input.stage) {
+      conditions.push(eq(portfolioCompanies.stage, input.stage));
+    }
+    if (input.q) {
+      conditions.push(sql`LOWER(${portfolioCompanies.name}) LIKE LOWER(${`%${input.q}%`})`);
+    }
+
+    let orderBy;
+    switch (input.sortBy) {
+      case 'exit_moic_desc':
+        orderBy = [
+          sql`${portfolioCompanies.exitMoicBps} DESC NULLS LAST`,
+          desc(portfolioCompanies.id),
+        ];
+        break;
+      case 'planned_reserves_desc':
+        orderBy = [desc(portfolioCompanies.plannedReservesCents), desc(portfolioCompanies.id)];
+        break;
+      case 'name_asc':
+        orderBy = [asc(portfolioCompanies.name), desc(portfolioCompanies.id)];
+        break;
+      default:
+        orderBy = [
+          sql`${portfolioCompanies.exitMoicBps} DESC NULLS LAST`,
+          desc(portfolioCompanies.id),
+        ];
+    }
+
+    const results = await db
+      .select({
+        id: portfolioCompanies.id,
+        fundId: portfolioCompanies.fundId,
+        name: portfolioCompanies.name,
+        sector: portfolioCompanies.sector,
+        stage: portfolioCompanies.stage,
+        status: portfolioCompanies.status,
+        investmentAmount: portfolioCompanies.investmentAmount,
+        deployedReservesCents: portfolioCompanies.deployedReservesCents,
+        plannedReservesCents: portfolioCompanies.plannedReservesCents,
+        exitMoicBps: portfolioCompanies.exitMoicBps,
+        ownershipCurrentPct: portfolioCompanies.ownershipCurrentPct,
+        allocationCapCents: portfolioCompanies.allocationCapCents,
+        allocationReason: portfolioCompanies.allocationReason,
+        lastAllocationAt: portfolioCompanies.lastAllocationAt,
+      })
+      .from(portfolioCompanies)
+      .where(and(...conditions))
+      .orderBy(...orderBy)
+      .limit(input.limit + 1);
+
+    const hasMore = results.length > input.limit;
+    const companies = hasMore ? results.slice(0, input.limit) : results;
+    const nextCursor =
+      hasMore && companies.length > 0
+        ? encodeCompanyListCursor(companies[companies.length - 1]!, input.sortBy)
+        : null;
+    const responseCompanies = companies.map((row) => companyListItemFromRow(row, fundId));
+
+    if (responseCompanies.length === 0 && input.cursor === undefined) {
+      const fundCheck = await db
+        .select({ count: sql<number>`count(*)` })
+        .from(portfolioCompanies)
+        .where(eq(portfolioCompanies.fundId, fundId));
+
+      if ((fundCheck[0]?.count || 0) === 0) {
+        return { kind: 'not_found' };
+      }
+    }
+
+    return {
+      kind: 'ok',
+      response: {
+        companies: responseCompanies,
+        pagination: {
+          next_cursor: nextCursor,
+          has_more: hasMore,
+        },
+      },
+    };
+  }
+
+  async getLatest(input: { fundId: number; requestId: string }) {
+    const { fundId } = input;
+    const [fund] = await db
+      .select({ id: funds.id })
+      .from(funds)
+      .where(eq(funds.id, fundId))
+      .limit(1);
+
+    if (!fund) {
+      return null;
+    }
+
+    const rows = await db
+      .select({
+        company_id: portfolioCompanies.id,
+        company_name: portfolioCompanies.name,
+        sector: portfolioCompanies.sector,
+        stage: portfolioCompanies.stage,
+        status: portfolioCompanies.status,
+        invested_amount: portfolioCompanies.investmentAmount,
+        planned_reserves_cents: portfolioCompanies.plannedReservesCents,
+        deployed_reserves_cents: portfolioCompanies.deployedReservesCents,
+        allocation_cap_cents: portfolioCompanies.allocationCapCents,
+        allocation_reason: portfolioCompanies.allocationReason,
+        allocation_version: portfolioCompanies.allocationVersion,
+        last_allocation_at: portfolioCompanies.lastAllocationAt,
+      })
+      .from(portfolioCompanies)
+      .where(eq(portfolioCompanies.fundId, fundId))
+      .orderBy(asc(portfolioCompanies.id));
+
+    const asOfDate = new Date().toISOString().slice(0, 10);
+    const actualsFacts = await loadAllocationActualsFacts({
+      fundId,
+      asOfDate,
+      requestId: input.requestId,
+    });
+    const factsByCompanyId = new Map(
+      actualsFacts?.facts.map((fact) => [fact.companyId, fact]) ?? []
+    );
+
+    const companies = rows.map((row) => {
+      const missingFields = missingAllocationFields(row);
+      const plannedReservesCents =
+        row.planned_reserves_cents != null ? Number(row.planned_reserves_cents) : 0;
+      const deployedReservesCents =
+        row.deployed_reserves_cents != null ? Number(row.deployed_reserves_cents) : 0;
+      const allocationVersion = row.allocation_version ?? 0;
+      const driftAllocationVersion = allocationVersion > 0 ? allocationVersion : 1;
+      const driftInput = {
+        allocation: {
+          companyId: row.company_id,
+          deployedReservesCents,
+          investmentAmount: row.invested_amount || '0',
+          allocationVersion: driftAllocationVersion,
+          lastAllocationAt: row.last_allocation_at,
+        },
+        asOfDate,
+      };
+      const actualsDrift =
+        actualsFacts === null
+          ? buildFailedAllocationActualsDrift(driftInput)
+          : buildAllocationActualsDrift({
+              ...driftInput,
+              fact: factsByCompanyId.get(row.company_id) ?? null,
+            });
+
+      return {
+        company_id: row.company_id,
+        company_name: row.company_name,
+        sector: row.sector,
+        stage: row.stage,
+        status: row.status,
+        invested_amount_cents: Math.round(parseFloat(row.invested_amount || '0') * 100),
+        planned_reserves_cents: plannedReservesCents,
+        deployed_reserves_cents: deployedReservesCents,
+        allocation_cap_cents:
+          row.allocation_cap_cents != null ? Number(row.allocation_cap_cents) : null,
+        allocation_reason: row.allocation_reason,
+        allocation_version: allocationVersion,
+        last_allocation_at: row.last_allocation_at ? row.last_allocation_at.toISOString() : null,
+        allocation_facts_missing: missingFields.length > 0,
+        missing_allocation_fields: missingFields,
+        actuals_drift: actualsDrift,
+      };
+    });
+
+    const total_planned_cents = companies.reduce((sum, company) => {
+      return sum + company.planned_reserves_cents;
+    }, 0);
+    const total_deployed_cents = companies.reduce((sum, company) => {
+      return sum + company.deployed_reserves_cents;
+    }, 0);
+    const last_updated_at =
+      companies
+        .map((company) => company.last_allocation_at)
+        .filter((date): date is string => date !== null)
+        .sort()
+        .reverse()[0] || null;
+
+    return LatestAllocationResponseSchema.parse({
+      fund_id: fundId,
+      companies,
+      metadata: {
+        total_planned_cents,
+        total_deployed_cents,
+        companies_count: companies.length,
+        allocation_facts_missing_count: companies.filter(
+          (company) => company.allocation_facts_missing
+        ).length,
+        last_updated_at,
+        actuals_drift_summary: {
+          facts_status: actualsFacts === null ? 'failed' : 'available',
+          drifted_company_count: companies.filter((company) =>
+            company.actuals_drift.comparisons.some((comparison) => comparison.state === 'drifted')
+          ).length,
+          material_company_count: companies.filter((company) =>
+            company.actuals_drift.comparisons.some((comparison) => comparison.material)
+          ).length,
+          degraded_company_count: companies.filter(
+            (company) => company.actuals_drift.trustState !== 'LIVE'
+          ).length,
+          facts_input_hash: actualsFacts?.inputHash ?? null,
+          as_of_date: asOfDate,
+        },
+      },
+    });
+  }
+}
+
+export const allocationReadService = new AllocationReadService();

--- a/server/services/allocations/company-list-cursor.ts
+++ b/server/services/allocations/company-list-cursor.ts
@@ -1,0 +1,220 @@
+import { sql } from 'drizzle-orm';
+import type { SQL } from 'drizzle-orm';
+
+import { portfolioCompanies } from '@shared/schema';
+
+const COMPANY_LIST_CURSOR_BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+export type CompanyListSortBy = 'exit_moic_desc' | 'planned_reserves_desc' | 'name_asc';
+export type CompanyListCursorKey = string | number | null;
+
+export interface CompanyListCursor {
+  k: CompanyListCursorKey;
+  id: number;
+}
+
+export interface CompanyListCursorRow {
+  id: number;
+  name: string;
+  plannedReservesCents?: number | bigint | null;
+  exitMoicBps?: number | null;
+}
+
+export function decodeCompanyListCursor(cursor: string): CompanyListCursor | null {
+  if (!COMPANY_LIST_CURSOR_BASE64URL_PATTERN.test(cursor)) {
+    return null;
+  }
+
+  try {
+    const decoded = Buffer.from(cursor, 'base64url').toString('utf8');
+    const parsed = JSON.parse(decoded) as unknown;
+
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return null;
+    }
+
+    const payload = parsed as Record<string, unknown>;
+    const id = payload['id'];
+    const key = payload['k'];
+
+    if (!Object.prototype.hasOwnProperty.call(payload, 'k')) {
+      return null;
+    }
+
+    if (typeof id !== 'number' || !Number.isSafeInteger(id) || id <= 0) {
+      return null;
+    }
+
+    if (
+      key !== null &&
+      typeof key !== 'string' &&
+      (typeof key !== 'number' || !Number.isFinite(key))
+    ) {
+      return null;
+    }
+
+    return { k: key as CompanyListCursorKey, id };
+  } catch {
+    return null;
+  }
+}
+
+export function isCompanyListCursorCompatible(
+  cursor: CompanyListCursor,
+  sortBy: CompanyListSortBy
+): boolean {
+  if (sortBy === 'name_asc') {
+    return typeof cursor.k === 'string';
+  }
+
+  if (sortBy === 'planned_reserves_desc') {
+    return typeof cursor.k === 'number';
+  }
+
+  return cursor.k === null || typeof cursor.k === 'number';
+}
+
+function plannedReservesSortValue(company: CompanyListCursorRow): number {
+  if ('plannedReservesCents' in company) {
+    return Number(company.plannedReservesCents ?? 0);
+  }
+
+  return 0;
+}
+
+function exitMoicSortKey(company: CompanyListCursorRow): number | null {
+  if ('exitMoicBps' in company) {
+    if (company.exitMoicBps == null) {
+      return null;
+    }
+    const value = Number(company.exitMoicBps);
+    return Number.isFinite(value) ? value : null;
+  }
+
+  return null;
+}
+
+function companyListSortKey(
+  company: CompanyListCursorRow,
+  sortBy: CompanyListSortBy
+): CompanyListCursorKey {
+  if (sortBy === 'name_asc') {
+    return company.name;
+  }
+
+  if (sortBy === 'planned_reserves_desc') {
+    return plannedReservesSortValue(company);
+  }
+
+  return exitMoicSortKey(company);
+}
+
+function compareNullableNumberDesc(left: number | null, right: number | null): number {
+  if (left === null && right === null) {
+    return 0;
+  }
+  if (left === null) {
+    return 1;
+  }
+  if (right === null) {
+    return -1;
+  }
+  return right - left;
+}
+
+export function compareCompanyListRows(
+  left: CompanyListCursorRow,
+  right: CompanyListCursorRow,
+  sortBy: CompanyListSortBy
+): number {
+  if (sortBy === 'name_asc') {
+    return left.name.localeCompare(right.name) || right.id - left.id;
+  }
+
+  if (sortBy === 'planned_reserves_desc') {
+    return plannedReservesSortValue(right) - plannedReservesSortValue(left) || right.id - left.id;
+  }
+
+  return (
+    compareNullableNumberDesc(exitMoicSortKey(left), exitMoicSortKey(right)) || right.id - left.id
+  );
+}
+
+export function isAfterCompanyListCursor(
+  company: CompanyListCursorRow,
+  cursor: CompanyListCursor,
+  sortBy: CompanyListSortBy
+): boolean {
+  const key = companyListSortKey(company, sortBy);
+
+  if (sortBy === 'name_asc') {
+    return (
+      typeof key === 'string' &&
+      typeof cursor.k === 'string' &&
+      (key.localeCompare(cursor.k) > 0 || (key === cursor.k && company.id < cursor.id))
+    );
+  }
+
+  if (sortBy === 'planned_reserves_desc') {
+    return (
+      typeof key === 'number' &&
+      typeof cursor.k === 'number' &&
+      (key < cursor.k || (key === cursor.k && company.id < cursor.id))
+    );
+  }
+
+  if (cursor.k === null) {
+    return key === null && company.id < cursor.id;
+  }
+
+  return (
+    typeof cursor.k === 'number' &&
+    (key === null ||
+      (typeof key === 'number' && (key < cursor.k || (key === cursor.k && company.id < cursor.id))))
+  );
+}
+
+export function encodeCompanyListCursor(
+  company: CompanyListCursorRow,
+  sortBy: CompanyListSortBy
+): string {
+  return Buffer.from(
+    JSON.stringify({ k: companyListSortKey(company, sortBy), id: company.id })
+  ).toString('base64url');
+}
+
+function requireCompanyListCursorNumberKey(cursor: CompanyListCursor): number {
+  if (typeof cursor.k !== 'number') {
+    throw new Error('Invalid numeric company-list cursor key');
+  }
+  return cursor.k;
+}
+
+function requireCompanyListCursorStringKey(cursor: CompanyListCursor): string {
+  if (typeof cursor.k !== 'string') {
+    throw new Error('Invalid string company-list cursor key');
+  }
+  return cursor.k;
+}
+
+export function companyListCursorPredicate(
+  cursor: CompanyListCursor,
+  sortBy: CompanyListSortBy
+): SQL {
+  if (sortBy === 'planned_reserves_desc') {
+    const key = requireCompanyListCursorNumberKey(cursor);
+    return sql`(${portfolioCompanies.plannedReservesCents}, ${portfolioCompanies.id}) < (${key}, ${cursor.id})`;
+  }
+
+  if (sortBy === 'name_asc') {
+    const key = requireCompanyListCursorStringKey(cursor);
+    return sql`(${portfolioCompanies.name}, -${portfolioCompanies.id}) > (${key}, ${-cursor.id})`;
+  }
+
+  if (cursor.k === null) {
+    return sql`${portfolioCompanies.exitMoicBps} IS NULL AND ${portfolioCompanies.id} < ${cursor.id}`;
+  }
+
+  const key = requireCompanyListCursorNumberKey(cursor);
+  return sql`((${portfolioCompanies.exitMoicBps}, ${portfolioCompanies.id}) < (${key}, ${cursor.id}) OR ${portfolioCompanies.exitMoicBps} IS NULL)`;
+}

--- a/tests/unit/routes/allocations.contract.test.ts
+++ b/tests/unit/routes/allocations.contract.test.ts
@@ -428,6 +428,10 @@ describe('allocations route contracts', () => {
   it('keeps the allocation read on the facts seam and strict response parser', async () => {
     const { readFileSync } = await vi.importActual<typeof import('node:fs')>('node:fs');
     const routeSource = readFileSync(join(process.cwd(), 'server/routes/allocations.ts'), 'utf8');
+    const readServiceSource = readFileSync(
+      join(process.cwd(), 'server/services/allocations/allocation-read-service.ts'),
+      'utf8'
+    );
     const driftSource = readFileSync(
       join(process.cwd(), 'server/services/allocations/allocation-actuals-drift-service.ts'),
       'utf8'
@@ -435,9 +439,11 @@ describe('allocations route contracts', () => {
     const forbiddenFactsTables =
       /investmentRounds|valuationMarks|investment_rounds|valuation_marks/;
 
-    expect(routeSource).toContain('buildFundCompanyActualsFacts');
-    expect(routeSource).toContain('LatestAllocationResponseSchema.parse');
+    expect(routeSource).toContain('allocationReadService.getLatest');
+    expect(readServiceSource).toContain('buildFundCompanyActualsFacts');
+    expect(readServiceSource).toContain('LatestAllocationResponseSchema.parse');
     expect(routeSource).not.toMatch(forbiddenFactsTables);
+    expect(readServiceSource).not.toMatch(forbiddenFactsTables);
     expect(driftSource).not.toMatch(forbiddenFactsTables);
   });
 

--- a/tests/unit/services/allocations/company-list-cursor.test.ts
+++ b/tests/unit/services/allocations/company-list-cursor.test.ts
@@ -1,0 +1,140 @@
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { describe, expect, it } from 'vitest';
+
+import {
+  companyListCursorPredicate,
+  decodeCompanyListCursor,
+  encodeCompanyListCursor,
+  isAfterCompanyListCursor,
+  isCompanyListCursorCompatible,
+  type CompanyListSortBy,
+} from '../../../../server/services/allocations/company-list-cursor';
+
+function cursorFor(payload: Record<string, unknown>): string {
+  return Buffer.from(JSON.stringify(payload)).toString('base64url');
+}
+
+describe('allocation company-list cursor', () => {
+  it.each([
+    { payload: { k: 27500, id: 31 }, expected: { k: 27500, id: 31 } },
+    { payload: { k: 'Alpha', id: 19 }, expected: { k: 'Alpha', id: 19 } },
+    { payload: { k: null, id: 7 }, expected: { k: null, id: 7 } },
+  ])('round-trips supported cursor payload $payload', ({ payload, expected }) => {
+    const encoded = cursorFor(payload);
+
+    expect(decodeCompanyListCursor(encoded)).toEqual(expected);
+  });
+
+  it.each([
+    'not+base64url',
+    cursorFor({ id: 1 }),
+    cursorFor({ k: 1, id: 0 }),
+    cursorFor({ k: 1, id: Number.MAX_SAFE_INTEGER + 1 }),
+    cursorFor({ k: true, id: 1 }),
+    Buffer.from('[]').toString('base64url'),
+  ])('rejects malformed cursor %s', (cursor) => {
+    expect(decodeCompanyListCursor(cursor)).toBeNull();
+  });
+
+  it.each([
+    { sortBy: 'exit_moic_desc', key: 25000, compatible: true },
+    { sortBy: 'exit_moic_desc', key: null, compatible: true },
+    { sortBy: 'exit_moic_desc', key: 'Alpha', compatible: false },
+    { sortBy: 'planned_reserves_desc', key: 500_000_00, compatible: true },
+    { sortBy: 'planned_reserves_desc', key: null, compatible: false },
+    { sortBy: 'name_asc', key: 'Alpha', compatible: true },
+    { sortBy: 'name_asc', key: 25000, compatible: false },
+  ] satisfies Array<{ sortBy: CompanyListSortBy; key: string | number | null; compatible: boolean }>) (
+    'requires $sortBy cursor key type compatibility for $key',
+    ({ sortBy, key, compatible }) => {
+      expect(isCompanyListCursorCompatible({ k: key, id: 11 }, sortBy)).toBe(compatible);
+    }
+  );
+
+  it.each([
+    {
+      sortBy: 'exit_moic_desc',
+      row: { id: 9, name: 'Alpha', exitMoicBps: 24000 },
+      payload: { k: 24000, id: 9 },
+    },
+    {
+      sortBy: 'planned_reserves_desc',
+      row: { id: 8, name: 'Alpha', plannedReservesCents: 900_000_00 },
+      payload: { k: 900_000_00, id: 8 },
+    },
+    { sortBy: 'name_asc', row: { id: 7, name: 'Beta' }, payload: { k: 'Beta', id: 7 } },
+  ] satisfies Array<{
+    sortBy: CompanyListSortBy;
+    row: { id: number; name: string; plannedReservesCents?: number; exitMoicBps?: number | null };
+    payload: { k: string | number | null; id: number };
+  }>)('encodes active $sortBy key plus id', ({ sortBy, row, payload }) => {
+    expect(encodeCompanyListCursor(row, sortBy)).toBe(cursorFor(payload));
+  });
+
+  it('keeps memory null-tail and tie-break behavior aligned with exit MOIC ordering', () => {
+    expect(
+      isAfterCompanyListCursor(
+        { id: 9, name: 'Null tail', exitMoicBps: null },
+        { k: 25000, id: 10 },
+        'exit_moic_desc'
+      )
+    ).toBe(true);
+    expect(
+      isAfterCompanyListCursor(
+        { id: 9, name: 'Tie after', exitMoicBps: 25000 },
+        { k: 25000, id: 10 },
+        'exit_moic_desc'
+      )
+    ).toBe(true);
+    expect(
+      isAfterCompanyListCursor(
+        { id: 11, name: 'Tie before', exitMoicBps: 25000 },
+        { k: 25000, id: 10 },
+        'exit_moic_desc'
+      )
+    ).toBe(false);
+    expect(
+      isAfterCompanyListCursor(
+        { id: 9, name: 'Null tail', exitMoicBps: null },
+        { k: null, id: 10 },
+        'exit_moic_desc'
+      )
+    ).toBe(true);
+  });
+
+  it.each([
+    {
+      sortBy: 'planned_reserves_desc',
+      cursor: { k: 500_000_00, id: 17 },
+      sql: '("portfoliocompanies"."planned_reserves_cents", "portfoliocompanies"."id") < ($1, $2)',
+      params: [500_000_00, 17],
+    },
+    {
+      sortBy: 'name_asc',
+      cursor: { k: 'Beta', id: 17 },
+      sql: '("portfoliocompanies"."name", -"portfoliocompanies"."id") > ($1, $2)',
+      params: ['Beta', -17],
+    },
+    {
+      sortBy: 'exit_moic_desc',
+      cursor: { k: 25000, id: 17 },
+      sql: '(("portfoliocompanies"."exit_moic_bps", "portfoliocompanies"."id") < ($1, $2) OR "portfoliocompanies"."exit_moic_bps" IS NULL)',
+      params: [25000, 17],
+    },
+    {
+      sortBy: 'exit_moic_desc',
+      cursor: { k: null, id: 17 },
+      sql: '"portfoliocompanies"."exit_moic_bps" IS NULL AND "portfoliocompanies"."id" < $1',
+      params: [17],
+    },
+  ] satisfies Array<{
+    sortBy: CompanyListSortBy;
+    cursor: { k: string | number | null; id: number };
+    sql: string;
+    params: unknown[];
+  }>)('preserves $sortBy database keyset predicate', ({ sortBy, cursor, sql, params }) => {
+    const rendered = new PgDialect().sqlToQuery(companyListCursorPredicate(cursor, sortBy));
+
+    expect(rendered).toEqual({ sql, params, typings: expect.any(Array) });
+  });
+});


### PR DESCRIPTION
## What changed

- extracted company-list cursor codec and PostgreSQL predicate construction into a focused module
- extracted allocation list/latest read orchestration into a read service
- reduced `server/routes/allocations.ts` from 1,141 to 493 lines (648-line, 56.8% reduction)
- left HTTP/auth/scope policy and entire write path in the router

## Contract preservation

- route literals unchanged
- normalized POST/write block is byte-identical to base, including `expected_version`, transaction, `applyAllocationUpdates`, 409 behavior, and error envelope
- cursor bytes, tie-break/null behavior, sort directions, table aliases, and SQL parameters preserved
- latest response keeps fund fallback, empty result, facts degradation, strict schema parsing, totals, and response shape

## Validation

- focused allocation/cursor/manifest batch - 103/103 passed in implementation run
- fresh controller cursor/route/manifest proof - 49/49 passed
- `npm run check` - passed
- `npm run lint` and guardrails - passed
- `npm run build` - passed
- `git diff --check` - passed
- independent task review - approved, no findings

## Verification limitations

- legacy `tests/api/allocations.test.ts` is `ENABLE_PHASE4_TESTS`-gated and excluded from default unit config, so it is not counted as proof
- DB keyset integration setup failed before assertions because local DB schema lacks `funds.deployed_capital`
- full server project exceeded the 603-second command ceiling and emitted EPIPE after parent termination; it is not counted as green

## Scope

Pure extraction only. No write semantics, API, auth, persistence schema, dependency, or public-contract change. Draft PR only; not merged.
