### PR TITLE
feat(schema): expand-first precursor for PR #1385 release-gate hardening (migration 0053)

### DIFF
--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -302,8 +302,9 @@ test_quarantine:
 # deleted files). Covers the files that define the Testcontainers proof lane:
 # every file in the vitest.config.testcontainers.ts include list, the DB
 # builders (journal replay + push), the vitest config, global setup, the
-# workflow, and this filter file itself (so edits to this group must run the
-# proof they gate). Keep in sync with the vitest include list.
+# workflow, this filter file, and canonical Testcontainers list module itself
+# (so edits to this trigger surface must run the proof they gate). Keep in sync
+# with the vitest include list.
 schema_tests:
   - 'migrations/**'
   - 'workers/**'
@@ -313,8 +314,10 @@ schema_tests:
   - 'server/migrations/**'
   - 'scripts/guardrails/server-migrations-new-file.mjs'
   - 'tests/helpers/testcontainers.ts'
+  - 'tests/helpers/testcontainers-migration.ts'
   - 'tests/integration/helpers/run-drizzle-push.ts'
   - 'vitest.config.testcontainers.ts'
+  - 'tests/config/testcontainers-test-paths.mjs'
   - 'tests/setup/global-setup.testcontainers.ts'
   - '.github/workflows/testcontainers-ci.yml'
   - '.github/path-filters.yml'
@@ -322,6 +325,7 @@ schema_tests:
   - 'tests/integration/fund-lifecycle-db.test.ts'
   - 'tests/integration/migration-drift.test.ts'
   - 'tests/integration/prod-schema-clone.test.ts'
+  - 'tests/integration/g3-schema-forward-compatibility.test.ts'
   - 'tests/integration/prod-journaled-migration-recovery.test.ts'
   - 'tests/integration/investment-scenario-capability.test.ts'
   - 'tests/integration/vehicle-financing-participations-real-pg.test.ts'

--- a/.github/workflows/prod-schema-reconcile.yml
+++ b/.github/workflows/prod-schema-reconcile.yml
@@ -95,12 +95,17 @@ jobs:
           fi
           echo "::add-mask::$SCHEMA_EVIDENCE_RETENTION_READ_TOKEN"
           retention_response_file="$(mktemp)"
-          trap 'rm -f "$retention_response_file"' EXIT
+          auth_header_file="$(mktemp)"
+          chmod 600 "$auth_header_file"
+          trap 'rm -f "$retention_response_file" "$auth_header_file"' EXIT
+          # Keep the token out of process argv: pass the Authorization header
+          # through a 0600 header file instead of a command-line argument.
+          printf 'header "Authorization: Bearer %s"\n' "$SCHEMA_EVIDENCE_RETENTION_READ_TOKEN" > "$auth_header_file"
           status="$(curl --silent --show-error \
             --output "$retention_response_file" \
             --write-out '%{http_code}' \
             --header "Accept: application/vnd.github+json" \
-            --header "Authorization: Bearer $SCHEMA_EVIDENCE_RETENTION_READ_TOKEN" \
+            --config "$auth_header_file" \
             --header "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/$REPOSITORY/actions/permissions/artifact-and-log-retention")"
           if [ "$status" -lt 200 ] || [ "$status" -ge 300 ]; then

--- a/.github/workflows/prod-schema-reconcile.yml
+++ b/.github/workflows/prod-schema-reconcile.yml
@@ -73,6 +73,58 @@ jobs:
       - name: Install dependencies
         run: npm ci --prefer-offline --no-audit
 
+      - name: Require first apply attempt
+        if: inputs.mode == 'apply'
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_RUN_ATTEMPT" != "1" ]; then
+            echo "Schema apply is only permitted on workflow attempt 1."
+            exit 1
+          fi
+
+      - name: Verify artifact retention before apply
+        if: inputs.mode == 'apply'
+        env:
+          SCHEMA_EVIDENCE_RETENTION_READ_TOKEN: ${{ secrets.SCHEMA_EVIDENCE_RETENTION_READ_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ -z "$SCHEMA_EVIDENCE_RETENTION_READ_TOKEN" ]; then
+            echo "SCHEMA_EVIDENCE_RETENTION_READ_TOKEN is required for apply mode."
+            exit 1
+          fi
+          echo "::add-mask::$SCHEMA_EVIDENCE_RETENTION_READ_TOKEN"
+          retention_response_file="$(mktemp)"
+          trap 'rm -f "$retention_response_file"' EXIT
+          status="$(curl --silent --show-error \
+            --output "$retention_response_file" \
+            --write-out '%{http_code}' \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer $SCHEMA_EVIDENCE_RETENTION_READ_TOKEN" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/$REPOSITORY/actions/permissions/artifact-and-log-retention")"
+          if [ "$status" -lt 200 ] || [ "$status" -ge 300 ]; then
+            echo "Artifact retention policy lookup failed before apply."
+            exit 1
+          fi
+          days="$(node - "$retention_response_file" <<'NODE'
+          const fs = require('node:fs');
+          const file = process.argv[2];
+          let body;
+          try {
+            body = JSON.parse(fs.readFileSync(file, 'utf8'));
+          } catch {
+            process.exit(1);
+          }
+          if (!Number.isSafeInteger(body?.days) || body.days < 90) process.exit(1);
+          process.stdout.write(String(body.days));
+          NODE
+          )" || {
+            echo "Artifact retention policy response is malformed or shorter than 90 days."
+            exit 1
+          }
+          echo "Artifact retention policy permits $days days."
+
       - name: Run pre-apply audit
         env:
           DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
@@ -232,6 +284,7 @@ jobs:
           exit "$STATUS"
 
       - name: Require clean post-apply audit
+        id: require_post_apply_clean
         if: ${{ !cancelled() && inputs.mode == 'apply' && (steps.post_audit.outcome == 'success' || steps.post_audit.outcome == 'failure') }}
         run: |
           node <<'NODE'
@@ -264,11 +317,52 @@ jobs:
           }
           NODE
 
+      - name: Build schema reconcile receipt
+        if: ${{ inputs.mode == 'apply' && steps.apply.outcome == 'success' && steps.post_audit.outcome == 'success' && steps.require_post_apply_clean.outcome == 'success' }}
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
+          SCHEMA_RECONCILE_SOURCE_SHA: ${{ inputs.expected_sha }}
+        run: |
+          set -euo pipefail
+          if ! grep -Eq '^g3-release-gate-hardening: APPLY-MISSING-DDL ' reports/pre-apply-audit.txt; then
+            echo "Apply receipt requires an APPLY-MISSING-DDL predecision."
+            exit 1
+          fi
+          npx tsx scripts/release/build-schema-reconcile-receipt.ts \
+            --output reports/schema-reconcile-receipt.json
+
+      - name: Require schema reconcile receipt after successful apply
+        if: ${{ inputs.mode == 'apply' && steps.apply.outcome == 'success' && steps.post_audit.outcome == 'success' && steps.require_post_apply_clean.outcome == 'success' }}
+        run: test -s reports/schema-reconcile-receipt.json
+
       - name: Upload redacted reconciliation reports
+        id: upload_evidence
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: prod-schema-reconcile-${{ github.run_id }}-${{ inputs.mode }}
-          path: reports/*.txt
-          if-no-files-found: warn
-          retention-days: 14
+          name: prod-schema-reconcile-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.mode }}-${{ inputs.expected_sha }}
+          path: |
+            reports/*.txt
+            reports/schema-reconcile-receipt.json
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Capture apply evidence identity
+        if: ${{ always() && inputs.mode == 'apply' && steps.apply.outcome == 'success' && steps.post_audit.outcome == 'success' && steps.require_post_apply_clean.outcome == 'success' }}
+        env:
+          ARTIFACT_ID: ${{ steps.upload_evidence.outputs.artifact-id }}
+          ARTIFACT_DIGEST: ${{ steps.upload_evidence.outputs.artifact-digest }}
+        run: |
+          set -euo pipefail
+          if [ -z "$ARTIFACT_ID" ] || [ -z "$ARTIFACT_DIGEST" ]; then
+            echo "Successful apply evidence is missing artifact identity outputs."
+            exit 1
+          fi
+          RECEIPT_SHA256="$(sha256sum reports/schema-reconcile-receipt.json | awk '{print $1}')"
+          {
+            echo "Schema evidence artifact ID: $ARTIFACT_ID"
+            echo "Schema evidence artifact digest: $ARTIFACT_DIGEST"
+            echo "Schema reconcile receipt SHA-256: $RECEIPT_SHA256"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/migrations/0053_g3_release_gate_hardening.sql
+++ b/migrations/0053_g3_release_gate_hardening.sql
@@ -44,14 +44,14 @@ CREATE TABLE IF NOT EXISTS "fund_scenario_calculation_commands" (
         "status" = 'completed'
         AND "run_id" IS NOT NULL
         AND "correlation_id" IS NOT NULL
-        AND "response_status" = 202
+        AND "response_status" IS NOT DISTINCT FROM 202
         AND "response_body" IS NOT NULL
         AND jsonb_typeof("response_body") = 'object'
         AND "response_body" ?& ARRAY[
           'fundId', 'scenarioSetId', 'calculationMode', 'status', 'jobId', 'correlationId'
         ]
-        AND "response_body"->>'calculationMode' = 'async_reserve_allocation'
-        AND "response_body"->>'status' = 'queued'
+        AND "response_body"->>'calculationMode' IS NOT DISTINCT FROM 'async_reserve_allocation'
+        AND "response_body"->>'status' IS NOT DISTINCT FROM 'queued'
         AND "failure_code" IS NULL
         AND "lease_token" IS NULL
         AND "lease_expires_at" IS NULL

--- a/migrations/0053_g3_release_gate_hardening.sql
+++ b/migrations/0053_g3_release_gate_hardening.sql
@@ -1,0 +1,215 @@
+-- @drift-patch
+-- Reason: G3 release-gate precursor adds the durable calculation command ledger,
+-- exactly-once queued-event marker, workflow execution identity, and complete
+-- canary residue accounting. Additive and replay-safe; Drizzle owns transaction.
+
+CREATE TABLE IF NOT EXISTS "fund_scenario_calculation_commands" (
+  "id" uuid DEFAULT gen_random_uuid() NOT NULL,
+  "fund_id" integer NOT NULL,
+  "scenario_set_id" uuid NOT NULL,
+  "idempotency_key" varchar(128) NOT NULL,
+  "request_hash" varchar(64) NOT NULL,
+  "status" varchar(16) DEFAULT 'pending' NOT NULL,
+  "run_id" uuid,
+  "correlation_id" varchar(36),
+  "response_status" integer,
+  "response_body" jsonb,
+  "attempt_count" integer DEFAULT 1 NOT NULL,
+  "lease_token" uuid,
+  "lease_expires_at" timestamp with time zone,
+  "failure_code" varchar(80),
+  "created_by_user_id" integer,
+  "created_by_label" text NOT NULL,
+  "version" integer DEFAULT 1 NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "fund_scenario_calculation_commands_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "fund_scenario_calculation_commands_fund_id_funds_id_fk"
+    FOREIGN KEY ("fund_id") REFERENCES "funds"("id") ON DELETE cascade,
+  CONSTRAINT "fund_scenario_calculation_commands_scenario_set_id_fund_scenario_sets_id_fk"
+    FOREIGN KEY ("scenario_set_id") REFERENCES "fund_scenario_sets"("id") ON DELETE cascade,
+  CONSTRAINT "fund_scenario_calculation_commands_run_id_fund_scenario_calculation_runs_id_fk"
+    FOREIGN KEY ("run_id") REFERENCES "fund_scenario_calculation_runs"("id") ON DELETE cascade,
+  CONSTRAINT "fund_scenario_calculation_commands_created_by_user_id_users_id_fk"
+    FOREIGN KEY ("created_by_user_id") REFERENCES "users"("id") ON DELETE restrict,
+  CONSTRAINT "fund_scenario_calc_commands_scope_unique"
+    UNIQUE ("fund_id", "scenario_set_id", "idempotency_key"),
+  CONSTRAINT "fund_scenario_calc_commands_status_check"
+    CHECK ("status" IN ('pending', 'completed', 'failed')),
+  CONSTRAINT "fund_scenario_calc_commands_hash_check"
+    CHECK ("request_hash" ~ '^[a-f0-9]{64}$'),
+  CONSTRAINT "fund_scenario_calc_commands_response_check"
+    CHECK (
+      (
+        "status" = 'completed'
+        AND "run_id" IS NOT NULL
+        AND "correlation_id" IS NOT NULL
+        AND "response_status" = 202
+        AND "response_body" IS NOT NULL
+        AND jsonb_typeof("response_body") = 'object'
+        AND "response_body" ?& ARRAY[
+          'fundId', 'scenarioSetId', 'calculationMode', 'status', 'jobId', 'correlationId'
+        ]
+        AND "response_body"->>'calculationMode' = 'async_reserve_allocation'
+        AND "response_body"->>'status' = 'queued'
+        AND "failure_code" IS NULL
+        AND "lease_token" IS NULL
+        AND "lease_expires_at" IS NULL
+      )
+      OR (
+        "status" = 'pending'
+        AND "response_status" IS NULL
+        AND "response_body" IS NULL
+        AND "failure_code" IS NULL
+        AND (
+          ("run_id" IS NULL AND "correlation_id" IS NULL)
+          OR ("run_id" IS NOT NULL AND "correlation_id" IS NOT NULL)
+        )
+      )
+      OR (
+        "status" = 'failed'
+        AND "response_status" IS NULL
+        AND "response_body" IS NULL
+        AND "failure_code" IS NOT NULL
+        AND (
+          ("run_id" IS NULL AND "correlation_id" IS NULL)
+          OR ("run_id" IS NOT NULL AND "correlation_id" IS NOT NULL)
+        )
+        AND "lease_token" IS NULL
+        AND "lease_expires_at" IS NULL
+      )
+    ),
+  CONSTRAINT "fund_scenario_calc_commands_lease_check"
+    CHECK (
+      ("lease_token" IS NULL AND "lease_expires_at" IS NULL)
+      OR ("lease_token" IS NOT NULL AND "lease_expires_at" IS NOT NULL)
+    ),
+  CONSTRAINT "fund_scenario_calc_commands_attempt_check"
+    CHECK ("attempt_count" >= 1),
+  CONSTRAINT "fund_scenario_calc_commands_version_check"
+    CHECK ("version" >= 1)
+);
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "fund_scenario_calc_commands_status_idx"
+  ON "fund_scenario_calculation_commands" ("status", "lease_expires_at");
+--> statement-breakpoint
+
+ALTER TABLE "fund_scenario_calculation_runs"
+  ADD COLUMN IF NOT EXISTS "queued_event_recorded_at" timestamp with time zone;
+--> statement-breakpoint
+
+UPDATE "fund_scenario_calculation_runs" AS run
+SET "queued_event_recorded_at" = (
+  SELECT event."created_at"
+  FROM "fund_scenario_set_events" AS event
+  WHERE event."fund_id" = run."fund_id"
+    AND event."scenario_set_id" = run."scenario_set_id"
+    AND event."event_type" = 'calculation_queued'
+    AND event."change_summary_json"->>'correlation_id' = run."correlation_id"
+  ORDER BY event."created_at" ASC, event."id" ASC
+  LIMIT 1
+)
+WHERE run."queued_event_recorded_at" IS NULL
+  AND EXISTS (
+    SELECT 1
+    FROM "fund_scenario_set_events" AS event
+    WHERE event."fund_id" = run."fund_id"
+      AND event."scenario_set_id" = run."scenario_set_id"
+      AND event."event_type" = 'calculation_queued'
+      AND event."change_summary_json"->>'correlation_id' = run."correlation_id"
+  );
+--> statement-breakpoint
+
+ALTER TABLE "release_canary_runs"
+  ADD COLUMN IF NOT EXISTS "workflow_run_id" varchar(32);
+--> statement-breakpoint
+ALTER TABLE "release_canary_runs"
+  ADD COLUMN IF NOT EXISTS "workflow_run_attempt" integer;
+--> statement-breakpoint
+ALTER TABLE "release_canary_runs"
+  ADD COLUMN IF NOT EXISTS "grant_residue_count" integer DEFAULT 0 NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "release_canary_runs"
+  ADD COLUMN IF NOT EXISTS "calculation_residue_count" integer DEFAULT 0 NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "release_canary_runs"
+  ADD COLUMN IF NOT EXISTS "mutation_receipt_residue_count" integer DEFAULT 0 NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "release_canary_runs"
+  ADD COLUMN IF NOT EXISTS "scenario_residue_count" integer DEFAULT 0 NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "release_canary_runs"
+  ADD COLUMN IF NOT EXISTS "reporting_residue_count" integer DEFAULT 0 NOT NULL;
+--> statement-breakpoint
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'public.release_canary_runs'::regclass
+      AND conname = 'release_canary_runs_workflow_identity_check'
+  ) THEN
+    ALTER TABLE "release_canary_runs"
+      ADD CONSTRAINT "release_canary_runs_workflow_identity_check"
+      CHECK (
+        (
+          "workflow_run_id" IS NULL
+          AND "workflow_run_attempt" IS NULL
+        )
+        OR (
+          "workflow_run_id" IS NOT NULL
+          AND "workflow_run_attempt" IS NOT NULL
+          AND "workflow_run_id" ~ '^[1-9][0-9]{0,31}$'
+          AND "workflow_run_attempt" >= 1
+        )
+      );
+  END IF;
+END $$;
+--> statement-breakpoint
+
+CREATE UNIQUE INDEX IF NOT EXISTS "release_canary_runs_workflow_identity_unique"
+  ON "release_canary_runs" ("workflow_run_id", "workflow_run_attempt")
+  WHERE "workflow_run_id" IS NOT NULL;
+--> statement-breakpoint
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'public.release_canary_runs'::regclass
+      AND conname = 'release_canary_runs_residue_count_check'
+  ) THEN
+    ALTER TABLE "release_canary_runs"
+      DROP CONSTRAINT "release_canary_runs_residue_count_check";
+  END IF;
+
+  ALTER TABLE "release_canary_runs"
+    ADD CONSTRAINT "release_canary_runs_residue_count_check"
+    CHECK (
+      "portfolio_company_residue_count" >= 0
+      AND "fund_residue_count" >= 0
+      AND "fund_config_residue_count" >= 0
+      AND "fund_event_residue_count" >= 0
+      AND "notification_residue_count" >= 0
+      AND "grant_residue_count" >= 0
+      AND "calculation_residue_count" >= 0
+      AND "mutation_receipt_residue_count" >= 0
+      AND "scenario_residue_count" >= 0
+      AND "reporting_residue_count" >= 0
+      AND "total_residue_count" = (
+        "portfolio_company_residue_count"
+        + "fund_residue_count"
+        + "fund_config_residue_count"
+        + "fund_event_residue_count"
+        + "notification_residue_count"
+        + "grant_residue_count"
+        + "calculation_residue_count"
+        + "mutation_receipt_residue_count"
+        + "scenario_residue_count"
+        + "reporting_residue_count"
+      )
+    );
+END $$;

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -379,6 +379,13 @@
       "when": 1785973200000,
       "tag": "0052_g3_capital_call_notification_outbox",
       "breakpoints": true
+    },
+    {
+      "idx": 54,
+      "version": "7",
+      "when": 1786059600000,
+      "tag": "0053_g3_release_gate_hardening",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/DEPLOYMENT_AUTOMATION_README.md
+++ b/scripts/DEPLOYMENT_AUTOMATION_README.md
@@ -3,6 +3,43 @@
 Complete automation for deploying CODEX fixes to staging and production with
 comprehensive smoke tests and security monitoring.
 
+## Production schema evidence preflight
+
+The `production-schema` environment owns the first and only governed apply of
+migration `0053`. Apply mode must run on workflow attempt 1 and uploads one
+immutable artifact named:
+
+```text
+prod-schema-reconcile-<runId>-<runAttempt>-<mode>-<expectedSha>
+```
+
+The artifact retention window is 90 days. Before any database connection or
+schema mutation, apply mode reads the repository artifact-and-log retention
+policy through:
+
+```text
+GET /repos/{owner}/{repo}/actions/permissions/artifact-and-log-retention
+```
+
+The `SCHEMA_EVIDENCE_RETENTION_READ_TOKEN` secret is a fine-grained token
+scoped only to this repository with Administration read permission and no
+write permission. The workflow masks it and uses it only for that GET request;
+it never enters command arguments, logs, artifacts, later steps, or a write
+API. Audit mode does not require this token.
+
+The apply receipt contains only the strict repository/workflow/run identity,
+source SHA, manifest `30-g3-release-gate-hardening`, migration `0053`,
+predecision `APPLY-MISSING-DDL`, postdecision `SKIP`, bounded build time, and
+`result=applied_and_clean`. It contains no database identifiers, connection
+data, secrets, report body, artifact ID, or artifact digest.
+
+If post-apply evidence is lost, the apply step started, or mutation outcome is
+unknown, stop. Do not rerun apply against a clean or uncertain database merely
+to recreate evidence. Record a new schema-evidence recovery decision. Rotate
+or revoke the retention-read credential after the first governed release under
+normal repository secret policy; retained artifacts use ordinary Actions read
+access.
+
 ## 📋 Overview
 
 These PowerShell scripts automate the entire deployment pipeline:

--- a/scripts/prod-schema-manifests/30-g3-release-gate-hardening.json
+++ b/scripts/prod-schema-manifests/30-g3-release-gate-hardening.json
@@ -72,6 +72,28 @@
     }
   ],
   "applyPolicy": {
+    "allowConstraintReplacements": [
+      {
+        "table": "release_canary_runs",
+        "name": "release_canary_runs_residue_count_check",
+        "expectedDefinition": {
+          "requiredFragments": [
+            "total_residue_count",
+            "portfolio_company_residue_count",
+            "fund_residue_count",
+            "fund_config_residue_count",
+            "fund_event_residue_count",
+            "notification_residue_count",
+            "grant_residue_count",
+            "calculation_residue_count",
+            "mutation_receipt_residue_count",
+            "scenario_residue_count",
+            "reporting_residue_count"
+          ],
+          "stringLiterals": []
+        }
+      }
+    ],
     "allowNonNullColumnAdds": [
       { "table": "release_canary_runs", "column": "grant_residue_count" },
       { "table": "release_canary_runs", "column": "calculation_residue_count" },

--- a/scripts/prod-schema-manifests/30-g3-release-gate-hardening.json
+++ b/scripts/prod-schema-manifests/30-g3-release-gate-hardening.json
@@ -1,0 +1,83 @@
+{
+  "name": "g3-release-gate-hardening",
+  "order": 30,
+  "description": "G3 release-gate schema precursor: durable calculation commands, queued-event fencing, workflow identity, and complete canary residue accounting.",
+  "missingTablePolicy": "create_or_repair",
+  "sqlFiles": ["migrations/0053_g3_release_gate_hardening.sql"],
+  "allowedCreateTables": ["fund_scenario_calculation_commands"],
+  "expectedTables": [
+    {
+      "name": "fund_scenario_calculation_commands",
+      "columns": [
+        { "name": "id", "type": "uuid", "nullable": false },
+        { "name": "fund_id", "type": "integer", "nullable": false },
+        { "name": "scenario_set_id", "type": "uuid", "nullable": false },
+        { "name": "idempotency_key", "type": "varchar", "nullable": false },
+        { "name": "request_hash", "type": "varchar", "nullable": false },
+        { "name": "status", "type": "varchar", "nullable": false },
+        { "name": "run_id", "type": "uuid", "nullable": true },
+        { "name": "correlation_id", "type": "varchar", "nullable": true },
+        { "name": "response_status", "type": "integer", "nullable": true },
+        { "name": "response_body", "type": "jsonb", "nullable": true },
+        { "name": "attempt_count", "type": "integer", "nullable": false },
+        { "name": "lease_token", "type": "uuid", "nullable": true },
+        { "name": "lease_expires_at", "type": "timestamptz", "nullable": true },
+        { "name": "failure_code", "type": "varchar", "nullable": true },
+        { "name": "created_by_user_id", "type": "integer", "nullable": true },
+        { "name": "created_by_label", "type": "text", "nullable": false },
+        { "name": "version", "type": "integer", "nullable": false },
+        { "name": "created_at", "type": "timestamptz", "nullable": false },
+        { "name": "updated_at", "type": "timestamptz", "nullable": false }
+      ],
+      "constraints": [
+        "fund_scenario_calculation_commands_pkey",
+        "fund_scenario_calculation_commands_fund_id_funds_id_fk",
+        "fund_scenario_calculation_commands_scenario_set_id_fund_scenario_sets_id_fk",
+        "fund_scenario_calculation_commands_run_id_fund_scenario_calculation_runs_id_fk",
+        "fund_scenario_calculation_commands_created_by_user_id_users_id_fk",
+        "fund_scenario_calc_commands_scope_unique",
+        "fund_scenario_calc_commands_status_check",
+        "fund_scenario_calc_commands_hash_check",
+        "fund_scenario_calc_commands_response_check",
+        "fund_scenario_calc_commands_lease_check",
+        "fund_scenario_calc_commands_attempt_check",
+        "fund_scenario_calc_commands_version_check"
+      ],
+      "indexes": ["fund_scenario_calc_commands_status_idx"]
+    },
+    {
+      "name": "fund_scenario_calculation_runs",
+      "sharedTable": true,
+      "columns": [
+        { "name": "queued_event_recorded_at", "type": "timestamptz", "nullable": true }
+      ]
+    },
+    {
+      "name": "release_canary_runs",
+      "sharedTable": true,
+      "columns": [
+        { "name": "workflow_run_id", "type": "varchar", "nullable": true },
+        { "name": "workflow_run_attempt", "type": "integer", "nullable": true },
+        { "name": "grant_residue_count", "type": "integer", "nullable": false },
+        { "name": "calculation_residue_count", "type": "integer", "nullable": false },
+        { "name": "mutation_receipt_residue_count", "type": "integer", "nullable": false },
+        { "name": "scenario_residue_count", "type": "integer", "nullable": false },
+        { "name": "reporting_residue_count", "type": "integer", "nullable": false }
+      ],
+      "constraints": [
+        "release_canary_runs_workflow_identity_check",
+        "release_canary_runs_residue_count_check"
+      ],
+      "indexes": ["release_canary_runs_workflow_identity_unique"]
+    }
+  ],
+  "applyPolicy": {
+    "allowNonNullColumnAdds": [
+      { "table": "release_canary_runs", "column": "grant_residue_count" },
+      { "table": "release_canary_runs", "column": "calculation_residue_count" },
+      { "table": "release_canary_runs", "column": "mutation_receipt_residue_count" },
+      { "table": "release_canary_runs", "column": "scenario_residue_count" },
+      { "table": "release_canary_runs", "column": "reporting_residue_count" }
+    ]
+  }
+}

--- a/scripts/reconcile-prod-schema.mjs
+++ b/scripts/reconcile-prod-schema.mjs
@@ -429,8 +429,11 @@ function validateApplyPolicy(manifest) {
       expectedDefinition.requiredFragments.some(
         (fragment) => typeof fragment !== 'string' || fragment.trim().length === 0
       ) ||
+      // A numeric-only constraint (e.g. residue-count equality) legitimately
+      // has zero string literals; an empty array is an explicit declaration
+      // that the live definition must contain none, enforced by exact
+      // multiset comparison in constraintDefinitionMatches.
       !Array.isArray(expectedDefinition.stringLiterals) ||
-      expectedDefinition.stringLiterals.length === 0 ||
       expectedDefinition.stringLiterals.some(
         (literal) => typeof literal !== 'string' || literal.length === 0
       )

--- a/scripts/release/build-schema-reconcile-receipt.ts
+++ b/scripts/release/build-schema-reconcile-receipt.ts
@@ -1,0 +1,128 @@
+import { randomUUID } from 'node:crypto';
+import { chmod, mkdir, rename, unlink, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  SchemaReconcileReceiptV1Schema,
+  type SchemaReconcileReceiptV1,
+} from '../../shared/contracts/schema-reconcile-receipt-v1.contract';
+
+export interface BuildSchemaReconcileReceiptInput {
+  repository: string;
+  workflowPath: '.github/workflows/prod-schema-reconcile.yml';
+  runId: string;
+  runAttempt: number;
+  mode: 'apply';
+  sourceSha: string;
+  manifest: '30-g3-release-gate-hardening';
+  migration: '0053';
+  preDecision: 'APPLY-MISSING-DDL';
+  postDecision: 'SKIP';
+  startedAtMs: number;
+  completedAtMs: number;
+}
+
+function assertTimestamp(name: string, value: number): void {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative integer timestamp`);
+  }
+}
+
+export function buildSchemaReconcileReceipt(
+  input: BuildSchemaReconcileReceiptInput
+): SchemaReconcileReceiptV1 {
+  assertTimestamp('startedAtMs', input.startedAtMs);
+  assertTimestamp('completedAtMs', input.completedAtMs);
+  if (input.completedAtMs < input.startedAtMs) {
+    throw new Error('completedAtMs must not precede startedAtMs');
+  }
+
+  return SchemaReconcileReceiptV1Schema.parse({
+    repository: input.repository,
+    workflowPath: input.workflowPath,
+    runId: input.runId,
+    runAttempt: input.runAttempt,
+    mode: input.mode,
+    sourceSha: input.sourceSha,
+    manifest: input.manifest,
+    migration: input.migration,
+    preDecision: input.preDecision,
+    postDecision: input.postDecision,
+    buildTimeMs: input.completedAtMs - input.startedAtMs,
+    result: 'applied_and_clean',
+  });
+}
+
+function requiredEnvironment(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function requiredPositiveIntegerEnvironment(name: string): number {
+  const value = Number(requiredEnvironment(name));
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
+}
+
+function parseOutputPath(argv: readonly string[]): string {
+  const index = argv.indexOf('--output');
+  const output = index >= 0 ? argv[index + 1] : undefined;
+  if (!output) throw new Error('--output is required');
+  return path.resolve(output);
+}
+
+export async function writeSchemaReconcileReceipt(
+  outputPath: string,
+  receipt: SchemaReconcileReceiptV1
+): Promise<void> {
+  const directory = path.dirname(outputPath);
+  await mkdir(directory, { recursive: true });
+  const temporaryPath = path.join(
+    directory,
+    `.${path.basename(outputPath)}.${process.pid}.${randomUUID()}.tmp`
+  );
+  try {
+    await writeFile(temporaryPath, `${JSON.stringify(receipt, null, 2)}\n`, {
+      encoding: 'utf8',
+      mode: 0o600,
+    });
+    await chmod(temporaryPath, 0o600);
+    await rename(temporaryPath, outputPath);
+  } catch (error) {
+    await unlink(temporaryPath).catch(() => undefined);
+    throw error;
+  }
+}
+
+async function main(): Promise<void> {
+  const startedAtMs = process.env['SCHEMA_RECONCILE_BUILD_STARTED_AT_MS']
+    ? Number(process.env['SCHEMA_RECONCILE_BUILD_STARTED_AT_MS'])
+    : Date.now();
+  const completedAtMs = process.env['SCHEMA_RECONCILE_BUILD_COMPLETED_AT_MS']
+    ? Number(process.env['SCHEMA_RECONCILE_BUILD_COMPLETED_AT_MS'])
+    : Date.now();
+  const receipt = buildSchemaReconcileReceipt({
+    repository: requiredEnvironment('GITHUB_REPOSITORY'),
+    workflowPath: '.github/workflows/prod-schema-reconcile.yml',
+    runId: requiredEnvironment('GITHUB_RUN_ID'),
+    runAttempt: requiredPositiveIntegerEnvironment('GITHUB_RUN_ATTEMPT'),
+    mode: 'apply',
+    sourceSha: requiredEnvironment('SCHEMA_RECONCILE_SOURCE_SHA'),
+    manifest: '30-g3-release-gate-hardening',
+    migration: '0053',
+    preDecision: 'APPLY-MISSING-DDL',
+    postDecision: 'SKIP',
+    startedAtMs,
+    completedAtMs,
+  });
+  await writeSchemaReconcileReceipt(parseOutputPath(process.argv.slice(2)), receipt);
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : '';
+if (invokedPath === path.resolve(fileURLToPath(import.meta.url))) {
+  await main();
+}

--- a/shared/contracts/schema-reconcile-receipt-v1.contract.ts
+++ b/shared/contracts/schema-reconcile-receipt-v1.contract.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+
+const GitHubRepositorySchema = z
+  .string()
+  .regex(/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/, 'Repository must be owner/name');
+const PositiveDecimalIdSchema = z
+  .string()
+  .regex(/^[1-9][0-9]{0,31}$/, 'Identifier must be a positive decimal string');
+const SourceShaSchema = z.string().regex(/^[a-f0-9]{40}$/, 'Source SHA must be lowercase SHA-1');
+
+export const SchemaReconcileReceiptV1Schema = z
+  .object({
+    repository: GitHubRepositorySchema,
+    workflowPath: z.literal('.github/workflows/prod-schema-reconcile.yml'),
+    runId: PositiveDecimalIdSchema,
+    runAttempt: z.number().int().min(1).max(100),
+    mode: z.literal('apply'),
+    sourceSha: SourceShaSchema,
+    manifest: z.literal('30-g3-release-gate-hardening'),
+    migration: z.literal('0053'),
+    preDecision: z.literal('APPLY-MISSING-DDL'),
+    postDecision: z.literal('SKIP'),
+    buildTimeMs: z.number().int().min(0).max(900_000),
+    result: z.literal('applied_and_clean'),
+  })
+  .strict()
+  .superRefine((receipt, ctx) => {
+    if (receipt.runAttempt !== 1) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['runAttempt'],
+        message: 'Schema apply must run on attempt 1',
+      });
+    }
+  });
+
+export type SchemaReconcileReceiptV1 = z.infer<typeof SchemaReconcileReceiptV1Schema>;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -45,6 +45,7 @@ export * from './schema/substrate-shadow-reconciliations';
 export * from './schema/financial-facts-snapshots';
 export * from './schema/current-plans';
 export * from './schema/fund-calculation-modes';
+export * from './schema/fund-scenario-calculation-commands';
 export * from './schema/fund-moic-input-update-requests';
 export * from './schema/portfolio-update-receipts';
 export * from './schema/release-canary';

--- a/shared/schema/fund-scenario-calculation-commands.ts
+++ b/shared/schema/fund-scenario-calculation-commands.ts
@@ -1,0 +1,133 @@
+import { sql } from 'drizzle-orm';
+import {
+  check,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  unique,
+  uuid,
+  varchar,
+} from 'drizzle-orm/pg-core';
+
+import { fundScenarioCalculationRuns, fundScenarioSets, funds } from './fund';
+import { users } from './user';
+
+export const fundScenarioCalculationCommands = pgTable(
+  'fund_scenario_calculation_commands',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    fundId: integer('fund_id')
+      .notNull()
+      .references(() => funds.id, { onDelete: 'cascade' }),
+    scenarioSetId: uuid('scenario_set_id')
+      .notNull()
+      .references(() => fundScenarioSets.id, { onDelete: 'cascade' }),
+    idempotencyKey: varchar('idempotency_key', { length: 128 }).notNull(),
+    requestHash: varchar('request_hash', { length: 64 }).notNull(),
+    status: varchar('status', { length: 16 })
+      .notNull()
+      .default('pending')
+      .$type<'pending' | 'completed' | 'failed'>(),
+    runId: uuid('run_id').references(() => fundScenarioCalculationRuns.id, {
+      onDelete: 'cascade',
+    }),
+    correlationId: varchar('correlation_id', { length: 36 }),
+    responseStatus: integer('response_status'),
+    responseBody: jsonb('response_body').$type<Record<string, unknown>>(),
+    attemptCount: integer('attempt_count').notNull().default(1),
+    leaseToken: uuid('lease_token'),
+    leaseExpiresAt: timestamp('lease_expires_at', { withTimezone: true }),
+    failureCode: varchar('failure_code', { length: 80 }),
+    createdByUserId: integer('created_by_user_id').references(() => users.id, {
+      onDelete: 'restrict',
+    }),
+    createdByLabel: text('created_by_label').notNull(),
+    version: integer('version').notNull().default(1),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    scopeUnique: unique('fund_scenario_calc_commands_scope_unique').on(
+      table.fundId,
+      table.scenarioSetId,
+      table.idempotencyKey
+    ),
+    statusCheck: check(
+      'fund_scenario_calc_commands_status_check',
+      sql`${table.status} IN ('pending', 'completed', 'failed')`
+    ),
+    hashCheck: check(
+      'fund_scenario_calc_commands_hash_check',
+      sql`${table.requestHash} ~ '^[a-f0-9]{64}$'`
+    ),
+    responseCheck: check(
+      'fund_scenario_calc_commands_response_check',
+      sql`
+        (
+          ${table.status} = 'completed'
+          AND ${table.runId} IS NOT NULL
+          AND ${table.correlationId} IS NOT NULL
+          AND ${table.responseStatus} = 202
+          AND ${table.responseBody} IS NOT NULL
+          AND jsonb_typeof(${table.responseBody}) = 'object'
+          AND ${table.responseBody} ?& ARRAY[
+            'fundId', 'scenarioSetId', 'calculationMode', 'status', 'jobId', 'correlationId'
+          ]
+          AND ${table.responseBody}->>'calculationMode' = 'async_reserve_allocation'
+          AND ${table.responseBody}->>'status' = 'queued'
+          AND ${table.failureCode} IS NULL
+          AND ${table.leaseToken} IS NULL
+          AND ${table.leaseExpiresAt} IS NULL
+        )
+        OR (
+          ${table.status} = 'pending'
+          AND ${table.responseStatus} IS NULL
+          AND ${table.responseBody} IS NULL
+          AND ${table.failureCode} IS NULL
+          AND (
+            (${table.runId} IS NULL AND ${table.correlationId} IS NULL)
+            OR (${table.runId} IS NOT NULL AND ${table.correlationId} IS NOT NULL)
+          )
+        )
+        OR (
+          ${table.status} = 'failed'
+          AND ${table.responseStatus} IS NULL
+          AND ${table.responseBody} IS NULL
+          AND ${table.failureCode} IS NOT NULL
+          AND (
+            (${table.runId} IS NULL AND ${table.correlationId} IS NULL)
+            OR (${table.runId} IS NOT NULL AND ${table.correlationId} IS NOT NULL)
+          )
+          AND ${table.leaseToken} IS NULL
+          AND ${table.leaseExpiresAt} IS NULL
+        )
+      `
+    ),
+    leaseCheck: check(
+      'fund_scenario_calc_commands_lease_check',
+      sql`
+        (${table.leaseToken} IS NULL AND ${table.leaseExpiresAt} IS NULL)
+        OR (${table.leaseToken} IS NOT NULL AND ${table.leaseExpiresAt} IS NOT NULL)
+      `
+    ),
+    attemptCheck: check(
+      'fund_scenario_calc_commands_attempt_check',
+      sql`${table.attemptCount} >= 1`
+    ),
+    versionCheck: check(
+      'fund_scenario_calc_commands_version_check',
+      sql`${table.version} >= 1`
+    ),
+    statusIdx: index('fund_scenario_calc_commands_status_idx').on(
+      table.status,
+      table.leaseExpiresAt
+    ),
+  })
+);
+
+export type FundScenarioCalculationCommand = typeof fundScenarioCalculationCommands.$inferSelect;
+export type NewFundScenarioCalculationCommand =
+  typeof fundScenarioCalculationCommands.$inferInsert;

--- a/shared/schema/fund-scenario-calculation-commands.ts
+++ b/shared/schema/fund-scenario-calculation-commands.ts
@@ -70,14 +70,14 @@ export const fundScenarioCalculationCommands = pgTable(
           ${table.status} = 'completed'
           AND ${table.runId} IS NOT NULL
           AND ${table.correlationId} IS NOT NULL
-          AND ${table.responseStatus} = 202
+          AND ${table.responseStatus} IS NOT DISTINCT FROM 202
           AND ${table.responseBody} IS NOT NULL
           AND jsonb_typeof(${table.responseBody}) = 'object'
           AND ${table.responseBody} ?& ARRAY[
             'fundId', 'scenarioSetId', 'calculationMode', 'status', 'jobId', 'correlationId'
           ]
-          AND ${table.responseBody}->>'calculationMode' = 'async_reserve_allocation'
-          AND ${table.responseBody}->>'status' = 'queued'
+          AND ${table.responseBody}->>'calculationMode' IS NOT DISTINCT FROM 'async_reserve_allocation'
+          AND ${table.responseBody}->>'status' IS NOT DISTINCT FROM 'queued'
           AND ${table.failureCode} IS NULL
           AND ${table.leaseToken} IS NULL
           AND ${table.leaseExpiresAt} IS NULL

--- a/shared/schema/fund.ts
+++ b/shared/schema/fund.ts
@@ -381,6 +381,7 @@ export const fundScenarioCalculationRuns = pgTable(
     completedAt: timestamp('completed_at', { withTimezone: true }),
     failedAt: timestamp('failed_at', { withTimezone: true }),
     deadlineAt: timestamp('deadline_at', { withTimezone: true }),
+    queuedEventRecordedAt: timestamp('queued_event_recorded_at', { withTimezone: true }),
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
   },

--- a/shared/schema/release-canary.ts
+++ b/shared/schema/release-canary.ts
@@ -1,5 +1,14 @@
 import { sql } from 'drizzle-orm';
-import { check, index, integer, pgTable, timestamp, uuid, varchar } from 'drizzle-orm/pg-core';
+import {
+  check,
+  index,
+  integer,
+  pgTable,
+  timestamp,
+  uniqueIndex,
+  uuid,
+  varchar,
+} from 'drizzle-orm/pg-core';
 
 import { users } from './user';
 
@@ -22,6 +31,8 @@ export const releaseCanaryRuns = pgTable(
     deploymentId: varchar('deployment_id', { length: 128 }).notNull(),
     workerDeploymentId: varchar('worker_deployment_id', { length: 128 }).notNull(),
     correlationId: varchar('correlation_id', { length: 128 }).notNull(),
+    workflowRunId: varchar('workflow_run_id', { length: 32 }),
+    workflowRunAttempt: integer('workflow_run_attempt'),
     principalUserId: integer('principal_user_id')
       .notNull()
       .references(() => users.id, { onDelete: 'restrict' }),
@@ -40,6 +51,11 @@ export const releaseCanaryRuns = pgTable(
     fundConfigResidueCount: integer('fund_config_residue_count').notNull().default(0),
     fundEventResidueCount: integer('fund_event_residue_count').notNull().default(0),
     notificationResidueCount: integer('notification_residue_count').notNull().default(0),
+    grantResidueCount: integer('grant_residue_count').notNull().default(0),
+    calculationResidueCount: integer('calculation_residue_count').notNull().default(0),
+    mutationReceiptResidueCount: integer('mutation_receipt_residue_count').notNull().default(0),
+    scenarioResidueCount: integer('scenario_residue_count').notNull().default(0),
+    reportingResidueCount: integer('reporting_residue_count').notNull().default(0),
     totalResidueCount: integer('total_residue_count').notNull().default(0),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
@@ -50,10 +66,51 @@ export const releaseCanaryRuns = pgTable(
       sql`${table.status} IN ('created', 'running', 'completed', 'failed', 'expired', 'purged')`
     ),
     versionCheck: check('release_canary_runs_version_check', sql`${table.version} >= 1`),
+    workflowIdentityCheck: check(
+      'release_canary_runs_workflow_identity_check',
+      sql`
+        (
+          ${table.workflowRunId} IS NULL
+          AND ${table.workflowRunAttempt} IS NULL
+        )
+        OR (
+          ${table.workflowRunId} IS NOT NULL
+          AND ${table.workflowRunAttempt} IS NOT NULL
+          AND ${table.workflowRunId} ~ '^[1-9][0-9]{0,31}$'
+          AND ${table.workflowRunAttempt} >= 1
+        )
+      `
+    ),
     residueCountCheck: check(
       'release_canary_runs_residue_count_check',
-      sql`${table.portfolioCompanyResidueCount} >= 0 AND ${table.fundResidueCount} >= 0 AND ${table.fundConfigResidueCount} >= 0 AND ${table.fundEventResidueCount} >= 0 AND ${table.notificationResidueCount} >= 0 AND ${table.totalResidueCount} >= 0`
+      sql`
+        ${table.portfolioCompanyResidueCount} >= 0
+        AND ${table.fundResidueCount} >= 0
+        AND ${table.fundConfigResidueCount} >= 0
+        AND ${table.fundEventResidueCount} >= 0
+        AND ${table.notificationResidueCount} >= 0
+        AND ${table.grantResidueCount} >= 0
+        AND ${table.calculationResidueCount} >= 0
+        AND ${table.mutationReceiptResidueCount} >= 0
+        AND ${table.scenarioResidueCount} >= 0
+        AND ${table.reportingResidueCount} >= 0
+        AND ${table.totalResidueCount} = (
+          ${table.portfolioCompanyResidueCount}
+          + ${table.fundResidueCount}
+          + ${table.fundConfigResidueCount}
+          + ${table.fundEventResidueCount}
+          + ${table.notificationResidueCount}
+          + ${table.grantResidueCount}
+          + ${table.calculationResidueCount}
+          + ${table.mutationReceiptResidueCount}
+          + ${table.scenarioResidueCount}
+          + ${table.reportingResidueCount}
+        )
+      `
     ),
+    workflowIdentityUnique: uniqueIndex('release_canary_runs_workflow_identity_unique')
+      .on(table.workflowRunId, table.workflowRunAttempt)
+      .where(sql`${table.workflowRunId} IS NOT NULL`),
     statusIdx: index('release_canary_runs_status_idx').on(table.status, table.expiresAt),
     principalIdx: index('release_canary_runs_principal_idx').on(table.principalUserId),
   })

--- a/tests/config/testcontainers-test-paths.mjs
+++ b/tests/config/testcontainers-test-paths.mjs
@@ -3,6 +3,7 @@ export const TESTCONTAINERS_TEST_PATHS = Object.freeze([
   'tests/integration/fund-lifecycle-db.test.ts',
   'tests/integration/migration-drift.test.ts',
   'tests/integration/prod-schema-clone.test.ts',
+  'tests/integration/g3-schema-forward-compatibility.test.ts',
   'tests/integration/prod-schema-reconcile-partial-drift.test.ts',
   'tests/integration/prod-journaled-migration-recovery.test.ts',
   'tests/integration/migrations/investment-rounds-schema.test.ts',

--- a/tests/integration/g3-schema-forward-compatibility.test.ts
+++ b/tests/integration/g3-schema-forward-compatibility.test.ts
@@ -1,0 +1,270 @@
+import { PostgreSqlContainer, type StartedPostgreSqlContainer } from '@testcontainers/postgresql';
+import { readFile } from 'node:fs/promises';
+import { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { runMigrationsWithConnectionString } from '../helpers/testcontainers-migration';
+
+const STARTUP_TIMEOUT_MS = 90_000;
+const skipIfNoDocker = !process.env.TEST_DATABASE_URL && !process.env.CI && process.platform === 'win32';
+
+let postgres: StartedPostgreSqlContainer | undefined;
+let connectionString: string | undefined;
+let pool: Pool | undefined;
+let closeApplicationPool: (() => Promise<void>) | undefined;
+
+describe.skipIf(skipIfNoDocker)('G3 schema forward compatibility', () => {
+  beforeAll(async () => {
+    const configuredConnectionString = process.env.TEST_DATABASE_URL;
+    let databaseUrl = configuredConnectionString;
+    if (!databaseUrl) {
+      postgres = await new PostgreSqlContainer('pgvector/pgvector:pg16')
+        .withDatabase('g3_schema_forward_compatibility')
+        .withUsername('test_user')
+        .withPassword('test_password')
+        .withStartupTimeout(STARTUP_TIMEOUT_MS)
+        .start();
+      databaseUrl = postgres.getConnectionUri();
+    }
+    connectionString = databaseUrl;
+
+    // Two-stage apply mirrors production: baseline schema stops at 0052, then
+    // 0053 applies on top — proving the precursor lands cleanly on a 0052 base
+    // before any application code runs against the expanded schema.
+    await runMigrationsWithConnectionString(
+      databaseUrl,
+      '0052_g3_capital_call_notification_outbox'
+    );
+    await runMigrationsWithConnectionString(
+      databaseUrl,
+      '0053_g3_release_gate_hardening'
+    );
+    pool = new Pool({ connectionString: databaseUrl, max: 1 });
+
+    Object.assign(process.env, {
+      DATABASE_URL: databaseUrl,
+      USE_REAL_DB_IN_VITEST: '1',
+      RELEASE_CANARY_TTL_HOURS: '24',
+      RELEASE_CANARY_MAX_PORTFOLIO_COMPANY_RESIDUE: '100',
+      RELEASE_CANARY_MAX_FUND_RESIDUE: '100',
+      RELEASE_CANARY_MAX_FUND_CONFIG_RESIDUE: '100',
+      RELEASE_CANARY_MAX_FUND_EVENT_RESIDUE: '100',
+      RELEASE_CANARY_MAX_NOTIFICATION_RESIDUE: '100',
+      RELEASE_CANARY_MAX_TOTAL_RESIDUE: '1000',
+    });
+
+    const { fundPersistenceService } = await import(
+      '../../server/services/fund-persistence-service'
+    );
+    const { getReserveScenarioCalculationIdentity } = await import(
+      '../../server/services/fund-scenario-reserve-calculation-service'
+    );
+    const { closeDatabasePool } = await import('../../server/db');
+    closeApplicationPool = closeDatabasePool;
+
+    await pool.query(`
+      INSERT INTO users (username, password, role, is_release_canary_principal)
+      VALUES
+        ('g3-forward-compat-ordinary', 'test-password', 'partner', false),
+        ('g3-forward-compat-canary', 'test-password', 'partner', true)
+    `);
+
+    const ordinaryUser = await pool.query<{ id: number }>(
+      `SELECT id FROM users WHERE username = 'g3-forward-compat-ordinary'`
+    );
+    const canaryUser = await pool.query<{ id: number }>(
+      `SELECT id FROM users WHERE username = 'g3-forward-compat-canary'`
+    );
+
+    const ordinary = await fundPersistenceService.createFundWithInitialDraft(
+      {
+        name: 'G3 ordinary compatibility fund',
+        size: '1000000',
+        managementFee: '0.02',
+        carryPercentage: '0.2',
+        vintageYear: 2026,
+        creatorUserId: ordinaryUser.rows[0]!.id,
+      },
+      { fundName: 'G3 ordinary compatibility fund', modelInputsAsOfDate: '2026-01-01' }
+    );
+    const canary = await fundPersistenceService.createFundWithInitialDraft(
+      {
+        name: 'G3 canary compatibility fund',
+        size: '1000000',
+        managementFee: '0.02',
+        carryPercentage: '0.2',
+        vintageYear: 2026,
+        creatorUserId: canaryUser.rows[0]!.id,
+      },
+      { fundName: 'G3 canary compatibility fund', modelInputsAsOfDate: '2026-01-01' }
+    );
+
+    await pool.query(
+      `
+        UPDATE fundconfigs
+        SET is_draft = false, is_published = true, published_at = now()
+        WHERE id IN ($1, $2)
+      `,
+      [ordinary.draft.id, canary.draft.id]
+    );
+
+    const scenarioSet = await pool.query<{ id: string }>(
+      `
+        INSERT INTO fund_scenario_sets
+          (fund_id, name, description, source_config_id, source_config_version, created_by_user_id, created_by_label)
+        VALUES ($1, 'Legacy reserve scenario', 'Forward compatibility fixture', $2, 1, $3, 'legacy-test')
+        RETURNING id
+      `,
+      [ordinary.fund.id, ordinary.draft.id, ordinaryUser.rows[0]!.id]
+    );
+    const scenarioSetId = scenarioSet.rows[0]!.id;
+    await pool.query(
+      `
+        INSERT INTO fund_scenario_variants
+          (scenario_set_id, name, description, sort_order, override_type, override_payload)
+        VALUES ($1, 'Reserve baseline', 'Legacy reserve variant', 0, 'reserve_allocation',
+                '{"items": [{"companyId": 1, "plannedReservesCents": 0}]}'::jsonb)
+      `,
+      [scenarioSetId]
+    );
+
+    const calculationIdentity = await getReserveScenarioCalculationIdentity(
+      ordinary.fund.id,
+      scenarioSetId
+    );
+    const correlationId = '11111111-1111-4111-8111-111111111111';
+    const run = await pool.query<{ id: string }>(
+      `
+        INSERT INTO fund_scenario_calculation_runs
+          (fund_id, scenario_set_id, source_config_id, source_config_version,
+           calculation_mode, override_type, input_hash, hash_kind,
+           model_inputs_as_of_date, comparison_lineage_version, job_id,
+           correlation_id, status)
+        VALUES ($1, $2, $3, $4, 'async_reserve_allocation', 'reserve_allocation', $5,
+                $6, $7::date, $8, $9, $10, 'queued')
+        RETURNING id
+      `,
+      [
+        ordinary.fund.id,
+        scenarioSetId,
+        calculationIdentity.sourceConfigId,
+        calculationIdentity.sourceConfigVersion,
+        calculationIdentity.inputHash,
+        calculationIdentity.inputLineage.hashKind,
+        calculationIdentity.inputLineage.modelInputsAsOfDate,
+        calculationIdentity.inputLineage.comparisonLineageVersion,
+        `legacy-${ordinary.fund.id}-${scenarioSetId}`,
+        correlationId,
+      ]
+    );
+    await pool.query(
+      `
+        INSERT INTO fund_scenario_set_events
+          (scenario_set_id, fund_id, event_type, actor_user_id, actor_label, change_summary_json)
+        VALUES ($1, $2, 'calculation_queued', $3, 'legacy-test', $4::jsonb)
+      `,
+      [
+        scenarioSetId,
+        ordinary.fund.id,
+        ordinaryUser.rows[0]!.id,
+        JSON.stringify({ correlation_id: correlationId, job_id: `legacy-${run.rows[0]!.id}` }),
+      ]
+    );
+
+    // Replay 0053 raw AFTER legacy-shaped run/event fixtures exist: proves the
+    // guarded statements are replay-safe AND exercises the backfill against
+    // real matching historic queued events (marker populated from event time).
+    const migration = await readFile(
+      'migrations/0053_g3_release_gate_hardening.sql',
+      'utf8'
+    );
+    await pool.query(migration.replaceAll('--> statement-breakpoint', '\n'));
+
+    const { getFundScenarioCalculationStatus } = await import(
+      '../../server/services/fund-scenario-calculation-status-service'
+    );
+    const status = await getFundScenarioCalculationStatus(ordinary.fund.id, scenarioSetId);
+    expect(status).toMatchObject({
+      status: 'queued',
+      correlationId,
+      jobId: `legacy-${ordinary.fund.id}-${scenarioSetId}`,
+    });
+  }, STARTUP_TIMEOUT_MS * 3);
+
+  afterAll(async () => {
+    await closeApplicationPool?.();
+    await pool?.end();
+    await postgres?.stop();
+  });
+
+  it('keeps legacy fund, canary, draft, scenario, and reserve writes readable after expand', async () => {
+    expect(pool).toBeDefined();
+
+    const funds = await pool!.query<{
+      data_origin: string;
+      canary_run_id: string | null;
+    }>(
+      `
+        SELECT data_origin, canary_run_id
+        FROM funds
+        WHERE name IN ('G3 ordinary compatibility fund', 'G3 canary compatibility fund')
+        ORDER BY name
+      `
+    );
+    expect(funds.rows).toEqual([
+      { data_origin: 'release_canary', canary_run_id: expect.any(String) },
+      { data_origin: 'production', canary_run_id: null },
+    ]);
+
+    const compatibility = await pool!.query<{
+      queued_event_recorded_at: Date | null;
+    }>(
+      `
+        SELECT queued_event_recorded_at
+        FROM fund_scenario_calculation_runs
+        WHERE correlation_id = '11111111-1111-4111-8111-111111111111'
+      `
+    );
+    expect(compatibility.rows[0]).toMatchObject({
+      queued_event_recorded_at: expect.any(Date),
+    });
+
+    const canary = await pool!.query<{
+      workflow_run_id: string | null;
+      workflow_run_attempt: number | null;
+      grant_residue_count: number;
+      calculation_residue_count: number;
+      mutation_receipt_residue_count: number;
+      scenario_residue_count: number;
+      reporting_residue_count: number;
+    }>(
+      `
+        SELECT workflow_run_id, workflow_run_attempt,
+          grant_residue_count, calculation_residue_count,
+          mutation_receipt_residue_count, scenario_residue_count, reporting_residue_count
+        FROM release_canary_runs
+        ORDER BY created_at DESC
+        LIMIT 1
+      `
+    );
+    expect(canary.rows[0]).toEqual({
+      workflow_run_id: null,
+      workflow_run_attempt: null,
+      grant_residue_count: 0,
+      calculation_residue_count: 0,
+      mutation_receipt_residue_count: 0,
+      scenario_residue_count: 0,
+      reporting_residue_count: 0,
+    });
+
+    const restartedPool = new Pool({ connectionString, max: 1 });
+    try {
+      const reread = await restartedPool.query<{ count: string }>(
+        `SELECT count(*)::text AS count FROM fund_scenario_sets WHERE name = 'Legacy reserve scenario'`
+      );
+      expect(reread.rows[0]?.count).toBe('1');
+    } finally {
+      await restartedPool.end();
+    }
+  });
+});

--- a/tests/integration/g3-schema-forward-compatibility.test.ts
+++ b/tests/integration/g3-schema-forward-compatibility.test.ts
@@ -267,4 +267,65 @@ describe.skipIf(skipIfNoDocker)('G3 schema forward compatibility', () => {
       await restartedPool.end();
     }
   });
+
+  it('rejects malformed durable-command and canary rows at the database boundary', { retry: 0 }, async () => {
+    expect(pool).toBeDefined();
+    const scenarioSet = await pool!.query<{ id: string; fund_id: number }>(
+      `SELECT id, fund_id FROM fund_scenario_sets WHERE name = 'Legacy reserve scenario'`
+    );
+    const setId = scenarioSet.rows[0]!.id;
+    const fundId = scenarioSet.rows[0]!.fund_id;
+    const run = await pool!.query<{ id: string }>(
+      `SELECT id FROM fund_scenario_calculation_runs
+       WHERE correlation_id = '11111111-1111-4111-8111-111111111111'`
+    );
+    const runId = run.rows[0]!.id;
+    const validBody = JSON.stringify({
+      fundId,
+      scenarioSetId: setId,
+      calculationMode: 'async_reserve_allocation',
+      status: 'queued',
+      jobId: 'probe-job',
+      correlationId: '11111111-1111-4111-8111-111111111111',
+    });
+
+    // NULL-trap probes: a completed row with NULL response_status, and one
+    // whose body carries JSON null calculationMode, must both violate the
+    // response check (three-valued logic must not satisfy the constraint).
+    await expect(pool!.query(
+      `INSERT INTO fund_scenario_calculation_commands
+         (fund_id, scenario_set_id, idempotency_key, request_hash, created_by_label,
+          status, run_id, correlation_id, response_status, response_body)
+       VALUES ($1, $2, 'nulltrap-status', repeat('7', 64), 'probe',
+               'completed', $3, '11111111-1111-4111-8111-111111111111', NULL, $4::jsonb)`,
+      [fundId, setId, runId, validBody]
+    )).rejects.toThrow(/response_check/);
+    await expect(pool!.query(
+      `INSERT INTO fund_scenario_calculation_commands
+         (fund_id, scenario_set_id, idempotency_key, request_hash, created_by_label,
+          status, run_id, correlation_id, response_status, response_body)
+       VALUES ($1, $2, 'nulltrap-mode', repeat('8', 64), 'probe',
+               'completed', $3, '11111111-1111-4111-8111-111111111111', 202,
+               jsonb_set($4::jsonb, '{calculationMode}', 'null'::jsonb))`,
+      [fundId, setId, runId, validBody]
+    )).rejects.toThrow(/response_check/);
+
+    // Scope-unique dedupe and workflow-identity coupling.
+    await pool!.query(
+      `INSERT INTO fund_scenario_calculation_commands
+         (fund_id, scenario_set_id, idempotency_key, request_hash, created_by_label, status)
+       VALUES ($1, $2, 'dedupe-probe', repeat('9', 64), 'probe', 'pending')`,
+      [fundId, setId]
+    );
+    await expect(pool!.query(
+      `INSERT INTO fund_scenario_calculation_commands
+         (fund_id, scenario_set_id, idempotency_key, request_hash, created_by_label, status)
+       VALUES ($1, $2, 'dedupe-probe', repeat('a', 64), 'probe', 'pending')`,
+      [fundId, setId]
+    )).rejects.toThrow(/scope_unique/);
+    await expect(pool!.query(
+      `UPDATE release_canary_runs SET workflow_run_id = '12345'
+       WHERE id = (SELECT id FROM release_canary_runs ORDER BY created_at DESC LIMIT 1)`
+    )).rejects.toThrow(/workflow_identity_check/);
+  });
 });

--- a/tests/integration/g3-schema-forward-compatibility.test.ts
+++ b/tests/integration/g3-schema-forward-compatibility.test.ts
@@ -1,7 +1,7 @@
 import { PostgreSqlContainer, type StartedPostgreSqlContainer } from '@testcontainers/postgresql';
 import { readFile } from 'node:fs/promises';
 import { Pool } from 'pg';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { runMigrationsWithConnectionString } from '../helpers/testcontainers-migration';
 
@@ -12,6 +12,9 @@ let postgres: StartedPostgreSqlContainer | undefined;
 let connectionString: string | undefined;
 let pool: Pool | undefined;
 let closeApplicationPool: (() => Promise<void>) | undefined;
+let closeRestartedApplicationPool: (() => Promise<void>) | undefined;
+let ordinaryFundId: number | undefined;
+let legacyScenarioSetId: string | undefined;
 
 describe.skipIf(skipIfNoDocker)('G3 schema forward compatibility', () => {
   beforeAll(async () => {
@@ -99,14 +102,18 @@ describe.skipIf(skipIfNoDocker)('G3 schema forward compatibility', () => {
       { fundName: 'G3 canary compatibility fund', modelInputsAsOfDate: '2026-01-01' }
     );
 
-    await pool.query(
-      `
-        UPDATE fundconfigs
-        SET is_draft = false, is_published = true, published_at = now()
-        WHERE id IN ($1, $2)
-      `,
-      [ordinary.draft.id, canary.draft.id]
+    const publishQueues = { reserve: null, pacing: null, cohort: null } as const;
+    await fundPersistenceService.publishDraft(
+      ordinary.fund.id,
+      publishQueues,
+      ordinaryUser.rows[0]!.id
     );
+    await fundPersistenceService.publishDraft(
+      canary.fund.id,
+      publishQueues,
+      canaryUser.rows[0]!.id
+    );
+    ordinaryFundId = ordinary.fund.id;
 
     const scenarioSet = await pool.query<{ id: string }>(
       `
@@ -118,6 +125,7 @@ describe.skipIf(skipIfNoDocker)('G3 schema forward compatibility', () => {
       [ordinary.fund.id, ordinary.draft.id, ordinaryUser.rows[0]!.id]
     );
     const scenarioSetId = scenarioSet.rows[0]!.id;
+    legacyScenarioSetId = scenarioSetId;
     await pool.query(
       `
         INSERT INTO fund_scenario_variants
@@ -133,6 +141,12 @@ describe.skipIf(skipIfNoDocker)('G3 schema forward compatibility', () => {
       scenarioSetId
     );
     const correlationId = '11111111-1111-4111-8111-111111111111';
+
+    // The current enqueue path intentionally hard-requires BullMQ plus a real
+    // Redis URL. This Postgres-only forward-compatibility suite keeps its
+    // legacy reserve-run/event fixture inline; the Redis-backed
+    // fund-scenario-reserve-worker integration already exercises the real
+    // enqueue path against Testcontainers Redis.
     const run = await pool.query<{ id: string }>(
       `
         INSERT INTO fund_scenario_calculation_runs
@@ -192,12 +206,15 @@ describe.skipIf(skipIfNoDocker)('G3 schema forward compatibility', () => {
   }, STARTUP_TIMEOUT_MS * 3);
 
   afterAll(async () => {
-    await closeApplicationPool?.();
+    const applicationPoolCloser = closeApplicationPool;
+    closeApplicationPool = undefined;
+    await applicationPoolCloser?.();
+    await closeRestartedApplicationPool?.();
     await pool?.end();
     await postgres?.stop();
   });
 
-  it('keeps legacy fund, canary, draft, scenario, and reserve writes readable after expand', async () => {
+  it('keeps legacy fund, canary, draft, scenario, and reserve writes readable after expand', { retry: 0 }, async () => {
     expect(pool).toBeDefined();
 
     const funds = await pool!.query<{
@@ -255,6 +272,25 @@ describe.skipIf(skipIfNoDocker)('G3 schema forward compatibility', () => {
       mutation_receipt_residue_count: 0,
       scenario_residue_count: 0,
       reporting_residue_count: 0,
+    });
+
+    const applicationPoolCloser = closeApplicationPool;
+    closeApplicationPool = undefined;
+    await applicationPoolCloser?.();
+    vi.resetModules();
+    const { getFundScenarioCalculationStatus: getRestartedCalculationStatus } = await import(
+      '../../server/services/fund-scenario-calculation-status-service'
+    );
+    ({ closeDatabasePool: closeRestartedApplicationPool } = await import('../../server/db'));
+
+    const restartedStatus = await getRestartedCalculationStatus(
+      ordinaryFundId!,
+      legacyScenarioSetId!
+    );
+    expect(restartedStatus).toMatchObject({
+      status: 'queued',
+      correlationId: '11111111-1111-4111-8111-111111111111',
+      jobId: `legacy-${ordinaryFundId}-${legacyScenarioSetId}`,
     });
 
     const restartedPool = new Pool({ connectionString, max: 1 });

--- a/tests/integration/g3-schema-forward-compatibility.test.ts
+++ b/tests/integration/g3-schema-forward-compatibility.test.ts
@@ -6,18 +6,105 @@ import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { runMigrationsWithConnectionString } from '../helpers/testcontainers-migration';
 
 const STARTUP_TIMEOUT_MS = 90_000;
-const skipIfNoDocker = !process.env.TEST_DATABASE_URL && !process.env.CI && process.platform === 'win32';
+const skipIfNoDocker =
+  !process.env.TEST_DATABASE_URL && !process.env.CI && process.platform === 'win32';
 
 let postgres: StartedPostgreSqlContainer | undefined;
 let connectionString: string | undefined;
 let pool: Pool | undefined;
 let closeApplicationPool: (() => Promise<void>) | undefined;
+let closeApplicationCircuitPool: (() => Promise<void>) | undefined;
 let closeRestartedApplicationPool: (() => Promise<void>) | undefined;
+let closeRestartedApplicationCircuitPool: (() => Promise<void>) | undefined;
 let ordinaryFundId: number | undefined;
 let legacyScenarioSetId: string | undefined;
 
+interface G3EnvironmentSnapshot {
+  databaseUrl: string | undefined;
+  useRealDbInVitest: string | undefined;
+  releaseCanaryTtlHours: string | undefined;
+  releaseCanaryMaxPortfolioCompanyResidue: string | undefined;
+  releaseCanaryMaxFundResidue: string | undefined;
+  releaseCanaryMaxFundConfigResidue: string | undefined;
+  releaseCanaryMaxFundEventResidue: string | undefined;
+  releaseCanaryMaxNotificationResidue: string | undefined;
+  releaseCanaryMaxTotalResidue: string | undefined;
+}
+
+let originalEnvironment: G3EnvironmentSnapshot | undefined;
+
+function snapshotEnvironment(): G3EnvironmentSnapshot {
+  return {
+    databaseUrl: process.env['DATABASE_URL'],
+    useRealDbInVitest: process.env['USE_REAL_DB_IN_VITEST'],
+    releaseCanaryTtlHours: process.env['RELEASE_CANARY_TTL_HOURS'],
+    releaseCanaryMaxPortfolioCompanyResidue:
+      process.env['RELEASE_CANARY_MAX_PORTFOLIO_COMPANY_RESIDUE'],
+    releaseCanaryMaxFundResidue: process.env['RELEASE_CANARY_MAX_FUND_RESIDUE'],
+    releaseCanaryMaxFundConfigResidue: process.env['RELEASE_CANARY_MAX_FUND_CONFIG_RESIDUE'],
+    releaseCanaryMaxFundEventResidue: process.env['RELEASE_CANARY_MAX_FUND_EVENT_RESIDUE'],
+    releaseCanaryMaxNotificationResidue: process.env['RELEASE_CANARY_MAX_NOTIFICATION_RESIDUE'],
+    releaseCanaryMaxTotalResidue: process.env['RELEASE_CANARY_MAX_TOTAL_RESIDUE'],
+  };
+}
+
+function restoreEnvironment(snapshot: G3EnvironmentSnapshot | undefined): void {
+  if (!snapshot) return;
+
+  const restore = (key: string, value: string | undefined): void => {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  };
+
+  restore('DATABASE_URL', snapshot.databaseUrl);
+  restore('USE_REAL_DB_IN_VITEST', snapshot.useRealDbInVitest);
+  restore('RELEASE_CANARY_TTL_HOURS', snapshot.releaseCanaryTtlHours);
+  restore(
+    'RELEASE_CANARY_MAX_PORTFOLIO_COMPANY_RESIDUE',
+    snapshot.releaseCanaryMaxPortfolioCompanyResidue
+  );
+  restore('RELEASE_CANARY_MAX_FUND_RESIDUE', snapshot.releaseCanaryMaxFundResidue);
+  restore('RELEASE_CANARY_MAX_FUND_CONFIG_RESIDUE', snapshot.releaseCanaryMaxFundConfigResidue);
+  restore('RELEASE_CANARY_MAX_FUND_EVENT_RESIDUE', snapshot.releaseCanaryMaxFundEventResidue);
+  restore('RELEASE_CANARY_MAX_NOTIFICATION_RESIDUE', snapshot.releaseCanaryMaxNotificationResidue);
+  restore('RELEASE_CANARY_MAX_TOTAL_RESIDUE', snapshot.releaseCanaryMaxTotalResidue);
+}
+
+async function closeModuleGeneration(
+  applicationPoolCloser: (() => Promise<void>) | undefined,
+  circuitPoolCloser: (() => Promise<void>) | undefined
+): Promise<void> {
+  let cleanupFailed = false;
+  let firstCleanupError: unknown;
+  const recordCleanupError = (error: unknown): void => {
+    if (!cleanupFailed) {
+      cleanupFailed = true;
+      firstCleanupError = error;
+    }
+  };
+
+  try {
+    await applicationPoolCloser?.();
+  } catch (error) {
+    recordCleanupError(error);
+  }
+  try {
+    await circuitPoolCloser?.();
+  } catch (error) {
+    recordCleanupError(error);
+  }
+
+  if (cleanupFailed) {
+    throw firstCleanupError;
+  }
+}
+
 describe.skipIf(skipIfNoDocker)('G3 schema forward compatibility', () => {
   beforeAll(async () => {
+    originalEnvironment = snapshotEnvironment();
     const configuredConnectionString = process.env.TEST_DATABASE_URL;
     let databaseUrl = configuredConnectionString;
     if (!databaseUrl) {
@@ -38,10 +125,7 @@ describe.skipIf(skipIfNoDocker)('G3 schema forward compatibility', () => {
       databaseUrl,
       '0052_g3_capital_call_notification_outbox'
     );
-    await runMigrationsWithConnectionString(
-      databaseUrl,
-      '0053_g3_release_gate_hardening'
-    );
+    await runMigrationsWithConnectionString(databaseUrl, '0053_g3_release_gate_hardening');
     pool = new Pool({ connectionString: databaseUrl, max: 1 });
 
     Object.assign(process.env, {
@@ -55,15 +139,18 @@ describe.skipIf(skipIfNoDocker)('G3 schema forward compatibility', () => {
       RELEASE_CANARY_MAX_NOTIFICATION_RESIDUE: '100',
       RELEASE_CANARY_MAX_TOTAL_RESIDUE: '1000',
     });
-
-    const { fundPersistenceService } = await import(
-      '../../server/services/fund-persistence-service'
-    );
-    const { getReserveScenarioCalculationIdentity } = await import(
-      '../../server/services/fund-scenario-reserve-calculation-service'
-    );
-    const { closeDatabasePool } = await import('../../server/db');
+    vi.resetModules();
+    const [{ closeDatabasePool }, { closePool }] = await Promise.all([
+      import('../../server/db'),
+      import('../../server/db/pg-circuit'),
+    ]);
     closeApplicationPool = closeDatabasePool;
+    closeApplicationCircuitPool = closePool;
+
+    const { fundPersistenceService } =
+      await import('../../server/services/fund-persistence-service');
+    const { getReserveScenarioCalculationIdentity } =
+      await import('../../server/services/fund-scenario-reserve-calculation-service');
 
     await pool.query(`
       INSERT INTO users (username, password, role, is_release_canary_principal)
@@ -188,15 +275,11 @@ describe.skipIf(skipIfNoDocker)('G3 schema forward compatibility', () => {
     // Replay 0053 raw AFTER legacy-shaped run/event fixtures exist: proves the
     // guarded statements are replay-safe AND exercises the backfill against
     // real matching historic queued events (marker populated from event time).
-    const migration = await readFile(
-      'migrations/0053_g3_release_gate_hardening.sql',
-      'utf8'
-    );
+    const migration = await readFile('migrations/0053_g3_release_gate_hardening.sql', 'utf8');
     await pool.query(migration.replaceAll('--> statement-breakpoint', '\n'));
 
-    const { getFundScenarioCalculationStatus } = await import(
-      '../../server/services/fund-scenario-calculation-status-service'
-    );
+    const { getFundScenarioCalculationStatus } =
+      await import('../../server/services/fund-scenario-calculation-status-service');
     const status = await getFundScenarioCalculationStatus(ordinary.fund.id, scenarioSetId);
     expect(status).toMatchObject({
       status: 'queued',
@@ -206,56 +289,107 @@ describe.skipIf(skipIfNoDocker)('G3 schema forward compatibility', () => {
   }, STARTUP_TIMEOUT_MS * 3);
 
   afterAll(async () => {
-    const applicationPoolCloser = closeApplicationPool;
-    closeApplicationPool = undefined;
-    await applicationPoolCloser?.();
-    await closeRestartedApplicationPool?.();
-    await pool?.end();
-    await postgres?.stop();
+    let cleanupFailed = false;
+    let firstCleanupError: unknown;
+    const recordCleanupError = (error: unknown): void => {
+      if (!cleanupFailed) {
+        cleanupFailed = true;
+        firstCleanupError = error;
+      }
+    };
+    const runCleanup = async (operation: (() => Promise<void>) | undefined): Promise<void> => {
+      try {
+        await operation?.();
+      } catch (error) {
+        recordCleanupError(error);
+      }
+    };
+
+    try {
+      const initialApplicationPoolCloser = closeApplicationPool;
+      const initialApplicationCircuitPoolCloser = closeApplicationCircuitPool;
+      closeApplicationPool = undefined;
+      closeApplicationCircuitPool = undefined;
+      await runCleanup(initialApplicationPoolCloser);
+      await runCleanup(initialApplicationCircuitPoolCloser);
+
+      const restartedApplicationPoolCloser = closeRestartedApplicationPool;
+      const restartedApplicationCircuitPoolCloser = closeRestartedApplicationCircuitPool;
+      closeRestartedApplicationPool = undefined;
+      closeRestartedApplicationCircuitPool = undefined;
+      await runCleanup(restartedApplicationPoolCloser);
+      await runCleanup(restartedApplicationCircuitPoolCloser);
+
+      const directPool = pool;
+      pool = undefined;
+      await runCleanup(directPool ? () => directPool.end() : undefined);
+
+      const startedPostgres = postgres;
+      postgres = undefined;
+      await runCleanup(startedPostgres ? () => startedPostgres.stop() : undefined);
+    } finally {
+      try {
+        restoreEnvironment(originalEnvironment);
+      } catch (error) {
+        recordCleanupError(error);
+      }
+      try {
+        vi.resetModules();
+      } catch (error) {
+        recordCleanupError(error);
+      }
+    }
+
+    if (cleanupFailed) {
+      throw firstCleanupError;
+    }
   });
 
-  it('keeps legacy fund, canary, draft, scenario, and reserve writes readable after expand', { retry: 0 }, async () => {
-    expect(pool).toBeDefined();
+  it(
+    'keeps legacy fund, canary, draft, scenario, and reserve writes readable after expand',
+    { retry: 0 },
+    async () => {
+      expect(pool).toBeDefined();
 
-    const funds = await pool!.query<{
-      data_origin: string;
-      canary_run_id: string | null;
-    }>(
-      `
+      const funds = await pool!.query<{
+        data_origin: string;
+        canary_run_id: string | null;
+      }>(
+        `
         SELECT data_origin, canary_run_id
         FROM funds
         WHERE name IN ('G3 ordinary compatibility fund', 'G3 canary compatibility fund')
         ORDER BY name
       `
-    );
-    expect(funds.rows).toEqual([
-      { data_origin: 'release_canary', canary_run_id: expect.any(String) },
-      { data_origin: 'production', canary_run_id: null },
-    ]);
+      );
+      expect(funds.rows).toEqual([
+        { data_origin: 'release_canary', canary_run_id: expect.any(String) },
+        { data_origin: 'production', canary_run_id: null },
+      ]);
 
-    const compatibility = await pool!.query<{
-      queued_event_recorded_at: Date | null;
-    }>(
-      `
+      const compatibility = await pool!.query<{
+        queued_event_recorded_at: Date | null;
+      }>(
+        `
         SELECT queued_event_recorded_at
         FROM fund_scenario_calculation_runs
         WHERE correlation_id = '11111111-1111-4111-8111-111111111111'
       `
-    );
-    expect(compatibility.rows[0]).toMatchObject({
-      queued_event_recorded_at: expect.any(Date),
-    });
+      );
+      expect(compatibility.rows[0]).toMatchObject({
+        queued_event_recorded_at: expect.any(Date),
+      });
 
-    const canary = await pool!.query<{
-      workflow_run_id: string | null;
-      workflow_run_attempt: number | null;
-      grant_residue_count: number;
-      calculation_residue_count: number;
-      mutation_receipt_residue_count: number;
-      scenario_residue_count: number;
-      reporting_residue_count: number;
-    }>(
-      `
+      const canary = await pool!.query<{
+        workflow_run_id: string | null;
+        workflow_run_attempt: number | null;
+        grant_residue_count: number;
+        calculation_residue_count: number;
+        mutation_receipt_residue_count: number;
+        scenario_residue_count: number;
+        reporting_residue_count: number;
+      }>(
+        `
         SELECT workflow_run_id, workflow_run_attempt,
           grant_residue_count, calculation_residue_count,
           mutation_receipt_residue_count, scenario_residue_count, reporting_residue_count
@@ -263,105 +397,124 @@ describe.skipIf(skipIfNoDocker)('G3 schema forward compatibility', () => {
         ORDER BY created_at DESC
         LIMIT 1
       `
-    );
-    expect(canary.rows[0]).toEqual({
-      workflow_run_id: null,
-      workflow_run_attempt: null,
-      grant_residue_count: 0,
-      calculation_residue_count: 0,
-      mutation_receipt_residue_count: 0,
-      scenario_residue_count: 0,
-      reporting_residue_count: 0,
-    });
-
-    const applicationPoolCloser = closeApplicationPool;
-    closeApplicationPool = undefined;
-    await applicationPoolCloser?.();
-    vi.resetModules();
-    const { getFundScenarioCalculationStatus: getRestartedCalculationStatus } = await import(
-      '../../server/services/fund-scenario-calculation-status-service'
-    );
-    ({ closeDatabasePool: closeRestartedApplicationPool } = await import('../../server/db'));
-
-    const restartedStatus = await getRestartedCalculationStatus(
-      ordinaryFundId!,
-      legacyScenarioSetId!
-    );
-    expect(restartedStatus).toMatchObject({
-      status: 'queued',
-      correlationId: '11111111-1111-4111-8111-111111111111',
-      jobId: `legacy-${ordinaryFundId}-${legacyScenarioSetId}`,
-    });
-
-    const restartedPool = new Pool({ connectionString, max: 1 });
-    try {
-      const reread = await restartedPool.query<{ count: string }>(
-        `SELECT count(*)::text AS count FROM fund_scenario_sets WHERE name = 'Legacy reserve scenario'`
       );
-      expect(reread.rows[0]?.count).toBe('1');
-    } finally {
-      await restartedPool.end();
+      expect(canary.rows[0]).toEqual({
+        workflow_run_id: null,
+        workflow_run_attempt: null,
+        grant_residue_count: 0,
+        calculation_residue_count: 0,
+        mutation_receipt_residue_count: 0,
+        scenario_residue_count: 0,
+        reporting_residue_count: 0,
+      });
+
+      const applicationPoolCloser = closeApplicationPool;
+      const applicationCircuitPoolCloser = closeApplicationCircuitPool;
+      closeApplicationPool = undefined;
+      closeApplicationCircuitPool = undefined;
+      await closeModuleGeneration(applicationPoolCloser, applicationCircuitPoolCloser);
+      vi.resetModules();
+      const [{ closeDatabasePool }, { closePool }] = await Promise.all([
+        import('../../server/db'),
+        import('../../server/db/pg-circuit'),
+      ]);
+      closeRestartedApplicationPool = closeDatabasePool;
+      closeRestartedApplicationCircuitPool = closePool;
+      const { getFundScenarioCalculationStatus: getRestartedCalculationStatus } =
+        await import('../../server/services/fund-scenario-calculation-status-service');
+
+      const restartedStatus = await getRestartedCalculationStatus(
+        ordinaryFundId!,
+        legacyScenarioSetId!
+      );
+      expect(restartedStatus).toMatchObject({
+        status: 'queued',
+        correlationId: '11111111-1111-4111-8111-111111111111',
+        jobId: `legacy-${ordinaryFundId}-${legacyScenarioSetId}`,
+      });
+
+      const restartedPool = new Pool({ connectionString, max: 1 });
+      try {
+        const reread = await restartedPool.query<{ count: string }>(
+          `SELECT count(*)::text AS count FROM fund_scenario_sets WHERE name = 'Legacy reserve scenario'`
+        );
+        expect(reread.rows[0]?.count).toBe('1');
+      } finally {
+        await restartedPool.end();
+      }
     }
-  });
+  );
 
-  it('rejects malformed durable-command and canary rows at the database boundary', { retry: 0 }, async () => {
-    expect(pool).toBeDefined();
-    const scenarioSet = await pool!.query<{ id: string; fund_id: number }>(
-      `SELECT id, fund_id FROM fund_scenario_sets WHERE name = 'Legacy reserve scenario'`
-    );
-    const setId = scenarioSet.rows[0]!.id;
-    const fundId = scenarioSet.rows[0]!.fund_id;
-    const run = await pool!.query<{ id: string }>(
-      `SELECT id FROM fund_scenario_calculation_runs
+  it(
+    'rejects malformed durable-command and canary rows at the database boundary',
+    { retry: 0 },
+    async () => {
+      expect(pool).toBeDefined();
+      const scenarioSet = await pool!.query<{ id: string; fund_id: number }>(
+        `SELECT id, fund_id FROM fund_scenario_sets WHERE name = 'Legacy reserve scenario'`
+      );
+      const setId = scenarioSet.rows[0]!.id;
+      const fundId = scenarioSet.rows[0]!.fund_id;
+      const run = await pool!.query<{ id: string }>(
+        `SELECT id FROM fund_scenario_calculation_runs
        WHERE correlation_id = '11111111-1111-4111-8111-111111111111'`
-    );
-    const runId = run.rows[0]!.id;
-    const validBody = JSON.stringify({
-      fundId,
-      scenarioSetId: setId,
-      calculationMode: 'async_reserve_allocation',
-      status: 'queued',
-      jobId: 'probe-job',
-      correlationId: '11111111-1111-4111-8111-111111111111',
-    });
+      );
+      const runId = run.rows[0]!.id;
+      const validBody = JSON.stringify({
+        fundId,
+        scenarioSetId: setId,
+        calculationMode: 'async_reserve_allocation',
+        status: 'queued',
+        jobId: 'probe-job',
+        correlationId: '11111111-1111-4111-8111-111111111111',
+      });
 
-    // NULL-trap probes: a completed row with NULL response_status, and one
-    // whose body carries JSON null calculationMode, must both violate the
-    // response check (three-valued logic must not satisfy the constraint).
-    await expect(pool!.query(
-      `INSERT INTO fund_scenario_calculation_commands
+      // NULL-trap probes: a completed row with NULL response_status, and one
+      // whose body carries JSON null calculationMode, must both violate the
+      // response check (three-valued logic must not satisfy the constraint).
+      await expect(
+        pool!.query(
+          `INSERT INTO fund_scenario_calculation_commands
          (fund_id, scenario_set_id, idempotency_key, request_hash, created_by_label,
           status, run_id, correlation_id, response_status, response_body)
        VALUES ($1, $2, 'nulltrap-status', repeat('7', 64), 'probe',
                'completed', $3, '11111111-1111-4111-8111-111111111111', NULL, $4::jsonb)`,
-      [fundId, setId, runId, validBody]
-    )).rejects.toThrow(/response_check/);
-    await expect(pool!.query(
-      `INSERT INTO fund_scenario_calculation_commands
+          [fundId, setId, runId, validBody]
+        )
+      ).rejects.toThrow(/response_check/);
+      await expect(
+        pool!.query(
+          `INSERT INTO fund_scenario_calculation_commands
          (fund_id, scenario_set_id, idempotency_key, request_hash, created_by_label,
           status, run_id, correlation_id, response_status, response_body)
        VALUES ($1, $2, 'nulltrap-mode', repeat('8', 64), 'probe',
                'completed', $3, '11111111-1111-4111-8111-111111111111', 202,
                jsonb_set($4::jsonb, '{calculationMode}', 'null'::jsonb))`,
-      [fundId, setId, runId, validBody]
-    )).rejects.toThrow(/response_check/);
+          [fundId, setId, runId, validBody]
+        )
+      ).rejects.toThrow(/response_check/);
 
-    // Scope-unique dedupe and workflow-identity coupling.
-    await pool!.query(
-      `INSERT INTO fund_scenario_calculation_commands
+      // Scope-unique dedupe and workflow-identity coupling.
+      await pool!.query(
+        `INSERT INTO fund_scenario_calculation_commands
          (fund_id, scenario_set_id, idempotency_key, request_hash, created_by_label, status)
        VALUES ($1, $2, 'dedupe-probe', repeat('9', 64), 'probe', 'pending')`,
-      [fundId, setId]
-    );
-    await expect(pool!.query(
-      `INSERT INTO fund_scenario_calculation_commands
+        [fundId, setId]
+      );
+      await expect(
+        pool!.query(
+          `INSERT INTO fund_scenario_calculation_commands
          (fund_id, scenario_set_id, idempotency_key, request_hash, created_by_label, status)
        VALUES ($1, $2, 'dedupe-probe', repeat('a', 64), 'probe', 'pending')`,
-      [fundId, setId]
-    )).rejects.toThrow(/scope_unique/);
-    await expect(pool!.query(
-      `UPDATE release_canary_runs SET workflow_run_id = '12345'
+          [fundId, setId]
+        )
+      ).rejects.toThrow(/scope_unique/);
+      await expect(
+        pool!.query(
+          `UPDATE release_canary_runs SET workflow_run_id = '12345'
        WHERE id = (SELECT id FROM release_canary_runs ORDER BY created_at DESC LIMIT 1)`
-    )).rejects.toThrow(/workflow_identity_check/);
-  });
+        )
+      ).rejects.toThrow(/workflow_identity_check/);
+    }
+  );
 });

--- a/tests/integration/prod-schema-clone.test.ts
+++ b/tests/integration/prod-schema-clone.test.ts
@@ -189,6 +189,11 @@ const G3_CANARY_MANIFEST_TABLES = ['users', 'release_canary_runs', 'funds'] as c
 const G3_CAPITAL_CALL_NOTIFICATION_OUTBOX_MANIFEST_TABLES = [
   'capital_call_notification_outbox',
 ] as const;
+const G3_RELEASE_GATE_HARDENING_MANIFEST_TABLES = [
+  'fund_scenario_calculation_commands',
+  'fund_scenario_calculation_runs',
+  'release_canary_runs',
+] as const;
 const EXPECTED_PRODUCTION_MANIFEST_NAMES = [
   'M1-cohort',
   'M2-fund-moic',
@@ -219,6 +224,7 @@ const EXPECTED_PRODUCTION_MANIFEST_NAMES = [
   'g3-portfolio-and-calculation',
   'g3-canary',
   'g3-capital-call-notification-outbox',
+  'g3-release-gate-hardening',
 ] as const;
 const SHAPE_ONLY_NOT_JOURNALED = [
   'flag_changes',
@@ -868,6 +874,7 @@ describe.skipIf(skipIfNoDocker)('prod schema synthetic clone', () => {
         ...G3_PORTFOLIO_AND_CALCULATION_MANIFEST_TABLES,
         ...G3_CANARY_MANIFEST_TABLES,
         ...G3_CAPITAL_CALL_NOTIFICATION_OUTBOX_MANIFEST_TABLES,
+        ...G3_RELEASE_GATE_HARDENING_MANIFEST_TABLES,
       ])
     );
 

--- a/tests/integration/vehicle-financing-participations-real-pg.test.ts
+++ b/tests/integration/vehicle-financing-participations-real-pg.test.ts
@@ -1,7 +1,7 @@
 import { sql, type SQLWrapper } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { CreateVehicleFinancingParticipationRequestSchema } from '../../shared/contracts/investment-ledger/participation.contract';
 import { canonicalSha256 } from '../../shared/lib/canonical-hash';
@@ -124,14 +124,23 @@ let financingEventService: FinancingEventServiceModule;
 let correctionService: LedgerCorrectionServiceModule;
 let legacyGuardService: LegacyGuardServiceModule;
 let factsService: FundCompanyActualsFactsServiceModule;
+let closeApplicationPool: (() => Promise<void>) | undefined;
+let originalDatabaseUrl: string | undefined;
+let originalUseRealDbInVitest: string | undefined;
 
 describe('vehicle financing participations real PostgreSQL', () => {
   beforeAll(async () => {
+    originalDatabaseUrl = process.env['DATABASE_URL'];
+    originalUseRealDbInVitest = process.env['USE_REAL_DB_IN_VITEST'];
     const connectionString =
       process.env.TEST_DATABASE_URL ?? (await startContainer()).connectionUri;
     // Dynamic service imports read server/db at module load, after the disposable DB exists.
-    // eslint-disable-next-line require-atomic-updates
-    process.env.DATABASE_URL = connectionString;
+    Object.assign(process.env, {
+      DATABASE_URL: connectionString,
+      USE_REAL_DB_IN_VITEST: '1',
+    });
+    vi.resetModules();
+    ({ closeDatabasePool: closeApplicationPool } = await import('../../server/db'));
     pool = new Pool({ connectionString, max: 10 });
     db = drizzle(pool, { schema }) as TransactionalDb;
     participationService =
@@ -147,8 +156,59 @@ describe('vehicle financing participations real PostgreSQL', () => {
   }, STARTUP_TIMEOUT_MS);
 
   afterAll(async () => {
-    await pool?.end();
-    await container?.stop();
+    let cleanupFailed = false;
+    let firstCleanupError: unknown;
+    const recordCleanupError = (error: unknown): void => {
+      if (!cleanupFailed) {
+        cleanupFailed = true;
+        firstCleanupError = error;
+      }
+    };
+    const runCleanup = async (operation: (() => Promise<void>) | undefined): Promise<void> => {
+      try {
+        await operation?.();
+      } catch (error) {
+        recordCleanupError(error);
+      }
+    };
+
+    try {
+      const applicationPoolCloser = closeApplicationPool;
+      closeApplicationPool = undefined;
+      await runCleanup(applicationPoolCloser);
+
+      const directPool = pool;
+      pool = undefined;
+      await runCleanup(directPool ? () => directPool.end() : undefined);
+
+      const startedContainer = container;
+      container = undefined;
+      await runCleanup(startedContainer ? () => startedContainer.stop() : undefined);
+    } finally {
+      try {
+        if (originalDatabaseUrl === undefined) {
+          delete process.env['DATABASE_URL'];
+        } else {
+          process.env['DATABASE_URL'] = originalDatabaseUrl;
+        }
+        if (originalUseRealDbInVitest === undefined) {
+          delete process.env['USE_REAL_DB_IN_VITEST'];
+        } else {
+          process.env['USE_REAL_DB_IN_VITEST'] = originalUseRealDbInVitest;
+        }
+      } catch (error) {
+        recordCleanupError(error);
+      }
+      try {
+        vi.resetModules();
+      } catch (error) {
+        recordCleanupError(error);
+      }
+    }
+
+    if (cleanupFailed) {
+      throw firstCleanupError;
+    }
   });
 
   it('commits exactly one participation head when concurrent create requests race', async () => {

--- a/tests/regressions/ci-fail-closed.test.ts
+++ b/tests/regressions/ci-fail-closed.test.ts
@@ -12,6 +12,7 @@ import YAML from 'yaml';
 type WorkflowStep = {
   ['continue-on-error']?: boolean;
   env?: Record<string, unknown>;
+  id?: string;
   name?: string;
   run?: string;
   shell?: string;
@@ -4224,6 +4225,70 @@ describe('required CI fails closed', () => {
         expect(bypass.npxCalled).toBe(true);
       }
     }
+  });
+
+  it('fails closed on schema evidence retention, receipt, and attempt identity', async () => {
+    const workflow = await readWorkflow('prod-schema-reconcile.yml');
+    const steps = workflow.jobs?.reconcile?.steps ?? [];
+    const retentionIndex = steps.findIndex(
+      (step) => step.name === 'Verify artifact retention before apply'
+    );
+    const firstAttemptIndex = steps.findIndex((step) => step.name === 'Require first apply attempt');
+    const preAuditIndex = steps.findIndex((step) => step.name === 'Run pre-apply audit');
+    const postCleanIndex = steps.findIndex((step) => step.name === 'Require clean post-apply audit');
+    const receiptIndex = steps.findIndex((step) => step.name === 'Build schema reconcile receipt');
+    const upload = steps.find((step) => step.name === 'Upload redacted reconciliation reports');
+    const capture = steps.find((step) => step.name === 'Capture apply evidence identity');
+    const retention = steps[retentionIndex];
+    const receipt = steps[receiptIndex];
+
+    expect(firstAttemptIndex).toBeGreaterThan(-1);
+    expect(firstAttemptIndex).toBeLessThan(preAuditIndex);
+    expect(steps[firstAttemptIndex]?.if).toBe("inputs.mode == 'apply'");
+    expect(steps[firstAttemptIndex]?.run).toContain('$GITHUB_RUN_ATTEMPT');
+    expect(steps[firstAttemptIndex]?.run).toContain('!= "1"');
+
+    expect(retentionIndex).toBeGreaterThan(-1);
+    expect(retentionIndex).toBeLessThan(preAuditIndex);
+    expect(retention?.if).toBe("inputs.mode == 'apply'");
+    expect(retention?.env?.SCHEMA_EVIDENCE_RETENTION_READ_TOKEN).toBe(
+      '${{ secrets.SCHEMA_EVIDENCE_RETENTION_READ_TOKEN }}'
+    );
+    expect(retention?.run).toContain('::add-mask::$SCHEMA_EVIDENCE_RETENTION_READ_TOKEN');
+    expect(retention?.run).toContain(
+      '/actions/permissions/artifact-and-log-retention'
+    );
+    expect(retention?.run).toContain('body?.days');
+    expect(retention?.run).toContain('body.days < 90');
+    expect(retention?.run).not.toContain('PRODUCTION_DATABASE_URL');
+    expect(retention?.run).not.toContain('--apply');
+
+    expect(receiptIndex).toBeGreaterThan(preAuditIndex);
+    expect(postCleanIndex).toBeGreaterThan(preAuditIndex);
+    expect(receiptIndex).toBeGreaterThan(postCleanIndex);
+    expect(receipt?.if).toContain("inputs.mode == 'apply'");
+    expect(receipt?.if).toContain("steps.require_post_apply_clean.outcome == 'success'");
+    expect(receipt?.run).toContain('APPLY-MISSING-DDL');
+    expect(receipt?.run).toContain('build-schema-reconcile-receipt.ts');
+    expect(receipt?.env?.GITHUB_RUN_ID).toBe('${{ github.run_id }}');
+    expect(receipt?.env?.GITHUB_RUN_ATTEMPT).toBe('${{ github.run_attempt }}');
+    expect(receipt?.env?.SCHEMA_RECONCILE_SOURCE_SHA).toBe('${{ inputs.expected_sha }}');
+
+    expect(upload?.if).toBe('always()');
+    expect(upload?.with?.name).toBe(
+      'prod-schema-reconcile-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.mode }}-${{ inputs.expected_sha }}'
+    );
+    expect(upload?.with?.path).toContain('reports/schema-reconcile-receipt.json');
+    expect(upload?.with?.['retention-days']).toBe(90);
+    expect(upload?.id).toBe('upload_evidence');
+    expect(capture?.if).toContain("steps.apply.outcome == 'success'");
+    expect(capture?.if).toContain("steps.post_audit.outcome == 'success'");
+    expect(capture?.env?.ARTIFACT_ID).toBe('${{ steps.upload_evidence.outputs.artifact-id }}');
+    expect(capture?.env?.ARTIFACT_DIGEST).toBe(
+      '${{ steps.upload_evidence.outputs.artifact-digest }}'
+    );
+    expect(capture?.run).toContain('sha256sum reports/schema-reconcile-receipt.json');
+    expect(JSON.stringify(steps)).not.toContain('retention-days: 14');
   });
 
   it('would fail when smoke commit equality is removed', async () => {

--- a/tests/regressions/ci-fail-closed.test.ts
+++ b/tests/regressions/ci-fail-closed.test.ts
@@ -4227,7 +4227,7 @@ describe('required CI fails closed', () => {
     }
   });
 
-  it('fails closed on schema evidence retention, receipt, and attempt identity', async () => {
+  it('fails closed on schema evidence retention, receipt, and attempt identity', { retry: 0 }, async () => {
     const workflow = await readWorkflow('prod-schema-reconcile.yml');
     const steps = workflow.jobs?.reconcile?.steps ?? [];
     const retentionIndex = steps.findIndex(
@@ -4262,6 +4262,23 @@ describe('required CI fails closed', () => {
     expect(retention?.run).toContain('body.days < 90');
     expect(retention?.run).not.toContain('PRODUCTION_DATABASE_URL');
     expect(retention?.run).not.toContain('--apply');
+    // Token stays out of curl argv (0600 header config file) and appears in
+    // exactly one step of the workflow.
+    expect(retention?.run).toContain('--config "$auth_header_file"');
+    expect(retention?.run).not.toContain('--header "Authorization: Bearer $SCHEMA_EVIDENCE_RETENTION_READ_TOKEN"');
+    const tokenSteps = steps.filter((step) =>
+      JSON.stringify(step).includes('SCHEMA_EVIDENCE_RETENTION_READ_TOKEN')
+    );
+    expect(tokenSteps).toHaveLength(1);
+    expect(tokenSteps[0]?.name).toBe('Verify artifact retention before apply');
+
+    const requireReceiptIndex = steps.findIndex(
+      (step) => step.name === 'Require schema reconcile receipt after successful apply'
+    );
+    expect(requireReceiptIndex).toBeGreaterThan(receiptIndex);
+    const requireReceipt = steps[requireReceiptIndex];
+    expect(requireReceipt?.if).toContain("inputs.mode == 'apply'");
+    expect(requireReceipt?.run).toContain('test -s reports/schema-reconcile-receipt.json');
 
     expect(receiptIndex).toBeGreaterThan(preAuditIndex);
     expect(postCleanIndex).toBeGreaterThan(preAuditIndex);

--- a/tests/unit/contracts/schema-reconcile-receipt-v1.contract.test.ts
+++ b/tests/unit/contracts/schema-reconcile-receipt-v1.contract.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { SchemaReconcileReceiptV1Schema } from '@shared/contracts/schema-reconcile-receipt-v1.contract';
+
+const validReceipt = {
+  repository: 'press-on/updog',
+  workflowPath: '.github/workflows/prod-schema-reconcile.yml',
+  runId: '123456789',
+  runAttempt: 1,
+  mode: 'apply',
+  sourceSha: 'a'.repeat(40),
+  manifest: '30-g3-release-gate-hardening',
+  migration: '0053',
+  preDecision: 'APPLY-MISSING-DDL',
+  postDecision: 'SKIP',
+  buildTimeMs: 42,
+  result: 'applied_and_clean',
+} as const;
+
+describe('schema-reconcile-receipt-v1 contract', () => {
+  it('accepts only successful attempt-one apply receipts with bounded fields', () => {
+    expect(SchemaReconcileReceiptV1Schema.parse(validReceipt)).toEqual(validReceipt);
+  });
+
+  it('rejects unknown fields, secrets, database identifiers, and future artifact metadata', () => {
+    expect(
+      SchemaReconcileReceiptV1Schema.safeParse({
+        ...validReceipt,
+        databaseUrl: 'postgresql://user:password@example.invalid/db',
+        artifactId: '123',
+        token: 'secret',
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects rerun attempts and non-clean decisions', () => {
+    expect(
+      SchemaReconcileReceiptV1Schema.safeParse({ ...validReceipt, runAttempt: 2 }).success
+    ).toBe(false);
+    expect(
+      SchemaReconcileReceiptV1Schema.safeParse({
+        ...validReceipt,
+        postDecision: 'APPLY-MISSING-DDL',
+      }).success
+    ).toBe(false);
+  });
+});

--- a/tests/unit/contracts/schema-reconcile-receipt-v1.contract.test.ts
+++ b/tests/unit/contracts/schema-reconcile-receipt-v1.contract.test.ts
@@ -17,7 +17,7 @@ const validReceipt = {
   result: 'applied_and_clean',
 } as const;
 
-describe('schema-reconcile-receipt-v1 contract', () => {
+describe('schema-reconcile-receipt-v1 contract', { retry: 0 }, () => {
   it('accepts only successful attempt-one apply receipts with bounded fields', () => {
     expect(SchemaReconcileReceiptV1Schema.parse(validReceipt)).toEqual(validReceipt);
   });

--- a/tests/unit/migration-ledger.test.ts
+++ b/tests/unit/migration-ledger.test.ts
@@ -63,6 +63,7 @@ const expectedJournaledDriftPatchFiles = [
   '0050_g3_portfolio_and_calculation_schema.sql',
   '0051_g3_canary_schema.sql',
   '0052_g3_capital_call_notification_outbox.sql',
+  '0053_g3_release_gate_hardening.sql',
 ].sort();
 
 afterEach(() => {
@@ -161,6 +162,34 @@ describe('migration ledger helpers', () => {
       tag: '0043_position_source_basis_reliefs',
       breakpoints: true,
     });
+  });
+
+  it('pins G3 release gate hardening to journal index 54 after migration 0052', () => {
+    const rawJournal = JSON.parse(
+      fs.readFileSync(path.join(repoRoot, 'migrations', 'meta', '_journal.json'), 'utf8')
+    ) as {
+      entries: Array<{
+        idx: number;
+        version: string;
+        when: number;
+        tag: string;
+        breakpoints: boolean;
+      }>;
+    };
+    const entry = rawJournal.entries.find(
+      (candidate) => candidate.tag === '0053_g3_release_gate_hardening'
+    );
+
+    expect(entry).toMatchObject({
+      idx: 54,
+      version: '7',
+      when: 1786059600000,
+      tag: '0053_g3_release_gate_hardening',
+      breakpoints: true,
+    });
+    expect(rawJournal.entries.find(
+      (candidate) => candidate.tag === '0052_g3_capital_call_notification_outbox'
+    )?.idx).toBe(53);
   });
 
   // T-A1 (WP-L3 Phase A): the pin asserts THIS migration's OWN journal entry

--- a/tests/unit/prod-schema-apply-policy.test.ts
+++ b/tests/unit/prod-schema-apply-policy.test.ts
@@ -372,4 +372,22 @@ describe('prod schema apply policy', () => {
       })
     ).toThrow(ReconcileError);
   });
+
+  it('accepts the g3-release-gate-hardening manifest against migration 0053', { retry: 0 }, async () => {
+    // The apply-mode preflight runs this exact validation before touching the
+    // database; a violation here means the governed 0053 apply is guaranteed
+    // to fail on its single permitted attempt. Historical manifests predate
+    // the current policy vocabulary and are not re-validated here.
+    const manifests = await loadManifests();
+    const hardening = manifests.find(
+      (manifest) => manifest.name === 'g3-release-gate-hardening'
+    );
+    expect(hardening).toBeDefined();
+    expect(() =>
+      assertApplyPolicyForManifests({
+        manifests,
+        applyingManifestNames: new Set([hardening!.name]),
+      })
+    ).not.toThrow();
+  });
 });

--- a/tests/unit/prod-schema-manifest-coverage.test.ts
+++ b/tests/unit/prod-schema-manifest-coverage.test.ts
@@ -101,4 +101,19 @@ describe('prod-schema manifest forward migration coverage', () => {
       /traversal\.json -> \.\.\/migrations\/0031_user_identity_grants_revocation\.sql/
     );
   });
+
+  it('pins G3 release gate hardening as manifest order 30', () => {
+    const manifest = JSON.parse(
+      fs.readFileSync(
+        path.join(manifestDir, '30-g3-release-gate-hardening.json'),
+        'utf8'
+      )
+    ) as { name: string; order: number; sqlFiles: string[] };
+
+    expect(manifest).toMatchObject({
+      name: 'g3-release-gate-hardening',
+      order: 30,
+      sqlFiles: ['migrations/0053_g3_release_gate_hardening.sql'],
+    });
+  });
 });

--- a/tests/unit/prod-schema-manifest-sentinels.test.ts
+++ b/tests/unit/prod-schema-manifest-sentinels.test.ts
@@ -380,10 +380,19 @@ describe('prod-schema manifest sentinels', () => {
           allowed.expectedDefinition.requiredFragments.length,
           `${file} ${allowed.name} required definition fragments`
         ).toBeGreaterThan(0);
+        // A numeric-only constraint (e.g. the residue-count equality check)
+        // legitimately declares zero string literals; the array must still be
+        // present so the exact multiset comparison stays fail-closed.
         expect(
-          allowed.expectedDefinition.stringLiterals.length,
-          `${file} ${allowed.name} expected string literals`
-        ).toBeGreaterThan(0);
+          Array.isArray(allowed.expectedDefinition.stringLiterals),
+          `${file} ${allowed.name} expected string literals array`
+        ).toBe(true);
+        if (allowed.name !== 'release_canary_runs_residue_count_check') {
+          expect(
+            allowed.expectedDefinition.stringLiterals.length,
+            `${file} ${allowed.name} expected string literals`
+          ).toBeGreaterThan(0);
+        }
       }
     }
   });

--- a/tests/unit/prod-schema-manifest-sentinels.test.ts
+++ b/tests/unit/prod-schema-manifest-sentinels.test.ts
@@ -157,6 +157,7 @@ describe('prod-schema manifest sentinels', () => {
       '27-g3-portfolio-and-calculation.json',
       '28-g3-canary.json',
       '29-g3-capital-call-notification-outbox.json',
+      '30-g3-release-gate-hardening.json',
     ]);
   });
 

--- a/tests/unit/schema/g3-foundations-schema.test.ts
+++ b/tests/unit/schema/g3-foundations-schema.test.ts
@@ -6,7 +6,11 @@ import { describe, expect, it } from 'vitest';
 
 import * as schema from '@shared/schema';
 import * as schemaIndex from '@shared/schema/index';
-import { fundScenarioCalculationRuns, funds } from '@shared/schema/fund';
+import {
+  fundScenarioCalculationRuns,
+  funds,
+} from '@shared/schema/fund';
+import { fundScenarioCalculationCommands } from '@shared/schema/fund-scenario-calculation-commands';
 import { portfolioCompanies } from '@shared/schema/portfolio';
 import { releaseCanaryRuns } from '@shared/schema/release-canary';
 import { users } from '@shared/schema/user';
@@ -98,6 +102,47 @@ describe('G3 foundations schema', () => {
     expect(deadline).toMatchObject({ notNull: false, hasDefault: false });
   });
 
+  it('defines durable calculation commands with scoped idempotency and lifecycle fences', () => {
+    const config = getTableConfig(fundScenarioCalculationCommands);
+    expect(config.columns.map((column) => column.name)).toEqual([
+      'id',
+      'fund_id',
+      'scenario_set_id',
+      'idempotency_key',
+      'request_hash',
+      'status',
+      'run_id',
+      'correlation_id',
+      'response_status',
+      'response_body',
+      'attempt_count',
+      'lease_token',
+      'lease_expires_at',
+      'failure_code',
+      'created_by_user_id',
+      'created_by_label',
+      'version',
+      'created_at',
+      'updated_at',
+    ]);
+    expect(config.uniqueConstraints.map((constraint) => constraint.name)).toContain(
+      'fund_scenario_calc_commands_scope_unique'
+    );
+    expect(config.checks.map((constraint) => constraint.name)).toEqual(
+      expect.arrayContaining([
+        'fund_scenario_calc_commands_status_check',
+        'fund_scenario_calc_commands_hash_check',
+        'fund_scenario_calc_commands_response_check',
+        'fund_scenario_calc_commands_lease_check',
+        'fund_scenario_calc_commands_attempt_check',
+        'fund_scenario_calc_commands_version_check',
+      ])
+    );
+    expect(config.indexes.map((index) => index.config.name)).toContain(
+      'fund_scenario_calc_commands_status_idx'
+    );
+  });
+
   it('pins canary principal, fund origin, and release run lifecycle shape', () => {
     const userConfig = getTableConfig(users);
     const canaryFlag = userConfig.columns.find(
@@ -125,6 +170,8 @@ describe('G3 foundations schema', () => {
       'deployment_id',
       'worker_deployment_id',
       'correlation_id',
+      'workflow_run_id',
+      'workflow_run_attempt',
       'principal_user_id',
       'status',
       'version',
@@ -138,12 +185,25 @@ describe('G3 foundations schema', () => {
       'fund_config_residue_count',
       'fund_event_residue_count',
       'notification_residue_count',
+      'grant_residue_count',
+      'calculation_residue_count',
+      'mutation_receipt_residue_count',
+      'scenario_residue_count',
+      'reporting_residue_count',
       'total_residue_count',
       'created_at',
       'updated_at',
     ]);
     expect(canaryConfig.foreignKeys.map((foreignKey) => foreignKey.getName())).toContain(
       'release_canary_runs_principal_user_id_users_id_fk'
+    );
+    expect(canaryConfig.columns.map((column) => column.name)).toContain('workflow_run_id');
+    expect(canaryConfig.columns.map((column) => column.name)).toContain('workflow_run_attempt');
+    expect(canaryConfig.checks.map((constraint) => constraint.name)).toContain(
+      'release_canary_runs_workflow_identity_check'
+    );
+    expect(canaryConfig.indexes.map((index) => index.config.name)).toContain(
+      'release_canary_runs_workflow_identity_unique'
     );
   });
 
@@ -182,6 +242,7 @@ describe('G3 foundations schema', () => {
     const migration0050 = migration('0050_g3_portfolio_and_calculation_schema.sql');
     const migration0051 = migration('0051_g3_canary_schema.sql');
     const migration0052 = migration('0052_g3_capital_call_notification_outbox.sql');
+    const migration0053 = migration('0053_g3_release_gate_hardening.sql');
 
     expect(migration0050).toContain('-- @drift-patch');
     expect(migration0050).toContain('ADD COLUMN IF NOT EXISTS "row_version"');
@@ -196,11 +257,22 @@ describe('G3 foundations schema', () => {
     );
     expect(migration0052).toContain("'exhausted'");
     expect(migration0052).not.toContain('"payload" jsonb');
+    expect(migration0053).toContain('-- @drift-patch');
+    expect(migration0053).toContain(
+      'CREATE TABLE IF NOT EXISTS "fund_scenario_calculation_commands"'
+    );
+    expect(migration0053).toContain('queued_event_recorded_at');
+    expect(migration0053).toContain('calculation_queued');
+    expect(migration0053).toContain('release_canary_runs_workflow_identity_unique');
+    expect(migration0053).toContain('release_canary_runs_residue_count_check');
+    expect(migration0053).toContain('ADD COLUMN IF NOT EXISTS "grant_residue_count"');
+    expect(migration0053).not.toMatch(/DELETE\s+FROM|UPDATE\s+fund_scenario_set_events/i);
 
     for (const [idx, tag] of [
       [51, '0050_g3_portfolio_and_calculation_schema'],
       [52, '0051_g3_canary_schema'],
       [53, '0052_g3_capital_call_notification_outbox'],
+      [54, '0053_g3_release_gate_hardening'],
     ] as const) {
       expect(
         journal.entries

--- a/tests/unit/scripts/build-schema-reconcile-receipt.test.ts
+++ b/tests/unit/scripts/build-schema-reconcile-receipt.test.ts
@@ -1,0 +1,68 @@
+import { readFile, stat, unlink } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildSchemaReconcileReceipt,
+  writeSchemaReconcileReceipt,
+} from '../../../scripts/release/build-schema-reconcile-receipt';
+
+const input = {
+  repository: 'press-on/updog',
+  workflowPath: '.github/workflows/prod-schema-reconcile.yml' as const,
+  runId: '123456789',
+  runAttempt: 1,
+  mode: 'apply' as const,
+  sourceSha: 'b'.repeat(40),
+  manifest: '30-g3-release-gate-hardening' as const,
+  migration: '0053' as const,
+  preDecision: 'APPLY-MISSING-DDL' as const,
+  postDecision: 'SKIP' as const,
+  startedAtMs: 1000,
+  completedAtMs: 1250,
+};
+
+describe('build-schema-reconcile-receipt', () => {
+  it('builds the strict receipt and reports only bounded evidence', () => {
+    expect(buildSchemaReconcileReceipt(input)).toEqual({
+      repository: 'press-on/updog',
+      workflowPath: '.github/workflows/prod-schema-reconcile.yml',
+      runId: '123456789',
+      runAttempt: 1,
+      mode: 'apply',
+      sourceSha: 'b'.repeat(40),
+      manifest: '30-g3-release-gate-hardening',
+      migration: '0053',
+      preDecision: 'APPLY-MISSING-DDL',
+      postDecision: 'SKIP',
+      buildTimeMs: 250,
+      result: 'applied_and_clean',
+    });
+  });
+
+  it('writes receipt privately and atomically', async () => {
+    const outputPath = path.join(
+      os.tmpdir(),
+      `schema-reconcile-receipt-${process.pid}-${Date.now()}.json`
+    );
+    try {
+      const receipt = buildSchemaReconcileReceipt(input);
+      await writeSchemaReconcileReceipt(outputPath, receipt);
+      expect(JSON.parse(await readFile(outputPath, 'utf8'))).toEqual(receipt);
+      expect((await stat(outputPath)).mode & 0o777).toBe(0o600);
+    } finally {
+      await unlink(outputPath).catch(() => undefined);
+    }
+  });
+
+  it('rejects a backward clock and non-attempt-one apply', () => {
+    expect(() =>
+      buildSchemaReconcileReceipt({ ...input, completedAtMs: 999 })
+    ).toThrow(/completedAtMs/);
+    expect(() =>
+      buildSchemaReconcileReceipt({ ...input, runAttempt: 2 })
+    ).toThrow(/attempt 1/);
+  });
+});

--- a/tests/unit/scripts/build-schema-reconcile-receipt.test.ts
+++ b/tests/unit/scripts/build-schema-reconcile-receipt.test.ts
@@ -24,7 +24,7 @@ const input = {
   completedAtMs: 1250,
 };
 
-describe('build-schema-reconcile-receipt', () => {
+describe('build-schema-reconcile-receipt', { retry: 0 }, () => {
   it('builds the strict receipt and reports only bounded evidence', () => {
     expect(buildSchemaReconcileReceipt(input)).toEqual({
       repository: 'press-on/updog',

--- a/tests/unit/testcontainers-path-filter-parity.test.ts
+++ b/tests/unit/testcontainers-path-filter-parity.test.ts
@@ -7,6 +7,17 @@ import { describe, expect, it } from 'vitest';
 import { TESTCONTAINERS_TEST_PATHS } from '../config/testcontainers-test-paths.mjs';
 
 const PATH_FILTERS = '.github/path-filters.yml';
+const TESTCONTAINERS_TEST_PATHS_MODULE = 'tests/config/testcontainers-test-paths.mjs';
+
+const REQUIRED_TESTCONTAINERS_TRIGGER_SEAMS = [
+  '.github/path-filters.yml',
+  '.github/workflows/testcontainers-ci.yml',
+  'vitest.config.testcontainers.ts',
+  'tests/setup/global-setup.testcontainers.ts',
+  'tests/helpers/testcontainers.ts',
+  'tests/helpers/testcontainers-migration.ts',
+  'tests/integration/helpers/run-drizzle-push.ts',
+] as const;
 
 interface PathFilters {
   schema_tests?: string[];
@@ -36,22 +47,58 @@ function schemaTestPatterns(): string[] {
   return patterns;
 }
 
+function expectSchemaTestPaths(
+  patterns: string[],
+  paths: readonly string[],
+  subject: string
+): void {
+  const isSchemaTestPath = picomatch(patterns);
+  const missing = paths.filter((path) => !isSchemaTestPath(path));
+
+  expect(
+    missing,
+    `${subject} missing from schema_tests: ${missing.join(', ')}. Add every listed path to ${PATH_FILTERS} under schema_tests.`
+  ).toEqual([]);
+}
+
 describe('Testcontainers path-filter parity', () => {
   it('matches every canonical Testcontainers include with schema_tests', () => {
     const patterns = schemaTestPatterns();
-    const isSchemaTestPath = picomatch(patterns);
-    const missing = TESTCONTAINERS_TEST_PATHS.filter(
-      (includePath) => !isSchemaTestPath(includePath)
-    );
 
-    expect(missing).toEqual([]);
+    expectSchemaTestPaths(
+      patterns,
+      TESTCONTAINERS_TEST_PATHS,
+      'Canonical Testcontainers test paths'
+    );
+  });
+
+  it('matches canonical Testcontainers list module with schema_tests', () => {
+    const patterns = schemaTestPatterns();
+
+    expectSchemaTestPaths(
+      patterns,
+      [TESTCONTAINERS_TEST_PATHS_MODULE],
+      'Canonical Testcontainers list module'
+    );
+  });
+
+  it('matches every core Testcontainers trigger seam with schema_tests', () => {
+    const patterns = schemaTestPatterns();
+
+    expectSchemaTestPaths(
+      patterns,
+      REQUIRED_TESTCONTAINERS_TRIGGER_SEAMS,
+      'Core Testcontainers trigger seams'
+    );
   });
 
   it('matches every required conversion production seam with schema_tests', () => {
     const patterns = schemaTestPatterns();
-    const isSchemaTestPath = picomatch(patterns);
-    const missing = REQUIRED_SCHEMA_TEST_SEAMS.filter((seamPath) => !isSchemaTestPath(seamPath));
 
-    expect(missing).toEqual([]);
+    expectSchemaTestPaths(
+      patterns,
+      REQUIRED_SCHEMA_TEST_SEAMS,
+      'Required conversion production seams'
+    );
   });
 });


### PR DESCRIPTION
## Schema-only precursor (Task 5, Steps 1-8 of the release-gate hardening plan)

Delivery split mandated by the governing plan (byte-frozen digest `fd15d073...`,
tracked on PR #1385's branch): this PR carries ONLY additive schema expansion and
its evidence hardening. Runtime consumers arrive in PR #1385 after this merges,
applies, and #1385 rebases.

### Contents
- `fund_scenario_calculation_commands` durable command ledger (exact plan columns,
  named constraints, status/lease/response coupling checks)
- `fund_scenario_calculation_runs.queued_event_recorded_at` exactly-once marker +
  backfill from matching historic `calculation_queued` events (non-destructive)
- `release_canary_runs`: coupled nullable `workflow_run_id`/`workflow_run_attempt` +
  partial unique index; five additive residue columns; residue total-equality check
- Migration `0053_g3_release_gate_hardening.sql` (replay-safe, additive-only,
  `-- @drift-patch`, no down migration), journal idx 54, production schema manifest
  order 30
- `schema-reconcile-receipt-v1` strict contract + builder; `prod-schema-reconcile.yml`
  retention preflight (90-day artifact window, attempt-1 rule, fail-closed apply guards)
- Forward-compatibility Testcontainers proof: 0052 base -> journal 0053 -> legacy-shaped
  fixtures -> raw replay (proves replay-safety AND backfill) -> legacy read paths green.
  Registered in the testcontainers CI lane.

### Verification (local, TZ=UTC)
- Unit battery: 252/252 across schema/ledger/manifest/receipt/regression suites
- Integration: prod-schema-clone 6/6 + g3-schema-forward-compatibility green (Docker)
- `npm run validate:schema-drift` exit 0; `npm run check` clean; eslint --no-ignore clean;
  actionlint clean

### Owner gates AFTER merge (do not self-serve)
1. Provision `production-schema` secret `SCHEMA_EVIDENCE_RETENTION_READ_TOKEN`
   (fine-grained, Administration read-only) + confirm 90-day artifact retention
2. Provision GitHub Production identity vars (`VERCEL_PRODUCTION_HOSTNAME`, 4 `RAILWAY_*` IDs)
3. Dispatch `prod-schema-reconcile.yml` apply mode at the exact merge SHA (attempt 1),
   then audit mode; observe Railway auto-deploy of both protected services (10-min stop rule)
4. Rebase PR #1385 onto the merge; V2 approval invalidates -> full gate-refresh cycle

Note for the apply window: Drizzle column lists in deployed precursor code reference the
new columns, so schedule the apply immediately after merge (auto-deploy precedes apply;
scenario-status reads can 42703 until apply completes).

Relates to #1385.

🤖 Generated with [Claude Code](https://claude.com/claude-code)